### PR TITLE
chore(test): Added unit test for both status modals

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.test.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.test.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import * as deps from '../../../Helpers/APIHelper';
+import CVEPairStatusModal from './CvePairStatusModal';
+import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
+import ReducerRegistry from '../../../Utilities/ReducerRegistry';
+
+const MockStore = ({ children }) => (
+    <IntlProvider>
+        <Provider store={ReducerRegistry.getStore()}>{children}</Provider>
+    </IntlProvider>
+);
+
+// testing for correct default checkbox, enabled alert box when statuses are different, and correct params sent to the setSystemCveStatus()
+describe('CvePairStatusModal component', () => {
+    const cveSingle = [ 
+        { id: "CVE-2020-0001", status_id: "3", justification: "old justification" } 
+    ];
+
+    const cveMultiple = [ 
+        { id: "CVE-2020-0001", status_id: "3", justification: "old justification" },
+        { id: "CVE-2020-0002", status_id: "4", justification: "old justification" } 
+    ];
+
+    const systemSingle = [
+        { id: "system-1", status_id: "2", justification: "old justification" } 
+    ];
+
+    const systemMultiple = [ 
+        { id: "system-1", status_id: "3", justification: "old justification" },
+        { id: "system-2", status_id: "4", justification: "different old justification" } 
+    ];
+
+    it('should render from perspective of system CVE table with one CVE selected', () => {
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        deps.setSystemCveStatus = setSystemCveStatusMock;
+
+        const pairStatusModal = mount(
+            <MockStore>
+                <CVEPairStatusModal open type={'systemDetail'} cves={cveSingle} inventories={systemSingle}/>
+            </MockStore>
+        );
+        
+        const isStatusDisabled            = pairStatusModal.find('FormSelect').prop('isDisabled');
+        const isJustificationNoteDisabled = pairStatusModal.find('TextArea').prop('disabled');
+        const setStatus                   = pairStatusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote        = pairStatusModal.find('TextArea').prop('onChange');
+        const setOverallCheckbox          = pairStatusModal.find('Checkbox').prop('onChange');
+        const alertBox                    = pairStatusModal.find({ "aria-label": "Warning Alert"});
+        const saveButton                  = pairStatusModal.find({ variant: 'primary' }).last();
+
+        expect(alertBox.exists()).toBeFalsy();
+
+        setOverallCheckbox(false);
+
+        expect(isStatusDisabled).toBeFalsy();
+        expect(isJustificationNoteDisabled).toBeFalsy();
+
+        setStatus(5);
+        setJustificationNote('new justification');
+
+        saveButton.simulate('click');
+        
+        expect(setSystemCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001'],
+            inventory_id: ['system-1'],
+            status_id: 5,
+            status_text: 'new justification'
+        });
+    });
+
+    it('should render from perspective of system CVE table with multiple CVE with different statuses selected', () => {
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        deps.setSystemCveStatus = setSystemCveStatusMock;
+
+        const pairStatusModal = mount(
+            <MockStore>
+                <CVEPairStatusModal open type={'systemDetail'} cves={cveMultiple} inventories={systemSingle} hasDifferentStatus/>
+            </MockStore>
+        );
+
+        const setStatus            = pairStatusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote = pairStatusModal.find('TextArea').prop('onChange');
+        const setOverallCheckbox   = pairStatusModal.find('Checkbox').prop('onChange');
+        const alertBox             = pairStatusModal.find({ "aria-label": "Warning Alert"});
+        const saveButton           = pairStatusModal.find({ variant: 'primary' }).last();
+
+        expect(alertBox.exists()).toBeTruthy();
+
+        setOverallCheckbox(false);
+        setStatus(5);
+        setJustificationNote('new justification');
+
+        saveButton.simulate('click');
+        
+        expect(setSystemCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001', 'CVE-2020-0002'],
+            inventory_id: ['system-1'],
+            status_id: 5,
+            status_text: 'new justification'
+        });
+    });
+
+    it('should render from perspective of affected systems table with single system selected', () => {
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        deps.setSystemCveStatus = setSystemCveStatusMock;
+
+        const pairStatusModal = mount(
+            <MockStore>
+                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemSingle} />
+            </MockStore>
+        );
+
+        const setStatus            = pairStatusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote = pairStatusModal.find('TextArea').prop('onChange');
+        const setOverallCheckbox   = pairStatusModal.find('Checkbox').prop('onChange');
+        const alertBox             = pairStatusModal.find({ "aria-label": "Warning Alert"});
+        const saveButton           = pairStatusModal.find({ variant: 'primary' }).last();
+
+        expect(alertBox.exists()).toBeFalsy();
+
+        setOverallCheckbox(false);
+        setStatus(5);
+        setJustificationNote('new justification');
+
+        saveButton.simulate('click');
+        
+        expect(setSystemCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001'],
+            inventory_id: ['system-1'],
+            status_id: 5,
+            status_text: 'new justification'
+        });
+    });
+
+    it('should render from perspective of affected systems table with multiple systems with different statuses selected', () => {
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        deps.setSystemCveStatus = setSystemCveStatusMock;
+        
+        const pairStatusModal = mount(
+            <MockStore>
+                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemMultiple} hasDifferentStatus/>
+            </MockStore>
+        );
+
+        const setStatus            = pairStatusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote = pairStatusModal.find('TextArea').prop('onChange');
+        const setOverallCheckbox   = pairStatusModal.find('Checkbox').prop('onChange');
+        const alertBox             = pairStatusModal.find({ "aria-label": "Warning Alert"});
+        const saveButton           = pairStatusModal.find({ variant: 'primary' }).last();
+
+        expect(alertBox.exists()).toBeTruthy();
+
+        setOverallCheckbox(false);
+        setStatus(5);
+        setJustificationNote('new justification');
+
+        saveButton.simulate('click');
+        
+        expect(setSystemCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001'],
+            inventory_id: ['system-1', 'system-2'],
+            status_id: 5,
+            status_text: 'new justification'
+        });
+    });
+
+    it('should render from perspective of affected systems table with multiple systems selected and use overall justification', () => {
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        deps.setSystemCveStatus = setSystemCveStatusMock;
+
+        const pairStatusModal = mount(
+            <MockStore>
+                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemMultiple}/>
+            </MockStore>
+        );
+
+        const isStatusDisabled            = pairStatusModal.find('FormSelect').prop('isDisabled');
+        const isJustificationNoteDisabled = pairStatusModal.find('TextArea').prop('disabled');
+        const setOverallCheckbox          = pairStatusModal.find('Checkbox').prop('onChange');
+        const alertBox                    = pairStatusModal.find({ "aria-label": "Warning Alert"});
+        const saveButton                  = pairStatusModal.find({ variant: 'primary' }).last();
+
+        expect(alertBox.exists()).toBeFalsy();
+
+        setOverallCheckbox(true);
+
+        expect(isStatusDisabled).toBeTruthy();
+        expect(isJustificationNoteDisabled).toBeTruthy();
+
+        saveButton.simulate('click');
+        
+        expect(setSystemCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001'],
+            inventory_id: ['system-1', 'system-2'],
+        });
+    });
+});

