### PR TITLE
Add 'Systems' in breadcrumb

### DIFF
--- a/src/Components/SmartComponents/CVEPage/CVEPage.js
+++ b/src/Components/SmartComponents/CVEPage/CVEPage.js
@@ -29,7 +29,10 @@ class CVEPage extends React.Component {
 
     componentDidMount() {
         this.props.setHeader({
-            breadcrumbs: [{ title: 'Vulnerability', to: paths.vulnerabilities }, { title: this.state.cveName, isActive: true }]
+            breadcrumbs: [
+                { title: paths.vulnerabilities.title, to: paths.vulnerabilities.to },
+                { title: this.state.cveName, isActive: true }
+            ]
         });
         this.props.fetchCveDetails(this.state.cveName);
     }

--- a/src/Components/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/Components/SmartComponents/SystemDetail/SystemDetail.js
@@ -25,6 +25,7 @@ class SystemDetail extends React.Component {
         this.props.setHeader({
             breadcrumbs: [
                 { title: paths.vulnerabilities.title, to: paths.vulnerabilities.to },
+                { title: paths.systems.title, to: paths.systems.to },
                 { title: (entity && entity.display_name) || 'Invalid System', isActive: true }
             ]
         });

--- a/src/Components/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/Components/SmartComponents/SystemDetail/SystemDetail.js
@@ -24,7 +24,7 @@ class SystemDetail extends React.Component {
         const { entity, isOptOut, optOutSystemHandler } = this.props;
         this.props.setHeader({
             breadcrumbs: [
-                { title: 'Vulnerability', to: paths.vulnerabilities },
+                { title: paths.vulnerabilities.title, to: paths.vulnerabilities.to },
                 { title: (entity && entity.display_name) || 'Invalid System', isActive: true }
             ]
         });

--- a/src/Components/SmartComponents/Systems/Systems.js
+++ b/src/Components/SmartComponents/Systems/Systems.js
@@ -204,7 +204,7 @@ class Systems extends React.Component {
         });
         return (
             <Page>
-                <VulnerabilityHeader />
+                <VulnerabilityHeader showBreadcrumb={false} />
                 <Main>
                     <InventoryCmp
                         hasCheckbox={data.length !== 0}

--- a/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
+++ b/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
@@ -29,9 +29,9 @@ class Vulnerabilities extends React.Component {
 
     componentDidMount() {
         const { location, history } = this.props;
-        if (location.pathname !== paths.upgrade) {
+        if (location.pathname !== paths.upgrade.to) {
             getSystems().then(res => {
-                res.meta && res.meta.total_items <= 0 && history.replace(paths.upgrade);
+                res.meta && res.meta.total_items <= 0 && history.replace(paths.upgrade.to);
             });
         }
     }
@@ -43,14 +43,13 @@ class Vulnerabilities extends React.Component {
         return (
             <React.Fragment>
                 <Switch>
-                    <Route exact path={paths.vulnerabilitiesCves} component={VulnerabilitiesCVEs} />
-                    <Route exact path={paths.systems} component={Systems} />
-                    <Route path={paths.inventoryDetail} component={InventoryDetail} />
-                    <Route exact path={paths.cvePage} component={CVEPage} />
-                    <Route exact path={paths.upgrade} component={Upgrade} />
-
-                    <Redirect from={paths.cvepagePath} to={paths.inventoryDetail} />
-                    <Route render={() => (some(paths, p => p === path) ? null : <Redirect to={paths.vulnerabilitiesCves} />)} />
+                    <Route exact path={paths.vulnerabilitiesCves.to} component={VulnerabilitiesCVEs} />
+                    <Route exact path={paths.systems.to} component={Systems} />
+                    <Route path={paths.inventoryDetail.to} component={InventoryDetail} />
+                    <Route exact path={paths.cvePage.to} component={CVEPage} />
+                    <Route exact path={paths.upgrade.to} component={Upgrade} />
+                    <Redirect from={paths.cvepagePath.to} to={paths.inventoryDetail.to} />
+                    <Route render={() => (some(paths, p => p.to === path) ? null : <Redirect to={paths.vulnerabilitiesCves.to} />)} />
                 </Switch>
             </React.Fragment>
         );

--- a/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
+++ b/src/Components/SmartComponents/Vulnerabilities/Vulnerabilities.js
@@ -49,7 +49,11 @@ class Vulnerabilities extends React.Component {
                     <Route exact path={paths.cvePage.to} component={CVEPage} />
                     <Route exact path={paths.upgrade.to} component={Upgrade} />
                     <Redirect from={paths.cvepagePath.to} to={paths.inventoryDetail.to} />
-                    <Route render={() => (some(paths, p => p.to === path) ? null : <Redirect to={paths.vulnerabilitiesCves.to} />)} />
+                    <Route render={() => (
+                        some(paths, p => p.to === path)
+                            ? null
+                            : <Redirect to={paths.vulnerabilitiesCves.to} />
+                    )} />
                 </Switch>
             </React.Fragment>
         );

--- a/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
+++ b/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
@@ -17,11 +17,11 @@ class VulnerabilitiesTabs extends Component {
     }
 
     findLocation = key => {
-        return mappings.findIndex(item => item === key.replace(/\/+$/, ''));
+        return key.replace(/\/+$/, '');
     };
 
-    handleRedirect = (event, tabIndex) => {
-        this.props.history.push(mappings[tabIndex]);
+    handleRedirect = (event, tabString) => {
+        this.props.history.push(tabString);
     };
 
     render() {
@@ -32,8 +32,8 @@ class VulnerabilitiesTabs extends Component {
                     onSelect={this.handleRedirect}
                     className={'vulnerability-tabs'}
                 >
-                    <Tab eventKey={this.findLocation(paths.vulnerabilitiesCves)} title="CVEs" />
-                    <Tab eventKey={this.findLocation(paths.systems)} title="Systems" />
+                    <Tab eventKey={paths.vulnerabilitiesCves.to} title={paths.vulnerabilitiesCves.title} />
+                    <Tab eventKey={paths.systems.to} title={paths.systems.title} />
                 </Tabs>
             </React.Fragment>
         );

--- a/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
+++ b/src/Components/SmartComponents/VulnerabilitiesTabs/VulnerabilitiesTabs.js
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router-dom';
 import { paths } from '../../../Utilities/Routes';
 import './VulnerabilitiesTabs.scss';
 
-const mappings = Object.values(paths);
 class VulnerabilitiesTabs extends Component {
     static propTypes = {
         location: propTypes.object,

--- a/src/Components/SmartComponents/VulnerabilityHeader/VulnerabilityHeader.js
+++ b/src/Components/SmartComponents/VulnerabilityHeader/VulnerabilityHeader.js
@@ -12,12 +12,14 @@ export class VulnerabilityHeader extends React.Component {
         breadcrumbs: propTypes.any,
         title: propTypes.string,
         showTabs: propTypes.bool,
+        showBreadcrumb: propTypes.bool,
         children: propTypes.any
     };
 
     static defaultProps = {
         title: 'Vulnerability',
-        showTabs: true
+        showTabs: true,
+        showBreadcrumb: true
     };
 
     constructor(props) {
@@ -37,12 +39,11 @@ export class VulnerabilityHeader extends React.Component {
     }
 
     render() {
-        const { breadcrumbs, title, showTabs } = this.props;
-
+        const { breadcrumbs, title, showTabs, showBreadcrumb } = this.props;
         return (
             <React.Fragment>
                 <PageHeader>
-                    {breadcrumbs && breadcrumbs.length !== 0 && this.buildBreadcrumbs(breadcrumbs)}
+                    {showBreadcrumb && breadcrumbs && breadcrumbs.length !== 0 && this.buildBreadcrumbs(breadcrumbs)}
                     <PageHeaderTitle title={title} />
                     {this.props.children}
                 </PageHeader>

--- a/src/Utilities/Routes.js
+++ b/src/Utilities/Routes.js
@@ -64,12 +64,6 @@ const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
     return <Route {...rest} component={Component} />;
 };
 
-function checkPaths(routes, group, appName) {
-    return some(Object.values(routes), route =>
-        matchPath(location.href, { path: `${document.baseURI}${group}/${appName}${route}` })
-    );
-}
-
 InsightsRoute.propTypes = {
     component: PropTypes.func,
     rootClass: PropTypes.string

--- a/src/Utilities/Routes.js
+++ b/src/Utilities/Routes.js
@@ -21,14 +21,36 @@ import asyncComponent from './asyncComponent';
 const Vulnerabilities = asyncComponent(() =>
     import(/* webpackChunkName: "Vulnerabilities" */ '../Components/SmartComponents/Vulnerabilities/Vulnerabilities')
 );
+
 export const paths = {
-    vulnerabilities: '/',
-    vulnerabilitiesCves: '/cves',
-    cvePage: '/cves/:cve',
-    systems: '/systems',
-    inventoryDetail: '/systems/:inventoryId',
-    cvepagePath: '/cves/:cve/:inventoryId',
-    upgrade: '/upgrade'
+    vulnerabilities: {
+        title: 'Vulnerability',
+        to: '/'
+    },
+    vulnerabilitiesCves: {
+        title: 'CVEs',
+        to: '/cves'
+    },
+    cvePage: {
+        title: 'CVE',
+        to: '/cves/:cve'
+    },
+    systems: {
+        title: 'Systems',
+        to: '/systems'
+    },
+    inventoryDetail: {
+        title: 'Inventory Detail',
+        to: '/systems/:inventoryId'
+    },
+    cvepagePath: {
+        title: 'CVE Page',
+        to: '/cves/:cve/:inventoryId'
+    },
+    upgrade: {
+        title: 'Upgrade',
+        to: '/upgrade'
+    }
 };
 
 const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
@@ -61,17 +83,7 @@ InsightsRoute.propTypes = {
  *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
  *      component - component to be rendered when a route has been chosen.
  */
-export const Routes = ({ childProps: { history } }) => {
-    const pathName = window.location.pathname.split('/');
-    pathName.shift();
-
-    if (pathName[0] === 'beta') {
-        pathName.shift();
-    }
-
-    if (!checkPaths(paths, pathName[0], pathName[1])) {
-        history.push(paths.cve_browser);
-    }
+export const Routes = () => {
 
     return (
         <Switch>

--- a/src/Utilities/Routes.js
+++ b/src/Utilities/Routes.js
@@ -1,7 +1,6 @@
-import some from 'lodash/some';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { matchPath, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import asyncComponent from './asyncComponent';
 
 /**


### PR DESCRIPTION
Apart from adding the "Systems" option in the breadcrumb, the PR contains: 

A small refactoring related to paths, I replaced the hardcoded titles with constants. 
Simplifying the functionality of the tabs, [patternfly](https://www.patternfly.org/v4/documentation/react/components/tabs/#props) now supports passing strings as `eventKey` . 


 