### PR TITLE
VMAAS-239 Tooltip in table header, .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+# 4 space indentation
+[*.{html,scss,js}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+# Matches the exact files either package.json
+[{package.json}]
+indent_style = space
+indent_size = 2

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -1,7 +1,9 @@
-import { InfoCircleIcon } from '@patternfly/react-icons';
+
 import { routerParams, Vulnerabilities, VulnerabilitiesCves } from '@red-hat-insights/insights-frontend-components';
 import propTypes from 'prop-types';
 import React from 'react';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { dispatchAction } from '../../../Helpers/Dispatcher';
 import { createCveListByAccount } from '../../../Helpers/VulnerabilitiesHelper';
@@ -38,7 +40,14 @@ CVEs.defaultProps = {
         {
             title: (
                 <React.Fragment>
-                    {'CVSS Base Score'} <InfoCircleIcon />
+                    {'CVSS Base Score'} <Tooltip
+                        position="right"
+                        content={
+                            <div>All CVEs use Common Vulnerability Scoring System v3 except where noted.</div>
+                        }
+                    >
+                        <InfoCircleIcon />
+                    </Tooltip>
                 </React.Fragment>
             ),
             key: 'cvss_score',


### PR DESCRIPTION
- .editorconfig file to set up editor code style indention and charset
- VMAAS-239 CVSS Base Score table column header with tooltip on info icon: https://projects.engineering.redhat.com/browse/VMAAS-239