### PR TITLE
Fix out of range filter on reload

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -126,11 +126,17 @@ class SystemsExposedTable extends React.Component {
     };
 
     dataReload = () => {
-        const { meta } = this.props.affectedSystems;
+        const { meta, data } = this.props.affectedSystems;
+        const lastPage = meta.page;
+        const { page } = this.state;
+        const reloadPage =
+            (page === lastPage && data.length === 1)
+                ? 1
+                : meta.page;
 
         this.setState({
             ...this.state,
-            page: meta.page,
+            page: reloadPage,
             page_size: meta.page_size,
             filter: this.state.filter,
             system_id: this.state.system_id


### PR DESCRIPTION
If there's an only available affected system and it's the last page then on reload it resets the page to first one to avoid the out of range error. 