### PR TITLE
fix(inventory): Use node instead of callback

### DIFF
--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -26,7 +26,7 @@ export const createExposedSystemsTable = ({ isLoading, payload, openedRows }) =>
         id: item.id,
         isOpen: openedRows.includes(item.id),
         status: item.attributes.status_name,
-        children: () => item.attributes.rule_id
+        children: item.attributes.rule_id
             ? <InsightsSystemRule systemId={item.id} ruleId={item.attributes.rule_id} isOpen={openedRows.includes(item.id)}/>
             : <InsightsNoSystemRule/>
     }));


### PR DESCRIPTION
inventory updated version, we are allowed to use node instead of callback that might cause reloads