### PR TITLE
bug-fix with ticket 795

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -166,14 +166,23 @@ export const FilterNotFoundForSystem = (
 export const EmptyCVEListForSystem = (
     <Bullseye>
         <EmptyState>
+        
             <Title headingLevel="h5" size="lg">
                 No CVEs reported for this system
             </Title>
             <TextContent>
                 <EmptyStateBody>
-                    <Text component={TextVariants.p}>
-                        No published CVEs in the Vulnerability service affect this system.
-                    </Text>
+ 
+                    This may be for one of the following reasons:
+ 
+                    <TextList>
+                        <TextListItem>
+                            No published CVEs in the Vulnerability service affect this system.
+                        </TextListItem>
+                        <TextListItem>
+                            You have opted out of reporting on a reported CVE.
+                        </TextListItem>
+                    </TextList>
 
                     <Text component={TextVariants.p}>
                         If you think this system has applicable CVEs, or would like more information, please contact{' '}

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -166,15 +166,12 @@ export const FilterNotFoundForSystem = (
 export const EmptyCVEListForSystem = (
     <Bullseye>
         <EmptyState>
-        
             <Title headingLevel="h5" size="lg">
                 No CVEs reported for this system
             </Title>
             <TextContent>
                 <EmptyStateBody>
- 
                     This may be for one of the following reasons:
- 
                     <TextList>
                         <TextListItem>
                             No published CVEs in the Vulnerability service affect this system.


### PR DESCRIPTION
Bug-fix with ticket 795:    
                      Formatting of text on page when system is excluded from vulnerability analysis is  off