### PR TITLE
fix(exposed-systems): Do not override systemRules store on _FULFILLED…

### DIFF
--- a/src/Store/Reducers/InsightsRuleStore.js
+++ b/src/Store/Reducers/InsightsRuleStore.js
@@ -10,6 +10,7 @@ export const InsightsRuleStore = (state = initialState, action) => {
     let newState = { ...state };
     switch (action.type) {
         case ActionTypes.FETCH_INSIGHTS_SYSTEM_RULES + '_PENDING':
+            newState.isLoading = true;
             return newState;
         case ActionTypes.FETCH_INSIGHTS_SYSTEM_RULES + '_REJECTED':
             newState.isLoading = false;
@@ -17,7 +18,7 @@ export const InsightsRuleStore = (state = initialState, action) => {
             return newState;
         case ActionTypes.FETCH_INSIGHTS_SYSTEM_RULES + '_FULFILLED':
             newState.isLoading = false;
-            newState.systemRules = action.payload;
+            newState.systemRules = [...newState.systemRules, ...action.payload];
             return newState;
         default:
             return state;


### PR DESCRIPTION
For multiple rules in cve, I was overriding the systemRules instead of pushing the new entry into the array. 
A cve with multiple different rules can be found`CVE-2019-11091`