### PR TITLE
fix(pair status modal): Show CVE justification note when using overall

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -21,14 +21,15 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
     const inventoryIds = inventoryList.map(item => item.id);
 
     useEffect(() => {
-        if (checkboxState) {
-            setSelectProps({ isDisabled: true });
-            setJustificationProps({ disabled: true });
-        }
+        setSelectProps({ isDisabled: checkboxState });
+        setJustificationProps({ disabled: checkboxState });
+        setStatusId(getCveStatus());
+        setJustification(getCveJustification());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [checkboxState, setSelectProps, setJustificationProps]);
 
     useEffect(() => {
-        setStatusId(getCvestatus());
+        setStatusId(getCveStatus());
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [checkboxState, setStatusId]);
 
@@ -52,7 +53,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
         }
 
         if (cveList && cveList.length > 0) {
-            return getCvestatus();
+            return getCveStatus();
         }
 
     }
@@ -89,7 +90,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
         return (inventoryList && inventoryList.length === 1 && inventoryList[0].justification) || '';
     }
 
-    function getCvestatus() {
+    function getCveStatus() {
         switch (type) {
             case 'systemsExposed' : {
                 return (cveList && cveList.length === 1 && cveList[0].status_id.toString()) || '0';
@@ -97,11 +98,16 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
 
             case 'systemDetail': {
                 if (cveList) {
-                    if (checkboxState && !hasDifferentStatus) { return cveList[0].cve_status_id || 0;}
-                    else if (hasDifferentStatus) {return '0';}
-                    else if (!checkboxState && !hasDifferentStatus) {return cveList[0].status_id;}
-                    else {return '0';}
-                } else {return '0';}
+                    if (checkboxState) { // use overall (CVE) status
+                        return hasDifferentStatus ? '0' : cveList[0].cve_status_id || '0';
+                    }
+                    else { // use system pair status
+                        return hasDifferentStatus ? '0' : cveList[0].status_id || '0';
+                    }
+                }
+                else {
+                    return '0';
+                }
             }
 
             default: {
@@ -112,15 +118,24 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
     }
 
     function getCveJustification() {
-        return (cveList && cveList.length === 1 && cveList[0].justification) || '';
-    }
+        switch (type) {
+            case 'systemsExposed' : {
+                return (cveList && cveList.length === 1 && cveList[0].justification) || '';
+            }
 
-    function handleCheckboxChange(checked) {
-        setCheckboxState(checked);
-        setSelectProps({ isDisabled: checked });
-        setStatusId(getCvestatus());
-        setJustification(getCveJustification());
-        setJustificationProps({ disabled: checked });
+            case 'systemDetail': {
+                if (checkboxState) { // use overall (CVE) justification
+                    return (cveList && cveList.length === 1 && cveList[0].cve_justification) || '';
+                }
+                else { // use system pair justification
+                    return (cveList && cveList.length === 1 && cveList[0].justification) || '';
+                }
+            }
+
+            default: {
+                return '';
+            }
+        }
     }
 
     const successNotification = {
@@ -164,7 +179,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
                                         id="alt-form-checkbox-1"
                                         name="alt-form-checkbox-1"
                                         isChecked={checkboxState}
-                                        onChange={handleCheckboxChange}
+                                        onChange={checked => setCheckboxState(checked)}
                                     />
                                 </SplitItem>
                                 <SplitItem>

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -75,7 +75,6 @@ class SystemCves extends Component {
     }
 
     apply = (config = {}) => {
-
         if (Object.prototype.hasOwnProperty.call(config, 'cvss_filter')) {
             let cvssEntry = CVSSOptions.find(item => item.value === config.cvss_filter);
 
@@ -187,7 +186,6 @@ class SystemCves extends Component {
     };
 
     showStatusModal = cves => {
-
         let hasDifferentStatus;
         if (cves.length > 1) {
             const selectedCves = Array.from(this.props.cveList.data.filter(cve => cves.some(element => element.id === cve.id)));

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -150,7 +150,8 @@ export const systemCveTableRowActions = methods => [
                     id: rowData.id,
                     status_id: rowData.status_id,
                     cve_status_id: rowData.cve_status_id,
-                    justification: rowData.status_justification
+                    justification: rowData.status_justification,
+                    cve_justification: rowData.cve_status_justification
                 }
             ])
     }

--- a/src/Helpers/VulnerabilitiesHelper.js
+++ b/src/Helpers/VulnerabilitiesHelper.js
@@ -140,6 +140,7 @@ export function createCveListBySystem(systemId, cveList) {
                         rules: row.attributes.rules,
                         cve_status_id: row.attributes.cve_status_id,
                         status_justification: row.attributes.status_text,
+                        cve_status_justification: row.attributes.cve_status_text,
                         cells: [
                             {
                                 title: (


### PR DESCRIPTION
Fixes [VULN-132](https://projects.engineering.redhat.com/browse/VULN-132).
- pass missing overall justification param necessary for the fix
- refactor getCvestatus -> getCveStatus
- simplify getCveStatus
- handle overall checkbox change inside hook