### PR TITLE
fix(system-detail): Enhanced system detail page

### DIFF
--- a/locales/translations.json
+++ b/locales/translations.json
@@ -131,7 +131,7 @@
         "impactTextList.moderate": "This rating is given to flaws that may be more difficult to exploit but could still lead to some compromise of the confidentiality, integrity, or availability of resources, under certain circumstances. These are the types of vulnerabilities that could have had a Critical impact or Important impact but are less easily exploited based on a technical evaluation of the flaw, or affect unlikely configurations.",
         "impactTextList.low": "This rating is given to all other issues that have a security impact. These are the types of vulnerabilities that are believed to require unlikely circumstances to be able to be exploited, or where a successful exploit would give minimal consequences.",
         "systemExcludedFromAnalysis.title": "Excluded from vulnerability analysis",
-        "systemExcludedFromAnalysis.body": "Excluded from vulnerability analysis",
+        "systemExcludedFromAnalysis.body": "This system has been excluded from vulnerability analysis. It is not being evaluated for potential vulnerabilities by Red Hat Insights.",
         "systemExcludedFromAnalysis.resumeAnalysis": "Resume vulnerability analysis",
         "createCveListByAccount.tooltip": "Individual CVE-Status pairs have differences from overall CVE status",
         "description": "Description",

--- a/src/Components/PresentationalComponents/Snippets/SnippetWithPopover.js
+++ b/src/Components/PresentationalComponents/Snippets/SnippetWithPopover.js
@@ -18,53 +18,48 @@ const SnippetWithPopover = props => {
     } = row.attributes;
     const hasDefaultStatus = systemStatusId === 0 && (cveStatusId === systemStatusId) && statusJustification === null;
 
