### PR TITLE
Update routing to match new version of cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ There is a [comprehensive quick start guide in the Storybook Documentation](http
     - starts webpack bundler and serves the files with webpack dev server
     - every code change will be visible inside container immediately
 
+## Running locally
+Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
+
+```shell
+SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
+```
+
+
 ### Testing
 
 - Travis is used to test the build for this code.

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -94,12 +94,4 @@ const HtmlReplaceWebpackPlugin = new(require('html-replace-webpack-plugin'))([{
 }]);
 plugins.push(HtmlReplaceWebpackPlugin);
 
-/**
- * Replaces any instance of RELEASE in js files with config.insightsDeployment value.
- */
-const Release = new webpack.DefinePlugin({
-    RELEASE: JSON.stringify(config.release)
-});
-plugins.push(Release);
-
 module.exports = { plugins };

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -98,7 +98,7 @@ plugins.push(HtmlReplaceWebpackPlugin);
  * Replaces any instance of RELEASE in js files with config.insightsDeployment value.
  */
 const Release = new webpack.DefinePlugin({
-    RELEASE: JSON.stringify(config.insightsDeployment)
+    RELEASE: JSON.stringify(config.release)
 });
 plugins.push(Release);
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ webpackConfig.serve = {
     content: config.paths.public,
     port: 8002,
     dev: {
-        publicPath: '/apps/vulnerability/'
+        publicPath: config.paths.publicPath
     },
     // https://github.com/webpack-contrib/webpack-serve/blob/master/docs/addons/history-fallback.config.js
     add: app => app.use(convert(history({})))

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ webpackConfig.serve = {
     content: config.paths.public,
     port: 8002,
     dev: {
-        publicPath: '/insights/platform/vulnerability/'
+        publicPath: '/apps/vulnerability/'
     },
     // https://github.com/webpack-contrib/webpack-serve/blob/master/docs/addons/history-fallback.config.js
     add: app => app.use(convert(history({})))

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,0 +1,7 @@
+/* global exports */
+
+exports.routes = {
+    '/rhcs/vulnerability': { host: 'http://localhost:8002' },
+    '/apps/vulnerability': { host: 'http://localhost:8002' },
+    '/apps/chrome': { host: 'https://ci.cloud.paas.upshift.redhat.com' }
+};

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,7 +1,14 @@
-/* global exports */
+/*global module, process*/
 
-exports.routes = {
-    '/rhcs/vulnerability': { host: 'http://localhost:8002' },
-    '/apps/vulnerability': { host: 'http://localhost:8002' },
-    '/apps/chrome': { host: 'https://ci.cloud.paas.upshift.redhat.com' }
+// Hack so that Mac OSX docker can sub in host.docker.internal instead of localhost
+// see https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+
+module.exports = {
+    routes: {
+        '/rhcs/vulnerability': { host: `http://${localhost}:8002` },
+        '/apps/vulnerability': { host: `http://${localhost}:8002` },
+        '/apps/chrome': { host: 'https://ci.cloud.paas.upshift.redhat.com' },
+        '/r/insights/platform': { host: 'http://access.ci.cloud.paas.upshift.redhat.com' }
+    }
 };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,7 +10,6 @@ const entry = process.env.NODE_ENV === 'production' ?
     path.resolve(__dirname, '../src/entry-dev.js');
 
 let insightsDeployment = 'apps';
-let release = '';
 const gitBranch = process.env.BRANCH || gitRevisionPlugin.branch();
 const betaBranch =
     gitBranch === 'master' ||
@@ -18,7 +17,6 @@ const betaBranch =
     gitBranch === 'prod-beta';
 if (process.env.NODE_ENV === 'production' && betaBranch) {
     insightsDeployment = 'beta/apps';
-    release = 'beta';
 }
 
 const publicPath = `/${insightsDeployment}/vulnerability/`;
@@ -34,6 +32,5 @@ module.exports = {
         static: path.resolve(__dirname, '../static'),
         publicPath
     },
-    insightsDeployment,
-    release
+    insightsDeployment
 };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -18,7 +18,7 @@ const betaBranch =
     gitBranch === 'prod-beta';
 if (process.env.NODE_ENV === 'production' && betaBranch) {
     insightsDeployment = 'beta/apps';
-    release = 'beta'
+    release = 'beta';
 }
 
 const publicPath = `/${insightsDeployment}/vulnerability/`;

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -9,17 +9,19 @@ const entry = process.env.NODE_ENV === 'production' ?
     path.resolve(__dirname, '../src/entry.js') :
     path.resolve(__dirname, '../src/entry-dev.js');
 
-let insightsDeployment = 'insights';
+let insightsDeployment = 'apps';
+let release = '';
 const gitBranch = process.env.BRANCH || gitRevisionPlugin.branch();
 const betaBranch =
     gitBranch === 'master' ||
     gitBranch === 'qa-beta' ||
     gitBranch === 'prod-beta';
 if (process.env.NODE_ENV === 'production' && betaBranch) {
-    insightsDeployment = 'insightsbeta';
+    insightsDeployment = 'beta/apps';
+    release = 'beta'
 }
 
-const publicPath = `/${insightsDeployment}/platform/vulnerability/`;
+const publicPath = `/${insightsDeployment}/vulnerability/`;
 
 module.exports = {
     paths: {
@@ -32,5 +34,6 @@ module.exports = {
         static: path.resolve(__dirname, '../static'),
         publicPath
     },
-    insightsDeployment
+    insightsDeployment,
+    release
 };

--- a/src/Utilities/Routes.js
+++ b/src/Utilities/Routes.js
@@ -43,7 +43,7 @@ const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
 
 function checkPaths(routes) {
     return some(Object.values(routes), route =>
-        matchPath(location.href, { path: `${document.baseURI}platform/vulnerability${route}` })
+        matchPath(location.href, { path: `${document.baseURI}rhcs/vulnerability${route}` })
     );
 }
 

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -11,7 +11,7 @@ import App from './App';
  */
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={`./rhcs/vulnerability` }>
+        <Router basename={`rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -15,7 +15,7 @@ import App from './App';
  */
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={ `/${RELEASE}/platform/vulnerability` }>
+        <Router basename={`${RELEASE ? `/${RELEASE}` : ''}/rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -5,17 +5,13 @@ import { Provider } from 'react-redux';
 import ReducerRegistry from './Utilities/ReducerRegistry';
 import App from './App';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
-
 /**
  * Hooks up redux to app.
  *  https://redux.js.org/advanced/usage-with-react-router
  */
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={`${RELEASE ? `/${RELEASE}` : ''}/rhcs/vulnerability` }>
+        <Router basename={`./rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry.js
+++ b/src/entry.js
@@ -7,7 +7,7 @@ import ReducerRegistry from './Utilities/ReducerRegistry';
 
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={`./rhcs/vulnerability` }>
+        <Router basename={`rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,13 +5,9 @@ import { Provider } from 'react-redux';
 import App from './App';
 import ReducerRegistry from './Utilities/ReducerRegistry';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
-
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={`${RELEASE ? `/${RELEASE}` : ''}/rhcs/vulnerability` }>
+        <Router basename={`./rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry.js
+++ b/src/entry.js
@@ -11,7 +11,7 @@ import ReducerRegistry from './Utilities/ReducerRegistry';
 
 ReactDOM.render(
     <Provider store={ReducerRegistry.getStore()}>
-        <Router basename={ `/${RELEASE}/platform/vulnerability` }>
+        <Router basename={`${RELEASE ? `/${RELEASE}` : ''}/rhcs/vulnerability` }>
             <App />
         </Router>
     </Provider>,

--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta charset="UTF-8">
         <title>Red Hat Insights | Vulnerability</title>
-        <esi:include src="/@@insights/static/chrome/snippets/head.html"/>
+        <esi:include src="/@@insights/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="/@@insights/static/chrome/snippets/body.html"/>
+        <esi:include src="/@@insights/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
You might have to run `npm run build` if you see errors with missing static files under `insights/platform`