### PR TITLE
fix(pair-status): Fix bulk status editing  in system details page

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -40,11 +40,11 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories }) => {
 
     function getDefaultStatus() {
         // system has different status
-        if (inventoryList && inventoryList.length === 1 && inventoryList[0].status_id) {
+        if (inventoryList && inventoryList.length > 0 && inventoryList[0].status_id) {
             return getSystemsStatus();
         }
 
-        if (cveList && cveList.length === 1) {
+        if (cveList && cveList.length > 0) {
             return getCvestatus();
         }
 
@@ -75,7 +75,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories }) => {
     }
 
     function getSystemsStatus() {
-        return (inventoryList && inventoryList.length === 1 && inventoryList[0].status_id.toString()) || '0';
+        return (inventoryList && inventoryList[0].status_id.toString()) || '0';
     }
 
     function getSystemsJustification() {
@@ -83,7 +83,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories }) => {
     }
 
     function getCvestatus() {
-        return (cveList && cveList.length === 1 && cveList[0].status_id.toString()) || '0';
+        return (cveList && cveList[0].status_id.toString()) || '0';
     }
 
     function getCveJustification() {


### PR DESCRIPTION
Strictly checking for `cveList.length === 1` returns undefined in case of editing multiple cves

Bug
![Screenshot from 2019-11-11 14-04-15](https://user-images.githubusercontent.com/3369346/69143269-d5819e00-0ac8-11ea-8da4-e1438c060ada.png)
 
Fix
![default](https://user-images.githubusercontent.com/3369346/69143328-fe099800-0ac8-11ea-800e-333f3bc21166.gif)
