### PR TITLE
fix(csaw): Fix associated cve links in csaw rule box

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -23,7 +23,7 @@ import { FormattedMessage } from 'react-intl';
 
 import Label from '../Snippets/Label';
 import messages from '../../../Messages';
-import { RISK_OF_CHANGE_TOOLTIP, RISK_OF_CHANGE_LABEL, RH_KB_URL } from '../../../Helpers/constants';
+import { RISK_OF_CHANGE_TOOLTIP, RISK_OF_CHANGE_LABEL, RH_KB_URL, CVES_PATH } from '../../../Helpers/constants';
 import TruncatedText from '../Snippets/TruncatedText';
 import { CSAwIcon } from '../../PresentationalComponents/CSAwIcon/CSAwIcon';
 import './CSAwRuleBox.scss';
@@ -60,9 +60,16 @@ const CSAwRuleBox = ({ rules, synopsis, fetchAffectedSystems }) => {
                                             {
                                                 rule.associated_cves
                                                 .filter(cve => cve !== synopsis)
-                                                .map(cve => (
-                                                    <Link key={cve} to={`/cves/${cve}`}>, {cve},</Link>)
+                                                .map((cve, _i) =>
+                                                    <a
+                                                        className="associated-cve-link"
+                                                        key={_i}
+                                                        href={`${document.baseURI}${CVES_PATH}/${cve}`}
+                                                    >
+                                                        {cve}
+                                                    </a>
                                                 )
+                                                .reduce((prev, curr) => [prev, ', ', curr], [''])
                                             }
                                         </Text>
                                     </TextContent>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
@@ -89,7 +89,7 @@ describe('CSAW Rule Box', () => {
         ]
 
         const wrapper = shallow(<CSAwRuleBox rules={rules} synopsis={synopsis}/>);
-        expect(wrapper.find('Link')).toHaveLength(3)
+        expect(wrapper.find('.associated-cve-link')).toHaveLength(2)
     });
 
     it('Should render with playbook', () => {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -32,6 +32,7 @@ const intlSettings = { locale };
 
 export const DEFAULT_PAGE_SIZE = 20;
 export const RH_KB_URL = 'https://access.redhat.com/node';
+export const CVES_PATH = 'rhel/vulnerability/cves';
 
 // eslint-disable-next-line react/prop-types
 export const SystemExludedFromAnalysis = ({ buttonAction }) => (


### PR DESCRIPTION
Fixing the commas and the reload issue when clicking on the associated cves