-    const brPopoverContent = (
-        <TextContent>
-            <Stack>
-                <StackItem>
-                    <StyledText
-                        fontWeight={StyledConstants.fontWeights.bold}
-                        fontSize={StyledConstants.fontSizes.sm}
-                        lineHeight={StyledConstants.lineHeights.sm}
-                    >
-                        <FormattedMessage {...messages.justificationNote} />
-                    </StyledText>
-                </StackItem>
-                <StackItem>{businessRiskJustification || '--'}</StackItem>
-            </Stack>
-        </TextContent>
+    const BusinessRiskPopoverContent = (
+        <StackItem>
+            <StyledText
+                fontWeight={StyledConstants.fontWeights.bold}
+                fontSize={StyledConstants.fontSizes.sm}
+                lineHeight={StyledConstants.lineHeights.sm}
+            >
+                <FormattedMessage {...messages.justificationNote} />
+            </StyledText>
+            {businessRiskJustification || '--'}
+        </StackItem>
     );
 
-    const statusPopoverContent = (
-        <Stack>
-            <StackItem>
-                <StyledText
-                    fontWeight={StyledConstants.fontWeights.bold}
-                    fontSize={StyledConstants.fontSizes.sm}
-                    lineHeight={StyledConstants.lineHeights.sm}
-                >
-                    <FormattedMessage {...messages.cveSystemPairStatus} />
-                </StyledText>
-                {systemStatus || '--'}
+    const StatusPopoverContent = (
+        <StackItem>
+            <StyledText
+                fontWeight={StyledConstants.fontWeights.bold}
+                fontSize={StyledConstants.fontSizes.sm}
+                lineHeight={StyledConstants.lineHeights.sm}
+            >
+                <FormattedMessage {...messages.cveSystemPairStatus} />
+            </StyledText>
+            {systemStatus || '--'}
 
-                <StyledText
-                    fontWeight={StyledConstants.fontWeights.bold}
-                    fontSize={StyledConstants.fontSizes.sm}
-                    lineHeight={StyledConstants.lineHeights.sm}
-                    style={{ marginTop: 'var(--pf-global--spacer--sm)' }}
-                >
-                    <FormattedMessage {...messages.justificationNote} />
-                </StyledText>
-                {statusJustification || '--'}
-            </StackItem>
-        </Stack>
+            <StyledText
+                fontWeight={StyledConstants.fontWeights.bold}
+                fontSize={StyledConstants.fontSizes.sm}
+                lineHeight={StyledConstants.lineHeights.sm}
+                style={{ marginTop: 'var(--pf-global--spacer--sm)' }}
+            >
+                <FormattedMessage {...messages.justificationNote} />
+            </StyledText>
+            {statusJustification || '--'}
+        </StackItem>
     );
 
-    const footerContent = (
+    const popoverContent = (
         <Stack>
+            {type === 0 ? BusinessRiskPopoverContent : StatusPopoverContent}
             <StackItem>
                 <TextContent>
-                    <hr className={'splitter'} />
+                    <hr className={'splitter pf-u-mb-md pf-u-mt-md'} />
                 </TextContent>
                 <StyledText
                     fontWeight={StyledConstants.fontWeights.bold}
@@ -85,19 +80,21 @@ const SnippetWithPopover = props => {
         wordBreak: 'normal',
         color: hasDefaultStatus ? 'black' : '',
         whiteSpace: 'unset',
-        maxWidth: '131px'
+        maxWidth: '131px',
+        textAlign: 'left',
+        padding: '0px'
     };
 
     return (
-        <Popover bodyContent={type === 0 ? brPopoverContent : statusPopoverContent} headerContent={''}
-            aria-label={'Business risk popover'} position="left" footerContent={footerContent}>
+        <Popover bodyContent={popoverContent}
+            aria-label={'Business risk popover'} position="left">
 
             <Button variant="link"
                 isDisabled={hasDefaultStatus}
                 style={buttonStyle}>
                 {cveStatusId !== systemStatusId ? (
                     <Tooltip content={<FormattedMessage {...messages.onlyThisSystemCvePair} />}>
-                        <ServerAltIcon  className='pf-u-m-l'/>
+                        <ServerAltIcon className='pf-u-m-l'/>
                     </Tooltip>
                 ) : ('')}
                 {' '}{STATUS_OPTIONS.find(option => option.value === systemStatusId.toString()).label}

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { classNames, expandable, sortable } from '@patternfly/react-table';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import propTypes from 'prop-types';
@@ -237,15 +237,15 @@ class SystemCves extends Component {
                 transforms: [sortable, classNames('col-width-10')]
             },
             {
-                title: this.props.intl.formatMessage(messages.cvssBaseScore),
-                key: 'cvss_score',
-                transforms: [sortable, classNames('col-width-10')]
-            },
-            {
                 title: this.props.intl.formatMessage(messages.impact),
                 key: 'impact',
                 transforms: [sortable, classNames('col-width-10')],
                 columnTransforms: [classNames('no-wrap')]
+            },
+            {
+                title: this.props.intl.formatMessage(messages.cvssBaseScore),
+                key: 'cvss_score',
+                transforms: [sortable, classNames('col-width-10')]
             },
             {
                 title: this.props.intl.formatMessage(messages.businessRisk),
@@ -278,6 +278,13 @@ class SystemCves extends Component {
                     <StatusModal />
 
                     <Stack>
+                        <StackItem>
+                            <TextContent>
+                                <Text component={TextVariants.h2}>
+                                    {this.props.intl.formatMessage(messages.systemCvesTableHeader)}
+                                </Text>
+                            </TextContent>
+                        </StackItem>
                         <StackItem>
                             <SystemCveTableToolbar showRemediationButton entity={entity} />
                         </StackItem>

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -36,7 +36,7 @@ export const DEFAULT_PAGE_SIZE = 20;
 export const SystemExludedFromAnalysis = ({ buttonAction }) => (
     <Bullseye>
         <EmptyState variant={EmptyStateVariant.large}>
-            <EmptyStateIcon icon={SecurityIcon} size={'lg'} />
+            <EmptyStateIcon icon={SecurityIcon} size={'sm'} />
             <Title headingLevel="h5" size="lg">
                 <FormattedMessage {...messages.emptyStateSystemExcludedTitle} />
             </Title>

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -160,6 +160,12 @@ export default defineMessages({
         defaultMessage: 'Status'
     },
 
+    systemCvesTableHeader: {
+        id: 'cveTable.header',
+        description: 'Header title for system CVEs table',
+        defaultMessage: 'CVEs'
+    },
+
     searchFilterLabel: {
         id: 'searchFilterLabel',
         description: 'Default label for search filters',
@@ -529,8 +535,9 @@ export default defineMessages({
     },
     emptyStateSystemExcludedBody: {
         id: 'systemExcludedFromAnalysis.body',
-        description: 'body for empty state when the system is exluded',
-        defaultMessage: 'Excluded from vulnerability analysis'
+        description: 'Body for empty state when the system is exluded',
+        defaultMessage: 'This system has been excluded from vulnerability analysis.\
+        It is not being evaluated for potential vulnerabilities by Red Hat Insights.'
     },
     emptyStateSystemResumeAnalysis: {
         id: 'systemExcludedFromAnalysis.resumeAnalysis',


### PR DESCRIPTION
1. Missing the “CVEs” title above the table
2. Columns in the table, Impact & base score should be reversed in order
3. Status should line up on the left - use a link style/get rid of button padding
the issue it's more obvious when we display the link, the alignment is off 
4. Status popover 
a)  ~Pair status should be a sentence case (ex Scheduled for patch, NOT scheduled for Patch)~ probably coming from back-end
b)  spacing bellow the "Justification note" and the horizontal line should be 16px (md spacer) 
c) The same applies to "CVE status" and the horizontal line. There should be a 16px spacer under the line
5. Excluded system page
a) icon size is wrong
b) replace RH Cloud Management Services with RH Insights 