### PR TITLE
fix(cve tables): Expand all button disables when no data

### DIFF
--- a/src/Components/PresentationalComponents/DownloadReportKebab/KebabItems.js
+++ b/src/Components/PresentationalComponents/DownloadReportKebab/KebabItems.js
@@ -28,8 +28,8 @@ export const kebabItemEditStatus = (showStatusModal, cves, inventoryIds,  { ...p
     </DropdownItem>
 );
 
-export const kebabItemToggleCvesDescription = (toggleCveDescription, isExpanded) => (
-    <DropdownItem key="toggleCveDescription" component="button" onClick={() => toggleCveDescription()}>
+export const kebabItemToggleCvesDescription = (toggleCveDescription, isExpanded, { ...props }) => (
+    <DropdownItem key="toggleCveDescription" component="button" onClick={() => toggleCveDescription()} {...props}>
         {isExpanded ? <FormattedMessage {...messages.kebabCollapseCves} /> : <FormattedMessage {...messages.kebabExpandCves} /> }
     </DropdownItem>
 );

--- a/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/VulnerabilitiesTableToolbar.js
@@ -76,7 +76,11 @@ class VulnerabilitiesToolbarWithContext extends Component {
             kebabItemEditStatus(methods.showStatusModal, selectedCves.map(item => ({ id: item, status_id: '0' })), [], {
                 isDisabled: !selectedCvesCount
             }),
-            kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
+            kebabItemToggleCvesDescription(
+                this.handleCveDescription,
+                expandCveDescription,
+                { isDisabled: cves.data.length === 0 }
+            ),
             kebabItemDownloadJSON(methods.downloadReport, { isDisabled: cves.data.length === 0 }),
             kebabItemDownloadCSV(methods.downloadReport, { isDisabled: cves.data.length === 0 })
         ];

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -79,7 +79,11 @@ class SystemCveToolbarWithContext extends Component {
                 [],
                 { isDisabled: !selectedCvesCount }
             ),
-            kebabItemToggleCvesDescription(this.handleCveDescription, expandCveDescription),
+            kebabItemToggleCvesDescription(
+                this.handleCveDescription,
+                expandCveDescription,
+                { isDisabled: cves.data.length === 0 }
+            ),
             kebabItemDownloadJSON(methods.downloadReport, { isDisabled: cves.data.length === 0 }),
             kebabItemDownloadCSV(methods.downloadReport, { isDisabled: cves.data.length === 0 })
         ];


### PR DESCRIPTION
Fixes [VMAAS-1147](https://projects.engineering.redhat.com/browse/VMAAS-1147).

1. Select any CVE in Vulnerability/CVE by system page
2. Filter out all CVES
**previous:**
Expand all item in toolbar kebab was enabled but didn't do anything
**new:**
Expand all item in toolbar kebab is disabled