### PR TITLE
Format index using new esi structure

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,23 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
     <head>
-        <meta charset="UTF-8" />
+        <meta charset="UTF-8">
         <title>Red Hat Insights | Vulnerability</title>
-        <esi:include src="/@@insights/static/chrome/snippets/head.html" />
+        <esi:include src="/@@insights/static/chrome/snippets/head.html"/>
     </head>
-
     <body>
-        <div class="pf-c-background-image"></div>
-        <div class="pf-c-page pf-l-page" id="page">
-            <esi:include src="/@@insights/static/chrome/snippets/header.html" />
-            <esi:include
-                src="/@@insights/static/chrome/snippets/sidebar.html"
-            />
-            <main role="main" class="pf-c-page__main pf-l-page__main" id="root">
-                <esi:include
-                    src="/@@insights/static/chrome/snippets/footer.html"
-                />
-            </main>
-        </div>
+        <esi:include src="/@@insights/static/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
We updated the ESI structure to allow more flexibility from chrome. This should fix the rendering issues with chrome

Related: https://projects.engineering.redhat.com/browse/RHIPLAT2-458