### PR TITLE
Fix routing by redirecting only on certain routes

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -8,7 +8,7 @@ const convert = require('koa-connect');
 
 webpackConfig.serve = {
     content: config.paths.public,
-    port: 8002,
+    port: 8091,
     dev: {
         publicPath: '/insights/platform/vulnerability/'
     },

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -8,7 +8,7 @@ const convert = require('koa-connect');
 
 webpackConfig.serve = {
     content: config.paths.public,
-    port: 8091,
+    port: 8002,
     dev: {
         publicPath: '/insights/platform/vulnerability/'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10675,12 +10675,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10695,17 +10697,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10822,7 +10827,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10834,6 +10840,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10848,6 +10855,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10855,12 +10863,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -10879,6 +10889,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10959,7 +10970,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10971,6 +10983,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11092,6 +11105,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import { notifications, NotificationsPortal } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -14,8 +14,6 @@ class App extends Component {
         insights.chrome.init();
         insights.chrome.identifyApp('vulnerability');
         insights.chrome.navigation(buildNavigation());
-
-        this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
         this.buildNav = this.props.history.listen(() => insights.chrome.navigation(buildNavigation()));
     }
 
@@ -42,7 +40,7 @@ App.propTypes = {
  * connect: https://github.com/reactjs/react-redux/blob/master/docs/api.md
  *          https://reactjs.org/docs/higher-order-components.html
  */
-export default routerParams(connect()(App));
+export default withRouter(connect()(App));
 
 function buildNavigation() {
     //const currentPath = window.location.pathname.split('/').slice(-1)[0];

--- a/src/Components/PresentationalComponents/CVEPageOverview/CVEPageOverview.js
+++ b/src/Components/PresentationalComponents/CVEPageOverview/CVEPageOverview.js
@@ -11,7 +11,7 @@ import {
     StackItem,
     Title
 } from '@patternfly/react-core';
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React from 'react';
 import WithLoader from '../WithLoader/WithLoader';
@@ -106,4 +106,4 @@ CVEPageOverview.propTypes = {
     match: propTypes.object
 };
 
-export default routerParams(CVEPageOverview);
+export default withRouter(CVEPageOverview);

--- a/src/Components/SmartComponents/CVEPage/CVEPage.js
+++ b/src/Components/SmartComponents/CVEPage/CVEPage.js
@@ -1,5 +1,5 @@
 import { Grid, GridItem } from '@patternfly/react-core';
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -54,7 +54,7 @@ CVEPage.propTypes = {
     entities: propTypes.object
 };
 
-export default routerParams(
+export default withRouter(
     connect(
         mapStateToProps,
         mapDispatchToProps

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -1,5 +1,6 @@
 
-import { routerParams, Vulnerabilities, VulnerabilitiesCves } from '@red-hat-insights/insights-frontend-components';
+import { Vulnerabilities, VulnerabilitiesCves } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React from 'react';
 import { InfoCircleIcon } from '@patternfly/react-icons';
@@ -72,7 +73,7 @@ CVEs.propTypes = {
     defaultSort: propTypes.any
 };
 
-export default routerParams(
+export default withRouter(
     connect(
         null,
         mapDispatchToProps

--- a/src/Components/SmartComponents/InventoryDetail/InventoryDetail.js
+++ b/src/Components/SmartComponents/InventoryDetail/InventoryDetail.js
@@ -1,7 +1,7 @@
 import * as reactCore from '@patternfly/react-core';
 import { Card, CardBody } from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -89,7 +89,7 @@ const mapDispatchToProps = () => {
     };
 };
 
-export default routerParams(
+export default withRouter(
     connect(
         mapStateToProps,
         mapDispatchToProps

--- a/src/Components/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/Components/SmartComponents/SystemDetail/SystemDetail.js
@@ -1,4 +1,4 @@
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -28,7 +28,7 @@ function mapStateToProps(state) {
     };
 }
 
-export default routerParams(
+export default withRouter(
     connect(
         mapStateToProps,
         null

--- a/src/Components/SmartComponents/Systems/Systems.js
+++ b/src/Components/SmartComponents/Systems/Systems.js
@@ -1,6 +1,6 @@
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
-import { routerParams } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import { PaginationRow } from 'patternfly-react';
 import propTypes from 'prop-types';
 import React from 'react';
@@ -95,7 +95,7 @@ const mapDispatchToProps = () => {
     };
 };
 
-export default routerParams(
+export default withRouter(
     connect(
         mapStateToProps,
         mapDispatchToProps

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -1,6 +1,7 @@
 import * as reactCore from '@patternfly/react-core';
 import * as reactIcons from '@patternfly/react-icons';
-import { RemediationButton, routerParams } from '@red-hat-insights/insights-frontend-components';
+import { RemediationButton } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 import { PaginationRow } from 'patternfly-react';
 import propTypes from 'prop-types';
@@ -133,7 +134,7 @@ const mapDispatchToProps = () => {
     };
 };
 
-export default routerParams(
+export default withRouter(
     connect(
         mapStateToProps,
         mapDispatchToProps

--- a/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
+++ b/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
@@ -1,4 +1,5 @@
-import { Main, PageHeader, PageHeaderTitle, routerParams } from '@red-hat-insights/insights-frontend-components';
+import { Main, PageHeader, PageHeaderTitle } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import some from 'lodash/some';
 import propTypes from 'prop-types';
 import React from 'react';
@@ -53,4 +54,4 @@ Vulnerabilities.propTypes = {
     location: propTypes.object.isRequired
 };
 
-export default routerParams(Vulnerabilities);
+export default withRouter(Vulnerabilities);

--- a/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
+++ b/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
@@ -1,4 +1,5 @@
-import { routerParams, TabLayout } from '@red-hat-insights/insights-frontend-components';
+import { TabLayout } from '@red-hat-insights/insights-frontend-components';
+import { withRouter } from 'react-router-dom';
 import propTypes from 'prop-types';
 import React, { Component } from 'react';
 import { paths } from '../Vulnerabilities/Vulnerabilities';
@@ -9,7 +10,7 @@ class VulnerabilitiesTabs extends Component {
         super(props);
         this.redirect = this.redirect.bind(this);
     }
-    redirect(event, tab) {
+    redirect(_event, tab) {
         this.props.history.push(tab.name);
     }
     render() {
@@ -33,4 +34,4 @@ VulnerabilitiesTabs.propTypes = {
     history: propTypes.object
 };
 
-export default routerParams(VulnerabilitiesTabs);
+export default withRouter(VulnerabilitiesTabs);

--- a/src/Utilities/Routes.js
+++ b/src/Utilities/Routes.js
@@ -1,7 +1,7 @@
 import some from 'lodash/some';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Route, Switch, matchPath } from 'react-router-dom';
 import asyncComponent from './asyncComponent';
 
 /**
@@ -25,10 +25,6 @@ export const paths = {
     vulnerabilities: '/:subpage?'
 };
 
-type Props = {
-    childProps: any
-};
-
 const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     const root = document.getElementById('root');
     root.removeAttribute('class');
@@ -36,8 +32,13 @@ const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     root.classList.add(`page__${rootClass}`, 'pf-l-page__main');
     root.setAttribute('role', 'main');
 
-    return <Component {...rest} />;
+    return <Route {...rest} component={Component} />;
 };
+
+function checkPaths(routes) {
+    return some(Object
+    .values(routes), route => matchPath(location.href, { path: `${document.baseURI}platform/vulnerability${route}` }));
+}
 
 InsightsRoute.propTypes = {
     component: PropTypes.func,
@@ -52,14 +53,22 @@ InsightsRoute.propTypes = {
  *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
  *      component - component to be rendered when a route has been chosen.
  */
-export const Routes = (props: Props) => {
-    const path = props.childProps.location.pathname;
+export const Routes = ({ childProps: { history } }) => {
+    if (!checkPaths(paths)) {
+        history.push(paths.cve_browser);
+    }
 
     return (
         <Switch>
             <InsightsRoute path={paths.vulnerabilities} component={Vulnerabilities} rootClass="Vulnerabilities" />
-            {/* Finally, catch all unmatched routes */}
-            <Route render={() => (some(paths, p => p === path) ? null : <Redirect to={paths.cve_browser} />)} />
         </Switch>
     );
+};
+
+Routes.propTypes = {
+    childProps: PropTypes.shape({
+        history: PropTypes.shape({
+            push: PropTypes.func
+        })
+    })
 };


### PR DESCRIPTION
I had to remove all `routerParams` from application because it was causing problems with a lot of redirects. We should revisit this approach once we figure out which components needs to use `routerParams` and which should use `withRouter` so they do not cause multiple redirects.