### PR TITLE
Add description label in system table

### DIFF
--- a/src/Helpers/VulnerabilitiesHelper.js
+++ b/src/Helpers/VulnerabilitiesHelper.js
@@ -177,7 +177,12 @@ export function createCveListBySystem(systemId, cveList) {
                     {
                         cells: [
                             {
-                                title: row.attributes.description
+                                title: (
+                                    <TextContent>
+                                        <Label>Description</Label>
+                                        <Text component={TextVariants.p}>{row.attributes.description}</Text>
+                                    </TextContent>
+                                )
                             }
                         ],
                         parent: index * 2


### PR DESCRIPTION
add the missing label fort the system cve table

![scrnli_11_6_2019_4-03-40 PM](https://user-images.githubusercontent.com/3369346/68309876-6743e100-00af-11ea-9dad-eae2e596d851.png)
 