### PR TITLE
fix(CVE status modal): Separated overwrite checkbox from tooltip

### DIFF
--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -49,24 +49,27 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                         {StatusSelect}
                         {JustificationInput}
                         <FormGroup fieldId={'overwrite'}>
-                            <Checkbox
-                                label={
-                                    <React.Fragment>
-                                        {intl.formatMessage(messages.cveStatusModalOverwriteCheckbox)}
-                                        <Tooltip
-                                            content={intl.formatMessage(messages.cveStatusModalOverwriteTooltip)}
-                                        >
-                                            <React.Fragment>
-                                                <OutlinedQuestionCircleIcon className="pf-u-ml-xs"/>
-                                            </React.Fragment>
-                                        </Tooltip>
-                                    </React.Fragment>
-                                }
-                                id="alt-form-checkbox-1"
-                                name="alt-form-checkbox-1"
-                                isChecked={checkboxState}
-                                onChange={checked => setCheckboxState(checked)}
-                            />
+                            <Split>
+                                <SplitItem>
+                                    <Checkbox
+                                        label={intl.formatMessage(messages.cveStatusModalOverwriteCheckbox)}
+                                        id="alt-form-checkbox-1"
+                                        name="alt-form-checkbox-1"
+                                        isChecked={checkboxState}
+                                        onChange={checked => setCheckboxState(checked)}
+                                    />
+                                </SplitItem>
+                                <SplitItem>
+                                    <Tooltip
+                                        content={intl.formatMessage(messages.cveStatusModalOverwriteTooltip)}
+                                    >
+                                        <OutlinedQuestionCircleIcon
+                                            className="pf-u-ml-xs"
+                                            style={{ verticalAlign: '0' }}
+                                        />
+                                    </Tooltip>
+                                </SplitItem>
+                            </Split>
                         </FormGroup>
                         <FormGroup fieldId={'info'}>
                             <Split>
@@ -84,7 +87,7 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                                         <React.Fragment>
                                             <OutlinedQuestionCircleIcon
                                                 className="pf-u-ml-xs"
-                                                style={{ cursor: 'pointer', verticalAlign: '-0.125em' }}
+                                                style={{ verticalAlign: '-0.125em' }}
                                             />
                                         </React.Fragment>
                                     </Tooltip>


### PR DESCRIPTION
Fixes [issue](https://projects.engineering.redhat.com/browse/VMAAS-1019?focusedCommentId=2245204&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2245204) where clicking tooltip icon checks "Do not overwrite individual system status" checkbox on the status modal.