### PR TITLE
chore(npm scripts): Add npm scripts for running  tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,8 @@
     "build": "webpack --config config/prod.webpack.config.js",
     "build:components": "webpack --config config/lib.webpack.config.js",
     "test": "jest --passWithNoTests",
+    "test-watch": "jest --watch --passWithNoTests",
+    "test-updateSnapshot": "jest --updateSnapshot --passWithNoTests",
     "coverage": "codecov",
     "lint": "npm-run-all lint:js",
     "lint:js": "eslint config src",


### PR DESCRIPTION
now you can use:

1. `npm run test-watch ` to watch your tests while you're writing tests
2.  `npm run test-updateSnapshot` to update snapshots 
