### PR TITLE
fix(UI): CVE detail page enhancement

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -75,7 +75,7 @@
         "systems.excludedNotification": " systems successfully excluded from vulnerability analysis",
         "systems.resumedNotification.title": " systems successfully resumed vulnerability analysis",
         "systems.resumedNotification.body": " There may be 24 hours before data is available",
-        "systemsExposedTable.header": "Affected systems",
+        "systemsExposedTable.header": "Exposed systems",
         "impactList.critical": "Critical",
         "impactList.high": "High",
         "impactList.important": "Important",

--- a/src/Components/PresentationalComponents/CVEPageDetails/__snapshots__/CVEPageDetails.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEPageDetails/__snapshots__/CVEPageDetails.test.js.snap
@@ -176,7 +176,7 @@ exports[`CVEPageDetails component should render with data 1`] = `
                   }
                 >
                   <Stack
-                    gutter="sm"
+                    gutter="md"
                   >
                     <div
                       className="pf-l-stack pf-m-gutter"
@@ -257,14 +257,12 @@ exports[`CVEPageDetails component should render with data 1`] = `
                             descriptionTitle="Unknown impact"
                             titleColor="severity-unknown"
                             titleContent={
-                              <span>
-                                <UnknownIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="lg"
-                                  title={null}
-                                />
-                              </span>
+                              <UnknownIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="lg"
+                                title={null}
+                              />
                             }
                           >
                             <Split
@@ -579,7 +577,7 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
                   }
                 >
                   <Stack
-                    gutter="sm"
+                    gutter="md"
                   >
                     <div
                       className="pf-l-stack pf-m-gutter"
@@ -660,14 +658,12 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
                             descriptionTitle="Unknown impact"
                             titleColor="severity-unknown"
                             titleContent={
-                              <span>
-                                <UnknownIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="lg"
-                                  title={null}
-                                />
-                              </span>
+                              <UnknownIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="lg"
+                                title={null}
+                              />
                             }
                           >
                             <Split
@@ -993,7 +989,7 @@ exports[`CVEPageDetails component should render with long description 1`] = `
                   }
                 >
                   <Stack
-                    gutter="sm"
+                    gutter="md"
                   >
                     <div
                       className="pf-l-stack pf-m-gutter"
@@ -1078,14 +1074,12 @@ exports[`CVEPageDetails component should render with long description 1`] = `
                             descriptionTitle="Important impact"
                             titleColor="severity-color-important"
                             titleContent={
-                              <span>
-                                <SecurityIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="lg"
-                                  title={null}
-                                />
-                              </span>
+                              <SecurityIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="lg"
+                                title={null}
+                              />
                             }
                           >
                             <Split
@@ -1366,7 +1360,7 @@ exports[`CVEPageDetails component should render without data 1`] = `
                   }
                 >
                   <Stack
-                    gutter="sm"
+                    gutter="md"
                   >
                     <div
                       className="pf-l-stack pf-m-gutter"
@@ -1447,14 +1441,12 @@ exports[`CVEPageDetails component should render without data 1`] = `
                             descriptionTitle="Unknown impact"
                             titleColor="severity-unknown"
                             titleContent={
-                              <span>
-                                <UnknownIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="lg"
-                                  title={null}
-                                />
-                              </span>
+                              <UnknownIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="lg"
+                                title={null}
+                              />
                             }
                           >
                             <Split

--- a/src/Components/PresentationalComponents/CVEPageDetailsDescription/SnippetWithHeaderAndTooltip.js
+++ b/src/Components/PresentationalComponents/CVEPageDetailsDescription/SnippetWithHeaderAndTooltip.js
@@ -13,7 +13,9 @@ const SnippetWithHeaderAndPopover = props => {
                 <StackItem>
                     <Label>{title}</Label>
                 </StackItem>
-                <StackItem>{value}</StackItem>
+                <StackItem>
+                    <a>{value}</a>
+                </StackItem>
             </Stack>
         </Popover>
     );

