### PR TITLE
fix(SystemsPage) unwanted uuid filter is added on systems page onload

### DIFF
--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -34,7 +34,7 @@ export function getAffectedSystemsByCVE(synopsis, apiProps) {
 }
 
 export function getSystems(apiProps) {
-    let parameterNames = ['filter', 'limit', 'offset', 'page', 'page_size', 'sort', 'data_format', 'stale', 'opt_out'];
+    let parameterNames = ['filter', 'limit', 'offset', 'page', 'page_size', 'sort', 'data_format', 'stale', 'uuid', 'opt_out'];
     let parameterArray = constructParameters(apiProps, parameterNames);
     let result = api.getSystemsList(...parameterArray);
     return result;

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -86,7 +86,6 @@ export function getCveListBySystem(apiProps) {
         'status_id',
         'data_format',
         'business_risk_id',
-        'stale',
         'security_rule'
     ];
     if (apiProps && system) {


### PR DESCRIPTION
After vulnerabilities-client has been updated, uuid = false is added to the endpoint /v1/systems. it was because the order of parameters sent to vulnerability client was influenced. I added 'uuid' to parameterNames array to make it even with API parameters from backend.