### PR TITLE
fix(kebab-menus): Don't disable kebab menus when table is empty and there is an action

### DIFF
--- a/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
@@ -77,8 +77,8 @@ class VulnerabilitiesToolbarWithContext extends Component {
                 isDisabled: !selectedCvesCount
             }),
             kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
-            kebabItemDownloadJSON(methods.downloadReport),
-            kebabItemDownloadCSV(methods.downloadReport)
+            kebabItemDownloadJSON(methods.downloadReport, { isDisabled: cves.data.length === 0 }),
+            kebabItemDownloadCSV(methods.downloadReport, { isDisabled: cves.data.length === 0 })
         ];
         return (
             <React.Fragment>
@@ -104,7 +104,10 @@ class VulnerabilitiesToolbarWithContext extends Component {
                         />
 
                         {showRemediationButton && <Remediation systemId={entity.id} selectedCves={selectedCves} />}
-                        <BaseKebab dropdownItems={kebabOptions} disabled={cves.data.length === 0} />
+                        <BaseKebab
+                            dropdownItems={kebabOptions}
+                            disabled={cves.data.length === 0 && selectedCvesCount === 0}
+                        />
                     </ToolbarGroup>
 
                     <ToolbarGroup>

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -80,8 +80,8 @@ class SystemCveToolbarWithContext extends Component {
                 { isDisabled: !selectedCvesCount }
             ),
             kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
-            kebabItemDownloadJSON(methods.downloadReport),
-            kebabItemDownloadCSV(methods.downloadReport)
+            kebabItemDownloadJSON(methods.downloadReport, { isDisabled: cves.data.length === 0 }),
+            kebabItemDownloadCSV(methods.downloadReport, { isDisabled: cves.data.length === 0 })
         ];
         return (
             <React.Fragment>
@@ -108,7 +108,10 @@ class SystemCveToolbarWithContext extends Component {
                             apply={methods.apply}
                         />
                         {showRemediationButton && <Remediation systemId={entity.id} selectedCves={selectedCves} />}
-                        <BaseKebab dropdownItems={kebabOptions} disabled={cves.data.length === 0} />
+                        <BaseKebab
+                            dropdownItems={kebabOptions}
+                            disabled={cves.data.length === 0 && selectedCvesCount === 0}
+                        />
                     </ToolbarGroup>
 
                     <ToolbarGroup>

--- a/src/Components/SmartComponents/Systems/Systems.js
+++ b/src/Components/SmartComponents/Systems/Systems.js
@@ -265,8 +265,8 @@ class Systems extends React.Component {
                 isDisabled: !this.getSelected().size
             }),
             kebabItemToggleExcludeSystemDisplay(this.handleOptOut, this.state.opt_out),
-            kebabItemDownloadJSON(this.downloadReport),
-            kebabItemDownloadCSV(this.downloadReport)
+            kebabItemDownloadJSON(this.downloadReport, { isDisabled: data.length === 0 }),
+            kebabItemDownloadCSV(this.downloadReport, { isDisabled: data.length === 0 })
         ];
         return (
             <Page>
@@ -301,7 +301,7 @@ class Systems extends React.Component {
                             </ToolbarItem>
 
                             <ToolbarItem>
-                                <BaseKebab dropdownItems={kebabOptions} disabled={data.length === 0} />
+                                <BaseKebab dropdownItems={kebabOptions} />
                             </ToolbarItem>
                         </ToolbarGroup>
                         <TableToolbar className="pf-u-pl-0 system-filter-chips">

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -298,8 +298,8 @@ class SystemsExposedTable extends Component {
             kebabItemEditStatus(methods.showStatusModal, [cveStatusDetails], selectedInventoryIds, {
                 isDisabled: !selectedInventoryIds.length
             }),
-            kebabItemDownloadJSON(this.downloadReport),
-            kebabItemDownloadCSV(this.downloadReport)
+            kebabItemDownloadJSON(this.downloadReport, { isDisabled: data.length === 0 }),
+            kebabItemDownloadCSV(this.downloadReport, { isDisabled: data.length === 0 })
         ];
         const dynamicCVESecurityRule = buildDynamicFilter(filtersCVESecurityRule, ruleErrorKeys);
         const urlParams = qs.parse(window.location.search);
@@ -352,7 +352,10 @@ class SystemsExposedTable extends Component {
                             />
                         </ToolbarItem>
                         <ToolbarItem>
-                            <BaseKebab dropdownItems={kebabOptions} disabled={data.length === 0} />
+                            <BaseKebab
+                                dropdownItems={kebabOptions}
+                                disabled={data.length === 0 && selectedInventoryIds.length === 0}
+                            />
                         </ToolbarItem>
                     </ToolbarGroup>
                     <TableToolbar className="pf-u-pl-0 affected-systems-filter-chips">


### PR DESCRIPTION
**Fixes [VMAAS-1045](https://projects.engineering.redhat.com/browse/VMAAS-1045) and [VMAAS-1050](https://projects.engineering.redhat.com/browse/VMAAS-1050).** 

**Previous behaviour:** 
**CVEs table:** Kebab was disabled when table was empty which prevented from bulk editing status and business risk when there were items selected but filtered out.
**System CVEs table and Systems exposed table:** Disabled kebab prevented from bulk editing pair status of selected but filtered out items.
**Systems table:** Disabled kebab prevented from toggling between showing and hiding excluded systems when table was empty.

**New behaviour:**
**All tables:** Disable export to CSV and export to JSON buttons when table is empty.
**CVEs table, System CVEs table and Systems exposed table:** Disable kebab only when table is empty AND there are no items selected.
**Systems table:** Never disable kebab. 