### PR TITLE
Add option to expand/collapse all cve rows in Vulnerability and System table

### DIFF
--- a/src/Components/PresentationalComponents/DownloadReportKebab/KebabItems.js
+++ b/src/Components/PresentationalComponents/DownloadReportKebab/KebabItems.js
@@ -26,6 +26,12 @@ export const kebabItemEditStatus = (showStatusModal, cves, inventoryIds,  { ...p
     </DropdownItem>
 );
 
+export const kebabItemToggleCvesDescription = (toggleCveDescription, isExpanded) => (
+    <DropdownItem key="toggleCveDescription" component="button" onClick={() => toggleCveDescription()}>
+        {isExpanded ? 'Collapse all CVE descriptions' : 'Expand all CVE descriptions'}
+    </DropdownItem>
+);
+
 export const kebabItemExcludeSystemAnalysis = (doOptOut, isOptOut,  { ...props }) => (
     <DropdownItem key="do_opt_out" component="button" onClick={() => doOptOut()} {...props}>
         {isOptOut ? 'Resume analysis for system' : 'Exclude system from vulnerability analysis'}

--- a/src/Components/SmartComponents/CVEs/VulnerabilitiesCves.js
+++ b/src/Components/SmartComponents/CVEs/VulnerabilitiesCves.js
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { CVSSOptions, GenericError, PublicDateOptions } from '../../../Helpers/constants';
 import { createCveListByAccount } from '../../../Helpers/VulnerabilitiesHelper';
-import { changeCveListParameters, fetchCveListByAccount, selectCve } from '../../../Store/Actions/Actions';
+import { changeCveListParameters, fetchCveListByAccount, selectCve, expandCve } from '../../../Store/Actions/Actions';
 import BusinessRiskModal from '../Modals/BusinessRiskModal';
 import StatusModal from '../Modals/CveStatusModal';
 import './vulnerabilities.scss';
@@ -57,7 +57,8 @@ class VulnerabilitiesCves extends Component {
         location: propTypes.object,
         parameters: propTypes.object,
         changeParameters: propTypes.func,
-        selectCve: propTypes.func
+        selectCve: propTypes.func,
+        openCve: propTypes.func
     };
 
     constructor(props) {
@@ -66,7 +67,8 @@ class VulnerabilitiesCves extends Component {
             isBusinessRiskOpen: false,
             isStatuskOpen: false,
             BusinessRiskModal: () => null,
-            StatusModal: () => null
+            StatusModal: () => null,
+            expandCveDescription: false
         };
     }
 
@@ -124,6 +126,16 @@ class VulnerabilitiesCves extends Component {
         this.props.selectCve(cveNames || []);
     };
 
+    toggleCveDescription = (cveList) => {
+        const { parameters } = this.props;
+        const { expandCveDescription } = parameters;
+        const openedCves = expandCveDescription
+            ? cveList.data.filter(cve => cve.id).map(cve => cve.id)
+            : parameters.openedCves.length ? parameters.openedCves : [];
+
+        this.props.openCve(openedCves);
+    }
+
     createUrlParams = allParams => {
         const params = { ...allParams };
         params.show_irrelevant = !params.show_all;
@@ -155,7 +167,14 @@ class VulnerabilitiesCves extends Component {
         //TODO: need a better way of doing this
         const showAllParam = parameters.hasOwnProperty('show_all') && !parameters.show_all;
         // eslint-disable-next-line camelcase
-        fetchData && fetchData({ ...parameters, show_all: showAllParam });
+        fetchData && fetchData({ ...parameters, show_all: showAllParam })
+        .then(response => {
+            const { value } = response;
+            if (parameters.expandCveDescription) {
+                this.toggleCveDescription(value);
+            }
+        });
+
         this.createUrlParams(parameters);
     };
 
@@ -183,7 +202,7 @@ class VulnerabilitiesCves extends Component {
     };
 
     render() {
-        const { cveList, parameters } = this.props;
+        const { cveList, parameters, openCve } = this.props;
         const { apply, downloadReport, selectCves, showBusinessRiskModal, showStatusModal } = this;
         const { BusinessRiskModal, StatusModal } = this.state;
         const cves = cveList;
@@ -200,7 +219,8 @@ class VulnerabilitiesCves extends Component {
                             selectCves,
                             showBusinessRiskModal,
                             showStatusModal,
-                            fetchResource: fetchCveListByAccount
+                            fetchResource: fetchCveListByAccount,
+                            openCve
                         }
                     }}
                 >
@@ -234,7 +254,8 @@ const mapDispatchToProps = dispatch => {
     return {
         fetchData: params => dispatch(fetchCveListByAccount(params)),
         selectCve: params => dispatch(selectCve(params)),
-        changeParameters: params => dispatch(changeCveListParameters(params))
+        changeParameters: params => dispatch(changeCveListParameters(params)),
+        openCve: params => dispatch(expandCve(params))
     };
 };
 

--- a/src/Components/SmartComponents/CVEs/VulnerabilitiesTable.js
+++ b/src/Components/SmartComponents/CVEs/VulnerabilitiesTable.js
@@ -2,11 +2,9 @@ import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { SkeletonTable, TableToolbar } from '@redhat-cloud-services/frontend-components';
 import propTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
 import { EmptyCVEList, EmptyCVEListForSystem, FilterNotFoundForCVE } from '../../../Helpers/constants';
 import { cveTableRowActions } from '../../../Helpers/CVEHelper';
 import { createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
-import { expandCve } from '../../../Store/Actions/Actions';
 import PaginationWrapper from '../../PresentationalComponents/PaginationWrapper/PaginationWrapper';
 import { CVETableContext } from './VulnerabilitiesCves';
 
@@ -14,8 +12,7 @@ class VulnerabilitiesTableWithContext extends Component {
     static propTypes = {
         context: propTypes.any,
         header: propTypes.array,
-        entity: propTypes.object,
-        openCve: propTypes.func
+        entity: propTypes.object
     };
 
     noCves = () => {
@@ -70,7 +67,7 @@ class VulnerabilitiesTableWithContext extends Component {
                             onSelect={this.handleOnSelect}
                             cells={header}
                             rows={cves.data}
-                            onCollapse={(event, rowKey) => this.props.openCve(rowKey)}
+                            onCollapse={(event, rowKey) => methods.openCve(rowKey)}
                             actions={cveTableRowActions(methods)}
                             sortBy={createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort)}
                             onSort={(event, key, direction) =>
@@ -103,18 +100,10 @@ class VulnerabilitiesTableWithContext extends Component {
     }
 }
 
-const mapDispatchToProps = dispatch => {
-    return {
-        openCve: params => dispatch(expandCve(params))
-    };
-};
-
 const VulnerabilitiesTable = props => (
     <CVETableContext.Consumer>
         {context => <VulnerabilitiesTableWithContext context={context} {...props} />}
     </CVETableContext.Consumer>
 );
-export default connect(
-    null,
-    mapDispatchToProps
-)(VulnerabilitiesTable);
+
+export default VulnerabilitiesTable;

--- a/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
@@ -16,7 +16,8 @@ import {
     kebabItemDownloadCSV,
     kebabItemDownloadJSON,
     kebabItemEditBusinessRisk,
-    kebabItemEditStatus
+    kebabItemEditStatus,
+    kebabItemToggleCvesDescription
 } from '../../PresentationalComponents/DownloadReportKebab/KebabItems';
 import FilterChips from '../../PresentationalComponents/Filters/FilterChips';
 import Filters from '../../PresentationalComponents/Filters/Filters';
@@ -39,10 +40,18 @@ class VulnerabilitiesToolbarWithContext extends Component {
         downloadReport: () => undefined
     };
 
+    handleCveDescription = () => {
+        const { context } = this.props;
+        const { cves, methods, params } = context;
+        const { expandCveDescription } = params;
+        const openedCves = !expandCveDescription ? cves.data.filter(cve => cve.id).map(cve => cve.id) : [];
+        methods.openCve(openedCves);
+    }
+
     render() {
         const { showRemediationButton, entity, context } = this.props;
         const { cves, params, methods } = context;
-        const { selectedCves } = params;
+        const { selectedCves, expandCveDescription } = params;
         const selectedCvesCount = selectedCves && selectedCves.length;
         const filterCategories = [
             filtersShowAll,
@@ -61,6 +70,7 @@ class VulnerabilitiesToolbarWithContext extends Component {
             kebabItemEditStatus(methods.showStatusModal, selectedCves.map(item => ({ id: item, status_id: '0' })), undefined, {
                 isDisabled: !selectedCvesCount
             }),
+            kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
             kebabItemDownloadJSON(methods.downloadReport),
             kebabItemDownloadCSV(methods.downloadReport)
         ];

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -32,9 +32,10 @@ class SystemCvesTableWithContext extends Component {
 
     handleOnCollapse(event, rowKey, isOpen) {
         const { context } = this.props;
-        const { cves, methods } = context;
+        const { cves, methods, params } = context;
+        const { expandCveDescription } = params;
         const cveName = cves.data[rowKey] && cves.data[rowKey].id;
-        methods.openCves(isOpen, cveName);
+        methods.openCves(isOpen, cveName, expandCveDescription);
     }
 
     handleOnSelect = (event, isSelected, rowId) => {

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -14,7 +14,8 @@ import BaseKebab from '../../PresentationalComponents/DownloadReportKebab/BaseKe
 import {
     kebabItemDownloadCSV,
     kebabItemDownloadJSON,
-    kebabItemEditStatus
+    kebabItemEditStatus,
+    kebabItemToggleCvesDescription
 } from '../../PresentationalComponents/DownloadReportKebab/KebabItems';
 import FilterChips from '../../PresentationalComponents/Filters/FilterChips';
 import Filters from '../../PresentationalComponents/Filters/Filters';
@@ -37,10 +38,19 @@ class SystemCveToolbarWithContext extends Component {
         downloadReport: () => undefined
     };
 
+    handleCveDescription = () => {
+        const { context } = this.props;
+        const { cves, methods, params } = context;
+        const { expandCveDescription } = params;
+        const isOpen = !expandCveDescription;
+        const openedCves = !expandCveDescription ? cves.data.filter(cve => cve.id).map(cve => cve.id) : [];
+        methods.openCves(isOpen, openedCves, !expandCveDescription);
+    }
+
     render() {
         const { showRemediationButton, entity, context } = this.props;
         const { cves, params, methods } = context;
-        const { selectedCves } = params;
+        const { selectedCves, expandCveDescription } = params;
         const selectedCvesCount =
             this.props.showRemediationButton === true ? (selectedCves && selectedCves.size) || 0 : undefined;
         const filterCategories = [filtersCVSSScore, filtersSeverity, filtersBusinessRisk, filtersPublishDate, filtersStatus];
@@ -51,6 +61,7 @@ class SystemCveToolbarWithContext extends Component {
                 undefined,
                 { isDisabled: !selectedCvesCount }
             ),
+            kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
             kebabItemDownloadJSON(methods.downloadReport),
             kebabItemDownloadCSV(methods.downloadReport)
         ];

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -58,7 +58,12 @@ class SystemCves extends Component {
 
     constructor(props) {
         super(props);
-        this.state = { selectedCves: new Set(), openedCves: new Set(), StatusModal: () => null };
+        this.state = {
+            selectedCves: new Set(),
+            openedCves: new Set(),
+            StatusModal: () => null,
+            expandCveDescription: false
+        };
     }
 
     componentDidMount() {
@@ -119,15 +124,22 @@ class SystemCves extends Component {
         this.setState({ ...this.state, selectedCves: new Set(selectedCves) });
     };
 
-    openCves = (isOpen, cveNames) => {
-        let { openedCves } = this.state;
+    // @TODO System has different mechanism to store opened, unify the mechanism with CVE
+    openCves = (isOpen, cveNames, isExpanded) => {
+        let { openedCves, expandCveDescription } = this.state;
+
+        // if expanded, collapse rows
+        if (expandCveDescription && !cveNames.length) {
+            openedCves = cveNames;
+        }
+
         if (cveNames) {
             openedCves = updateStateSet(openedCves, cveNames, isOpen);
         } else {
             openedCves = new Set();
         }
 
-        this.setState({ ...this.state, openedCves: new Set(openedCves) });
+        this.setState({ ...this.state, openedCves: new Set(openedCves), expandCveDescription: isExpanded });
     };
 
     createUrlParams = allParams => {
@@ -156,7 +168,15 @@ class SystemCves extends Component {
 
     sendRequest = () => {
         const { fetchData, entity } = this.props;
-        fetchData && fetchData({ ...this.state, system: entity.id });
+        const { expandCveDescription } = this.state;
+        fetchData && fetchData({ ...this.state, system: entity.id })
+        .then(response => {
+            const { value } = response;
+            if (expandCveDescription) {
+                const cveIds = value && value.data.map(cve => cve.id);
+                this.openCves(true, cveIds, expandCveDescription);
+            }
+        });
         this.createUrlParams(this.state);
     };
 

--- a/src/Store/Reducers/VulnerabilitiesStore.js
+++ b/src/Store/Reducers/VulnerabilitiesStore.js
@@ -11,7 +11,8 @@ export const initialState = {
         show_all: 'true',
         sort: '-public_date',
         selectedCves: [],
-        openedCves: []
+        openedCves: [],
+        expandCveDescription: false
     }
 };
 
@@ -61,6 +62,12 @@ export const VulnerabilitiesStore = (state = initialState, action) => {
         }
 
         case ActionTypes.EXPAND_CVE: {
+            if (Array.isArray(action.payload)) {
+                const openedCves = action.payload;
+                const expandCveDescription = action.payload.length === 0 ? false : true;
+                return { ...newState, parameters: { ...newState.parameters, openedCves, expandCveDescription } };
+            }
+
             const cveName = newState.cveList.payload.data[action.payload / 2].id;
             const openedCves = newState.parameters.openedCves.slice();
             (openedCves.includes(cveName) && openedCves.splice(openedCves.indexOf(cveName), 1)) || openedCves.push(cveName);


### PR DESCRIPTION
Add the option to expand/collapse all cve rows. The option is under the kebab toolbar. 

![Screenshot from 2019-11-05 13-45-56](https://user-images.githubusercontent.com/3369346/68209255-3e4e1e00-ffd3-11e9-8a53-2b8dc2384d46.png)

Expanded rows in vulnerability 
![Screenshot from 2019-11-05 13-46-14](https://user-images.githubusercontent.com/3369346/68209260-40b07800-ffd3-11e9-92ff-85f6778984b9.png)

Systems details table
![Screenshot from 2019-11-05 13-46-45](https://user-images.githubusercontent.com/3369346/68209272-4a39e000-ffd3-11e9-9ebf-bc864badfb84.png)

Expanded rows in system
![Screenshot from 2019-11-05 13-47-15](https://user-images.githubusercontent.com/3369346/68209279-545bde80-ffd3-11e9-9e8e-2a180a162be4.png)
 
Also, it respects the filtering and pagination. 

