### PR TITLE
fix(modals): StatusModal and PairStatusModal fixes

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -55,7 +55,7 @@
         "cveStatusModal.titleSingle": "Set status for this CVEs and all systems",
         "cveStatusModal.overwriteCheckbox": "Do not overwrite individual system status",
         "cveStatusModal.overwriteTooltip": "When checked, this setting does not change any pre-existing statuses set on individual systems for this CVE.",
-        "cveStatusModal.info": "This status is applied to all existing matching systems. Any new matching systems will have the status \"Not reviewed\"  ",
+        "cveStatusModal.info": "This status is applied to all existing matching systems. Any new matching systems will have the status \"Not reviewed\"",
         "cveStatusModal.infoTooltip": "Example: If a new system is added and matches to this vulnerability, it will be given a status \"Not reviewed\"",
         "remediations.withAnsible": "Remediate with Ansible",
         "downloadExecutive.label": "Download executive report",

--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -121,14 +121,15 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
     return (
         <BaseModal items={cveList} onSave={handleSave} onSuccessNotification={successNotification} title={modalTitle}>
             <Stack gutter={'md'}>
-                <StackItem>
-                    {hasDifferentStatus ?
+                {hasDifferentStatus &&
+                    <StackItem>
                         <Alert
                             variant="warning"
                             isInline
-                            title={intl.formatMessage(messages.cvePairStatusModalAlert)} />
-                        : ''}
-                </StackItem>
+                            title={intl.formatMessage(messages.cvePairStatusModalAlert)}
+                        />
+                    </StackItem>
+                }
                 <StackItem>
                     <Form key="key">
                         <FormGroup fieldId={'overall'}>

--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -55,7 +55,7 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                                             content={intl.formatMessage(messages.cveStatusModalOverwriteTooltip)}
                                         >
                                             <React.Fragment>
-                                                <OutlinedQuestionCircleIcon />
+                                                <OutlinedQuestionCircleIcon className="pf-u-ml-xs"/>
                                             </React.Fragment>
                                         </Tooltip>
                                     </React.Fragment>
@@ -69,7 +69,7 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                         <FormGroup fieldId={'info'}>
                             <Split>
                                 <SplitItem style={{ marginRight: 'var(--pf-global--spacer--xs)' }}>
-                                    <InfoCircleIcon size="md" color="var(--pf-global--active-color--400)" />
+                                    <InfoCircleIcon color="var(--pf-global--active-color--400)" />
                                 </SplitItem>
                                 <SplitItem isFilled>
                                     {intl.formatMessage(messages.cveStatusModalInfo)}
@@ -77,7 +77,10 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                                         content={intl.formatMessage(messages.cveStatusModalInfoTooltip)}
                                     >
                                         <React.Fragment>
-                                            <OutlinedQuestionCircleIcon />
+                                            <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                style={{ cursor: 'pointer', verticalAlign: '-0.125em' }}
+                                            />
                                         </React.Fragment>
                                     </Tooltip>
                                 </SplitItem>


### PR DESCRIPTION
**CVE overall status modal**
- Info icon is too large. Change to 1.2em (currently 1.5)
- Missing cursor change when hovering over this tooltip (after "Not reviewed")
- Do not overwrite icon has no left margin

**CVE Pair status modal**
- Double spacing above checkbox should be removed