### PR TITLE
allow data_format parameter for getAffectedSystemsByCVE API call

### DIFF
--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -52,7 +52,7 @@ export function getCveDetails(synopsis) {
 }
 
 export function getAffectedSystemsByCVE(synopsis, apiProps) {
-    let allowedParams = ['filter', 'limit', 'offset', 'page', 'page_size', 'sort', 'status_id'];
+    let allowedParams = ['filter', 'limit', 'offset', 'page', 'page_size', 'sort', 'status_id', 'data_format'];
     let queryParams = verifyParameters(apiProps, allowedParams);
     let endpoint = '/cves/' + synopsis + '/affected_systems/';
     let result = createApiCall(endpoint, 'get', queryParams);


### PR DESCRIPTION
this is a wild guess to fix https://projects.engineering.redhat.com/browse/VMAAS-490 just by reading the code
(I had no chance to run and test the code)