--- a/src/Components/SmartComponents/Modals/CveStatusModal.test.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import * as deps from '../../../Helpers/APIHelper';
+import CVEStatusModal from './CveStatusModal';
+import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
+import ReducerRegistry from '../../../Utilities/ReducerRegistry';
+
+const MockStore = ({ children }) => <Provider store={ReducerRegistry.getStore()}>{children}</Provider>;
+
+describe('CveStatusModal component', () => {
+    it('should render with one CVE selected', () => {
+        const setCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        
+        deps.setCveStatus = setCveStatusMock; // CVE status
+        deps.setSystemCveStatus = setSystemCveStatusMock; // CVE-system pair status, only call when checkbox is unchecked
+
+        const cveList = [ {
+            id: "CVE-2020-0001",
+            status_id: "3",
+            justification: "old justification" 
+        } ];
+
+        const statusModal = mount(
+            <IntlProvider>
+                <MockStore>
+                    <CVEStatusModal open cves={cveList} />
+                </MockStore>
+            </IntlProvider>
+        );
+
+        const setStatus = statusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote = statusModal.find('TextArea').prop('onChange');
+        // const setOverallCheckbox = statusModal.find('Checkbox').prop('onChange');
+        const saveButton = statusModal.find({ variant: 'primary' }).last();
+
+        setStatus(5);
+        setJustificationNote('new justification');
+        //setOverallCheckbox(true);
+
+        saveButton.simulate('click');
+        
+        expect(setCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001'],
+            status_id: 5,
+            status_text: 'new justification'
+        });
+    });
+
+    it('should render with multiple CVEs selected', () => {
+        const setCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        const setSystemCveStatusMock = jest.fn(parameters => new Promise(resolve => resolve(parameters)));
+        
+        deps.setCveStatus = setCveStatusMock; // CVE status
+        deps.setSystemCveStatus = setSystemCveStatusMock; // CVE-system pair status, only call when checkbox is unchecked
+
+        const cveList2 = [ 
+            {
+                id: "CVE-2020-0001",
+                status_id: "3",
+                justification: "test" 
+            },
+            {
+                id: "CVE-2020-0002",
+                status_id: "4",
+                justification: "test2" 
+            }
+        ];
+
+        const statusModal = mount(
+            <IntlProvider>
+                <MockStore>
+                    <CVEStatusModal open cves={cveList2} />
+                </MockStore>
+            </IntlProvider>
+        );
+
+        const setStatus = statusModal.find('FormSelect').prop('onChange');
+        const setJustificationNote = statusModal.find('TextArea').prop('onChange');
+        // const setOverallCheckbox = statusModal.find('Checkbox').prop('onChange');
+        const saveButton = statusModal.find({ variant: 'primary' }).last();
+
+        setStatus(0);
+        setJustificationNote('new justification');
+        //setOverallCheckbox(true);
+
+        saveButton.simulate('click');
+        
+        expect(setCveStatusMock).toBeCalledWith({
+            cve: ['CVE-2020-0001', 'CVE-2020-0002'],
+            status_id: 0,
+            status_text: 'new justification'
+        });
+    });
+});


### PR DESCRIPTION
It doesn't check whether setSystemCveStatus() was called correctly for the status modal, I haven't figured out testing promise chaining yet.