--- a/src/Components/PresentationalComponents/CVEPageDetailsDescription/__snapshots__/SnippetWithHeaderAndTooltip.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEPageDetailsDescription/__snapshots__/SnippetWithHeaderAndTooltip.test.js.snap
@@ -121,7 +121,9 @@ exports[`SnippetWithHeaderAndTooltip Should render with title and label and Tool
             <div
               className="pf-l-stack__item"
             >
-              testDescription
+              <a>
+                testDescription
+              </a>
             </div>
           </StackItem>
         </div>
@@ -254,7 +256,9 @@ exports[`SnippetWithHeaderAndTooltip Should render with title and label only 1`]
             <div
               className="pf-l-stack__item"
             >
-              testDescription
+              <a>
+                testDescription
+              </a>
             </div>
           </StackItem>
         </div>
@@ -381,7 +385,9 @@ exports[`SnippetWithHeaderAndTooltip Should render without params 1`] = `
           <StackItem>
             <div
               className="pf-l-stack__item"
-            />
+            >
+              <a />
+            </div>
           </StackItem>
         </div>
       </Stack>

--- a/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
+++ b/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
@@ -36,7 +36,7 @@ const CVEPageDetailsSeverity = props => {
     const cvssVersion = (props.cvss3_score && 'CVSS 3.0') || (props.cvss2_score && 'CVSS 2.0') || 'CVSS 3.0';
     return (
         <React.Fragment>
-            <Stack gutter="sm">
+            <Stack gutter="md">
                 <StackItem>
                     <CVEInfoBox
                         titleColor={cveDetails.color}

--- a/src/Components/PresentationalComponents/CvssVector/CvssVector.js
+++ b/src/Components/PresentationalComponents/CvssVector/CvssVector.js
@@ -1,5 +1,5 @@
 import { Popover, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import propTypes from 'prop-types';
 import React from 'react';
@@ -50,7 +50,6 @@ const CvssVector = props => {
                                         <Table
                                             aria-label={'Metric breakdown'}
                                             variant={TableVariant.compact}
-                                            borders={false}
                                             gridBreakPoint={null}
                                             cells={
                                                 [intl.formatMessage(messages.cvssVectorMetric),
@@ -67,9 +66,7 @@ const CvssVector = props => {
                             <React.Fragment>
                                 <Text component={TextVariants.h6} style={{ display: 'inline-block' }}>
                                     {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
-                                    <a>
-                                        <QuestionCircleIcon />
-                                    </a>
+                                    <OutlinedQuestionCircleIcon color={'var(--pf-global--secondary-color--100)'}/>
                                 </Text>
                                 <br />
                             </React.Fragment>

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -73,7 +73,7 @@ export function createCveDetailsPage(cves) {
 export function createRHDBLink(item) {
     return (
         <a target="_blank" rel="noopener noreferrer" href={'https://access.redhat.com/security/cve/' + item}>
-            {<FormattedMessage {...messages.RHDBLink} />}{<ExternalLinkAltIcon />}
+            {<FormattedMessage {...messages.RHDBLink} />}{<ExternalLinkAltIcon className="pf-u-ml-sm"/>}
         </a>
     );
 }

--- a/src/Helpers/CVEHelper.test.js
+++ b/src/Helpers/CVEHelper.test.js
@@ -96,7 +96,7 @@ describe('CVEHelper', () => {
         expect(link.prop('target')).toEqual('_blank');
         expect(link.prop('rel')).toEqual('noopener noreferrer');
         expect(link.prop('children')[0]).toEqual(<FormattedMessage defaultMessage="View in Red Hat CVE database" description="Link label for RHDB button" id="cveHelper.RHDBLink" values={{}} />);
-        expect(link.prop('children')[1]).toEqual(<ExternalLinkAltIcon />);
+        expect(link.prop('children')[1]).toEqual(<ExternalLinkAltIcon className="pf-u-ml-sm"/>);
     });
 
     it('createMitreLink', () => {

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -29,9 +29,7 @@ export function getImpactDetails(impact) {
             color: impactList[impact].color,
             text: impactList[impact].text,
             titleContent: (
-                <span>
-                    <SecurityIcon size="lg" />
-                </span>
+                <SecurityIcon size="lg" />
             )
         };
     } else {
@@ -40,9 +38,7 @@ export function getImpactDetails(impact) {
             color: impactColorList.unknown,
             text: '',
             titleContent: (
-                <span>
-                    <UnknownIcon size="lg" />
-                </span>
+                <UnknownIcon size="lg" />
             )
         };
     }

--- a/src/Helpers/MiscHelper.test.js
+++ b/src/Helpers/MiscHelper.test.js
@@ -21,9 +21,7 @@ describe('MiscHelper', () => {
                 color: impactList[impact].color,
                 text: impactList[impact].text,
                 titleContent: (
-                    <span>
-                        <SecurityIcon size="lg" />
-                    </span>
+                    <SecurityIcon size="lg" />
                 )
             };
             const res = getImpactDetails(impact);
@@ -36,9 +34,7 @@ describe('MiscHelper', () => {
             color: impactColorList['unknown'],
             text: '',
             titleContent: ( 
-                    <span>
-                        <UnknownIcon size="lg" />
-                    </span>
+                    <UnknownIcon size="lg" />
                 )
         };
         const res = getImpactDetails(undefined);

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -411,7 +411,7 @@ export default defineMessages({
     systemsExposedTableHeader: {
         id: 'systemsExposedTable.header',
         description: 'Header title for systems exposed table ',
-        defaultMessage: 'Affected systems'
+        defaultMessage: 'Exposed systems'
     },
 
     //constants file


### PR DESCRIPTION
1. Business risk & status should be blue to indicate tooltip
2. "Affected” should be changed to “Exposed”
3. ~spacing between the impact & base score. Should be 16px (md spacer)~ 
^^^ Fixed, but won't apply until Patternfly resolves this: https://github.com/patternfly/patternfly-next/issues/2725
4. Center Shield Icon 
5. Missing lines in CVSS popup - should be prop of the table component
6. Info icon color should be gray not blue
7. Padding to right of link with icon - Should be 8px (sm spacer) 