### PR TITLE
fix(layout): Fixed spacing after PF4 migration

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -40,7 +40,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
         {ruleCards && ruleCards.map(rule => (
             <Card className="card-box-shadow" key={rule.rule_id}>
                 <CardBody>
-                    <Grid gutter="md">
+                    <Grid hasGutter>
                         <GridItem span={12}>
                             <TextContent className={'icon-with-label'}>
                                 <Text component={TextVariants.h3}>
@@ -52,7 +52,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                             </TextContent>
                         </GridItem>
                         <GridItem span={8}>
-                            <Stack gutter="md">
+                            <Stack hasGutter>
                                 <StackItem>
                                     <CSAwRuleSummary text={rule.summary} />
                                 </StackItem>
@@ -107,7 +107,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                             </Stack>
                         </GridItem>
                         <GridItem span={4}>
-                            <Stack gutter="md">
+                            <Stack hasGutter>
                                 {rule.rule_id &&
                                     <StackItem>
                                         <TextContent>
@@ -133,7 +133,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                             {intl.formatMessage(messages.remediatioLabel)}
 
                                         </Text>
-                                        <Split gutter="md">
+                                        <Split hasGutter>
                                             <SplitItem>
                                                 <Label className="label">
                                                     {intl.formatMessage(messages.ansibleRemediation)}
@@ -161,7 +161,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                                 }
                                             </SplitItem>
                                         </Split>
-                                        <Split gutter="md">
+                                        <Split hasGutter>
                                             <SplitItem>
                                                 <Label className="label">
                                                     {intl.formatMessage(messages.riskOfChange)}

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-danger */
-import React, { Fragment } from 'react';
+import React from 'react';
 import marked from 'marked';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
@@ -24,17 +24,17 @@ const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
     const dangerousHtml = (text) => ({ __html: sanitizeHtml(text) });
 
     return (
-        <TextContent className="rule-description">
-            { truncate
-                ? (
-                    <Truncate
-                        length={230}
-                        expandText={intl.formatMessage(messages.readMore)}
-                        collapseText={intl.formatMessage(messages.readLess)}
-                        text={marked(text)}
-                    />
-                ) : (
-                    <Fragment>
+        <StackItem>
+            <TextContent className="rule-description">
+                { truncate
+                    ? (
+                        <Truncate
+                            length={230}
+                            expandText={intl.formatMessage(messages.readMore)}
+                            collapseText={intl.formatMessage(messages.readLess)}
+                            text={marked(text)}
+                        />
+                    ) : (
                         <Stack>
                             <StackItem>
                                 <span dangerouslySetInnerHTML={dangerousHtml(marked(text))}/>
@@ -43,10 +43,10 @@ const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
                                 {link && handleCVELink(link, intl.formatMessage(messages.readMore))}
                             </StackItem>
                         </Stack>
-                    </Fragment>
-                )
-            }
-        </TextContent>
+                    )
+                }
+            </TextContent>
+        </StackItem>
     );
 
 };

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -126,11 +126,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                 className="pf-c-card__body"
               >
                 <Component
-                  gutter="md"
+                  hasGutter={true}
                 >
                   <div
-                    className="pf-l-grid"
-                    gutter="md"
+                    className="pf-l-grid pf-m-gutter"
                   >
                     <Component
                       span={12}
@@ -296,11 +295,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                         className="pf-l-grid__item pf-m-8-col"
                       >
                         <Component
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-stack"
-                            gutter="md"
+                            className="pf-l-stack pf-m-gutter"
                           >
                             <Component>
                               <div
@@ -358,69 +356,75 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
 "
                                     truncate={true}
                                   >
-                                    <Component
-                                      className="rule-description"
-                                    >
+                                    <Component>
                                       <div
-                                        className="pf-c-content rule-description"
+                                        className="pf-l-stack__item"
                                       >
-                                        <Truncate
-                                          collapseText="Read less"
-                                          expandText="Read More"
-                                          length={230}
-                                          text="<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target='_blank' href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11135</a>. Complete mitigations for this issue require microcode and kernel updates, and disabling hyperthreading where applicable.</p>
+                                        <Component
+                                          className="rule-description"
+                                        >
+                                          <div
+                                            className="pf-c-content rule-description"
+                                          >
+                                            <Truncate
+                                              collapseText="Read less"
+                                              expandText="Read More"
+                                              length={230}
+                                              text="<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target='_blank' href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11135</a>. Complete mitigations for this issue require microcode and kernel updates, and disabling hyperthreading where applicable.</p>
 <p>An unprivileged user can use this flaw to gain read access to privileged memory that would otherwise be inacessible, including from other virtual machines on the same host system.</p>
 "
-                                        >
-                                          <Component
-                                            className="ins-c-truncate is-block"
-                                          >
-                                            <div
-                                              className="pf-l-stack ins-c-truncate is-block"
                                             >
-                                              <Component>
+                                              <Component
+                                                className="ins-c-truncate is-block"
+                                              >
                                                 <div
-                                                  className="pf-l-stack__item"
+                                                  className="pf-l-stack ins-c-truncate is-block"
                                                 >
-                                                  <span
-                                                    dangerouslySetInnerHTML={
-                                                      Object {
-                                                        "__html": "<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target=\\"_blank\\" href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11...</a></p>",
-                                                      }
-                                                    }
-                                                    widget-type="InsightsTruncateBlock"
-                                                  />
-                                                </div>
-                                              </Component>
-                                              <Component>
-                                                <div
-                                                  className="pf-l-stack__item"
-                                                >
-                                                  <Component
-                                                    className="ins-c-expand-button"
-                                                    onClick={[Function]}
-                                                    variant="link"
-                                                  >
-                                                    <button
-                                                      aria-disabled={null}
-                                                      aria-label={null}
-                                                      className="pf-c-button pf-m-link ins-c-expand-button"
-                                                      data-ouia-component-id={null}
-                                                      data-ouia-component-type="PF4/Button"
-                                                      data-ouia-safe={true}
-                                                      disabled={false}
-                                                      onClick={[Function]}
-                                                      tabIndex={null}
-                                                      type="button"
+                                                  <Component>
+                                                    <div
+                                                      className="pf-l-stack__item"
                                                     >
-                                                      Read More
-                                                    </button>
+                                                      <span
+                                                        dangerouslySetInnerHTML={
+                                                          Object {
+                                                            "__html": "<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target=\\"_blank\\" href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11...</a></p>",
+                                                          }
+                                                        }
+                                                        widget-type="InsightsTruncateBlock"
+                                                      />
+                                                    </div>
+                                                  </Component>
+                                                  <Component>
+                                                    <div
+                                                      className="pf-l-stack__item"
+                                                    >
+                                                      <Component
+                                                        className="ins-c-expand-button"
+                                                        onClick={[Function]}
+                                                        variant="link"
+                                                      >
+                                                        <button
+                                                          aria-disabled={null}
+                                                          aria-label={null}
+                                                          className="pf-c-button pf-m-link ins-c-expand-button"
+                                                          data-ouia-component-id={null}
+                                                          data-ouia-component-type="PF4/Button"
+                                                          data-ouia-safe={true}
+                                                          disabled={false}
+                                                          onClick={[Function]}
+                                                          tabIndex={null}
+                                                          type="button"
+                                                        >
+                                                          Read More
+                                                        </button>
+                                                      </Component>
+                                                    </div>
                                                   </Component>
                                                 </div>
                                               </Component>
-                                            </div>
-                                          </Component>
-                                        </Truncate>
+                                            </Truncate>
+                                          </div>
+                                        </Component>
                                       </div>
                                     </Component>
                                   </CSAwRuleSummary>
@@ -530,11 +534,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                         className="pf-l-grid__item pf-m-4-col"
                       >
                         <Component
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-stack"
-                            gutter="md"
+                            className="pf-l-stack pf-m-gutter"
                           >
                             <Component>
                               <div
@@ -594,11 +597,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       </h4>
                                     </Component>
                                     <Component
-                                      gutter="md"
+                                      hasGutter={true}
                                     >
                                       <div
-                                        className="pf-l-split"
-                                        gutter="md"
+                                        className="pf-l-split pf-m-gutter"
                                       >
                                         <Component>
                                           <div
@@ -806,11 +808,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       </div>
                                     </Component>
                                     <Component
-                                      gutter="md"
+                                      hasGutter={true}
                                     >
                                       <div
-                                        className="pf-l-split"
-                                        gutter="md"
+                                        className="pf-l-split pf-m-gutter"
                                       >
                                         <Component>
                                           <div

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleSummary.test.js.snap
@@ -47,68 +47,74 @@ exports[`CSAW Rule summary should render compenent 1`] = `
     text="An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned [CVE-2019-11135](https://access.redhat.com/security/cve/CVE-2019-11135). Complete mitigations for this issue require microcode and kernel updates, and disabling hyperthreading where applicable.↵↵An unprivileged user can use this flaw to gain read access to privileged memory that would otherwise be inacessible, including from other virtual machines on the same host system.↵"
     truncate={true}
   >
-    <Component
-      className="rule-description"
-    >
+    <Component>
       <div
-        className="pf-c-content rule-description"
+        className="pf-l-stack__item"
       >
-        <Truncate
-          collapseText="Read less"
-          expandText="Read More"
-          length={230}
-          text="<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target='_blank' href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11135</a>. Complete mitigations for this issue require microcode and kernel updates, and disabling hyperthreading where applicable.↵↵An unprivileged user can use this flaw to gain read access to privileged memory that would otherwise be inacessible, including from other virtual machines on the same host system.↵</p>
-"
+        <Component
+          className="rule-description"
         >
-          <Component
-            className="ins-c-truncate is-block"
+          <div
+            className="pf-c-content rule-description"
           >
-            <div
-              className="pf-l-stack ins-c-truncate is-block"
+            <Truncate
+              collapseText="Read less"
+              expandText="Read More"
+              length={230}
+              text="<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target='_blank' href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11135</a>. Complete mitigations for this issue require microcode and kernel updates, and disabling hyperthreading where applicable.↵↵An unprivileged user can use this flaw to gain read access to privileged memory that would otherwise be inacessible, including from other virtual machines on the same host system.↵</p>
+"
             >
-              <Component>
+              <Component
+                className="ins-c-truncate is-block"
+              >
                 <div
-                  className="pf-l-stack__item"
+                  className="pf-l-stack ins-c-truncate is-block"
                 >
-                  <span
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target=\\"_blank\\" href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11...</a></p>",
-                      }
-                    }
-                    widget-type="InsightsTruncateBlock"
-                  />
-                </div>
-              </Component>
-              <Component>
-                <div
-                  className="pf-l-stack__item"
-                >
-                  <Component
-                    className="ins-c-expand-button"
-                    onClick={[Function]}
-                    variant="link"
-                  >
-                    <button
-                      aria-disabled={null}
-                      aria-label={null}
-                      className="pf-c-button pf-m-link ins-c-expand-button"
-                      data-ouia-component-id={null}
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex={null}
-                      type="button"
+                  <Component>
+                    <div
+                      className="pf-l-stack__item"
                     >
-                      Read More
-                    </button>
+                      <span
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<p>An issue was found in the manner in which certain x86 microprocessors manage thread memory access synchronization. It has been assigned <a target=\\"_blank\\" href=\\"https://access.redhat.com/security/cve/CVE-2019-11135\\">CVE-2019-11...</a></p>",
+                          }
+                        }
+                        widget-type="InsightsTruncateBlock"
+                      />
+                    </div>
+                  </Component>
+                  <Component>
+                    <div
+                      className="pf-l-stack__item"
+                    >
+                      <Component
+                        className="ins-c-expand-button"
+                        onClick={[Function]}
+                        variant="link"
+                      >
+                        <button
+                          aria-disabled={null}
+                          aria-label={null}
+                          className="pf-c-button pf-m-link ins-c-expand-button"
+                          data-ouia-component-id={null}
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe={true}
+                          disabled={false}
+                          onClick={[Function]}
+                          tabIndex={null}
+                          type="button"
+                        >
+                          Read More
+                        </button>
+                      </Component>
+                    </div>
                   </Component>
                 </div>
               </Component>
-            </div>
-          </Component>
-        </Truncate>
+            </Truncate>
+          </div>
+        </Component>
       </div>
     </Component>
   </CSAwRuleSummary>

--- a/src/Components/PresentationalComponents/CVEInfoBox/CVEInfoBox.js
+++ b/src/Components/PresentationalComponents/CVEInfoBox/CVEInfoBox.js
@@ -9,7 +9,7 @@ const CVEInfoBox = (props) => {
     return (
         <CVEPageContext.Consumer>
             {context => (
-                <Split className="infobox-square" gutter="md">
+                <Split className="infobox-square" hasGutter>
                     <WithLoader loading={context.isLoading}>
                         <SplitItem className={props.titleColor}>
                             <Bullseye>{props.titleContent}</Bullseye>

--- a/src/Components/PresentationalComponents/CVEInfoBox/__snapshots__/CVEInfoBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEInfoBox/__snapshots__/CVEInfoBox.test.js.snap
@@ -7,11 +7,10 @@ exports[`CveInfoBox Should redner with both title and description 1`] = `
 >
   <Component
     className="infobox-square"
-    gutter="md"
+    hasGutter={true}
   >
     <div
-      className="pf-l-split infobox-square"
-      gutter="md"
+      className="pf-l-split pf-m-gutter infobox-square"
     >
       <WithLoader
         loading={true}
@@ -38,11 +37,10 @@ exports[`CveInfoBox Should render with description only 1`] = `
 >
   <Component
     className="infobox-square"
-    gutter="md"
+    hasGutter={true}
   >
     <div
-      className="pf-l-split infobox-square"
-      gutter="md"
+      className="pf-l-split pf-m-gutter infobox-square"
     >
       <WithLoader
         loading={true}
@@ -69,11 +67,10 @@ exports[`CveInfoBox Should render with title only 1`] = `
 >
   <Component
     className="infobox-square"
-    gutter="md"
+    hasGutter={true}
   >
     <div
-      className="pf-l-split infobox-square"
-      gutter="md"
+      className="pf-l-split pf-m-gutter infobox-square"
     >
       <WithLoader
         loading={true}
@@ -98,11 +95,10 @@ exports[`CveInfoBox Should render without params 1`] = `
 <CVEInfoBox>
   <Component
     className="infobox-square"
-    gutter="md"
+    hasGutter={true}
   >
     <div
-      className="pf-l-split infobox-square"
-      gutter="md"
+      className="pf-l-split pf-m-gutter infobox-square"
     >
       <WithLoader
         loading={true}

--- a/src/Components/PresentationalComponents/CVEPageDetails/CVEPageDetails.js
+++ b/src/Components/PresentationalComponents/CVEPageDetails/CVEPageDetails.js
@@ -11,7 +11,7 @@ const CVEPageDetails = props => {
     return (
         <CVEPageContext.Consumer>
             {context => (
-                <Grid gutter="sm">
+                <Grid hasGutter>
                     <GridItem md={8} sm={12}>
                         <WithLoader loading={context.isLoading} variant="spinner">
                             <CVEPageDetailsDescription cveAttributes={props.data.data} />

--- a/src/Components/PresentationalComponents/CVEPageDetails/__snapshots__/CVEPageDetails.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEPageDetails/__snapshots__/CVEPageDetails.test.js.snap
@@ -73,11 +73,10 @@ exports[`CVEPageDetails component should render with data 1`] = `
   }
 >
   <Component
-    gutter="sm"
+    hasGutter={true}
   >
     <div
-      className="pf-l-grid"
-      gutter="sm"
+      className="pf-l-grid pf-m-gutter"
     >
       <Component
         md={8}
@@ -158,11 +157,10 @@ exports[`CVEPageDetails component should render with data 1`] = `
               }
             >
               <Component
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-stack"
-                  gutter="md"
+                  className="pf-l-stack pf-m-gutter"
                 >
                   <Component>
                     <div
@@ -248,11 +246,10 @@ exports[`CVEPageDetails component should render with data 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -325,11 +322,10 @@ exports[`CVEPageDetails component should render with data 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -498,11 +494,10 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
   }
 >
   <Component
-    gutter="sm"
+    hasGutter={true}
   >
     <div
-      className="pf-l-grid"
-      gutter="sm"
+      className="pf-l-grid pf-m-gutter"
     >
       <Component
         md={8}
@@ -583,11 +578,10 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
               }
             >
               <Component
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-stack"
-                  gutter="md"
+                  className="pf-l-stack pf-m-gutter"
                 >
                   <Component>
                     <div
@@ -673,11 +667,10 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -750,11 +743,10 @@ exports[`CVEPageDetails component should render with enabled WithLoader 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -930,11 +922,10 @@ exports[`CVEPageDetails component should render with long description 1`] = `
   }
 >
   <Component
-    gutter="sm"
+    hasGutter={true}
   >
     <div
-      className="pf-l-grid"
-      gutter="sm"
+      className="pf-l-grid pf-m-gutter"
     >
       <Component
         md={8}
@@ -1019,11 +1010,10 @@ exports[`CVEPageDetails component should render with long description 1`] = `
               }
             >
               <Component
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-stack"
-                  gutter="md"
+                  className="pf-l-stack pf-m-gutter"
                 >
                   <Component>
                     <div
@@ -1113,11 +1103,10 @@ exports[`CVEPageDetails component should render with long description 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -1156,11 +1145,10 @@ exports[`CVEPageDetails component should render with long description 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -1332,11 +1320,10 @@ exports[`CVEPageDetails component should render without data 1`] = `
   }
 >
   <Component
-    gutter="sm"
+    hasGutter={true}
   >
     <div
-      className="pf-l-grid"
-      gutter="sm"
+      className="pf-l-grid pf-m-gutter"
     >
       <Component
         md={8}
@@ -1417,11 +1404,10 @@ exports[`CVEPageDetails component should render without data 1`] = `
               }
             >
               <Component
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-stack"
-                  gutter="md"
+                  className="pf-l-stack pf-m-gutter"
                 >
                   <Component>
                     <div
@@ -1507,11 +1493,10 @@ exports[`CVEPageDetails component should render without data 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}
@@ -1584,11 +1569,10 @@ exports[`CVEPageDetails component should render without data 1`] = `
                       >
                         <Component
                           className="infobox-square"
-                          gutter="md"
+                          hasGutter={true}
                         >
                           <div
-                            className="pf-l-split infobox-square"
-                            gutter="md"
+                            className="pf-l-split pf-m-gutter infobox-square"
                           >
                             <WithLoader
                               loading={true}

--- a/src/Components/PresentationalComponents/CVEPageDetailsDescription/CVEPageDetailsDescription.js
+++ b/src/Components/PresentationalComponents/CVEPageDetailsDescription/CVEPageDetailsDescription.js
@@ -1,4 +1,4 @@
-import { Stack, StackItem, Text, TextContent, TextVariants, Flex, FlexItem } from '@patternfly/react-core';
+import { Stack, StackItem, Text, TextContent, TextVariants, Split, SplitItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { PatternFlyThemeProvider, StyledBox, StyledText, StyledConstants } from '@patternfly/react-styled-system';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
@@ -94,18 +94,18 @@ const CVEPageDetailsDescription = ({ cveAttributes, intl }) => {
     );
     return (
         <PatternFlyThemeProvider>
-            <Stack gutter="sm">
+            <Stack hasGutter>
                 <StackItem />
                 <StackItem>
-                    <Flex>
-                        <FlexItem breakpointMods={[{ modifier: 'spacer-xl' }]}>
+                    <Split hasGutter>
+                        <SplitItem>
                             <SnippetWithHeaderAndPopover
                                 title={intl.formatMessage(messages.businessRiskLabel)}
                                 value={businessRisk}
                                 content={brPopoverContent}
                             />
-                        </FlexItem>
-                        <FlexItem breakpointMods={[{ modifier: 'spacer-xl' }]}>
+                        </SplitItem>
+                        <SplitItem>
                             <SnippetWithHeaderAndPopover
                                 title={intl.formatMessage(messages.statusLabel)}
                                 content={statusPopoverContent}
@@ -118,8 +118,8 @@ const CVEPageDetailsDescription = ({ cveAttributes, intl }) => {
                                     </span>
                                 }
                             />
-                        </FlexItem>
-                    </Flex>
+                        </SplitItem>
+                    </Split>
                 </StackItem>
                 <StackItem>
                     <TextContent>

--- a/src/Components/PresentationalComponents/CVEPageDetailsDescription/__snapshots__/CVEPageDetailsDescription.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEPageDetailsDescription/__snapshots__/CVEPageDetailsDescription.test.js.snap
@@ -330,11 +330,10 @@ exports[`CVEPageDetailsDescription component should render without props 1`] = `
         }
       >
         <Component
-          gutter="sm"
+          hasGutter={true}
         >
           <div
-            className="pf-l-stack"
-            gutter="sm"
+            className="pf-l-stack pf-m-gutter"
           >
             <Component>
               <div
@@ -345,28 +344,15 @@ exports[`CVEPageDetailsDescription component should render without props 1`] = `
               <div
                 className="pf-l-stack__item"
               >
-                <Component>
+                <Component
+                  hasGutter={true}
+                >
                   <div
-                    className="pf-l-flex"
+                    className="pf-l-split pf-m-gutter"
                   >
-                    <Component
-                      breakpointMods={
-                        Array [
-                          Object {
-                            "modifier": "spacer-xl",
-                          },
-                        ]
-                      }
-                    >
+                    <Component>
                       <div
-                        breakpointMods={
-                          Array [
-                            Object {
-                              "modifier": "spacer-xl",
-                            },
-                          ]
-                        }
-                        className=""
+                        className="pf-l-split__item"
                       >
                         <SnippetWithHeaderAndPopover
                           content={
@@ -648,24 +634,9 @@ exports[`CVEPageDetailsDescription component should render without props 1`] = `
                         </SnippetWithHeaderAndPopover>
                       </div>
                     </Component>
-                    <Component
-                      breakpointMods={
-                        Array [
-                          Object {
-                            "modifier": "spacer-xl",
-                          },
-                        ]
-                      }
-                    >
+                    <Component>
                       <div
-                        breakpointMods={
-                          Array [
-                            Object {
-                              "modifier": "spacer-xl",
-                            },
-                          ]
-                        }
-                        className=""
+                        className="pf-l-split__item"
                       >
                         <SnippetWithHeaderAndPopover
                           content={

--- a/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
+++ b/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
@@ -35,32 +35,30 @@ const CVEPageDetailsSeverity = props => {
     const cveDetails = getImpactDetails(props.impact);
     const cvssVersion = (props.cvss3_score && 'CVSS 3.0') || (props.cvss2_score && 'CVSS 2.0') || 'CVSS 3.0';
     return (
-        <React.Fragment>
-            <Stack gutter="md">
-                <StackItem>
-                    <CVEInfoBox
-                        titleColor={cveDetails.color}
-                        titleContent={cveDetails.titleContent}
-                        descriptionTitle={cveDetails.title + props.intl.formatMessage(messages.cvePageSeverityDetailsImpact)}
-                        descriptionContent={learnMorePopover(cveDetails, props.intl)}
-                    />
-                </StackItem>
-                <StackItem>
-                    <CVEInfoBox
-                        titleContent={
-                            <TextContent>
-                                <Text component={TextVariants.h3}>{parseCvssScore(props.cvss2_score, props.cvss3_score)}</Text>
-                            </TextContent>
-                        }
-                        descriptionTitle={cvssVersion + props.intl.formatMessage(messages.cvePageSeverityDetailsBaseScore)}
-                    />
-                </StackItem>
+        <Stack hasGutter>
+            <StackItem>
+                <CVEInfoBox
+                    titleColor={cveDetails.color}
+                    titleContent={cveDetails.titleContent}
+                    descriptionTitle={cveDetails.title + props.intl.formatMessage(messages.cvePageSeverityDetailsImpact)}
+                    descriptionContent={learnMorePopover(cveDetails, props.intl)}
+                />
+            </StackItem>
+            <StackItem>
+                <CVEInfoBox
+                    titleContent={
+                        <TextContent>
+                            <Text component={TextVariants.h3}>{parseCvssScore(props.cvss2_score, props.cvss3_score)}</Text>
+                        </TextContent>
+                    }
+                    descriptionTitle={cvssVersion + props.intl.formatMessage(messages.cvePageSeverityDetailsBaseScore)}
+                />
+            </StackItem>
 
-                <StackItem>
-                    <CvssVector cvss2_metrics={props.cvss2_metrics} cvss3_metrics={props.cvss3_metrics} />
-                </StackItem>
-            </Stack>
-        </React.Fragment>
+            <StackItem>
+                <CvssVector cvss2_metrics={props.cvss2_metrics} cvss3_metrics={props.cvss3_metrics} />
+            </StackItem>
+        </Stack>
     );
 };
 

--- a/src/Components/PresentationalComponents/CVEPageDetailsSeverity/__snapshots__/CVEPageDetailsSeverity.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEPageDetailsSeverity/__snapshots__/CVEPageDetailsSeverity.test.js.snap
@@ -46,11 +46,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is Cr
     }
   >
     <Component
-      gutter="md"
+      hasGutter={true}
     >
       <div
-        className="pf-l-stack"
-        gutter="md"
+        className="pf-l-stack pf-m-gutter"
       >
         <Component>
           <div
@@ -139,11 +138,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is Cr
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}
@@ -216,11 +214,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is Cr
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}
@@ -374,11 +371,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is un
     }
   >
     <Component
-      gutter="md"
+      hasGutter={true}
     >
       <div
-        className="pf-l-stack"
-        gutter="md"
+        className="pf-l-stack pf-m-gutter"
       >
         <Component>
           <div
@@ -464,11 +460,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is un
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}
@@ -541,11 +536,10 @@ exports[`CVEPageDetailsSeverity component should render where impact value is un
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}
@@ -699,11 +693,10 @@ exports[`CVEPageDetailsSeverity component should render without props 1`] = `
     }
   >
     <Component
-      gutter="md"
+      hasGutter={true}
     >
       <div
-        className="pf-l-stack"
-        gutter="md"
+        className="pf-l-stack pf-m-gutter"
       >
         <Component>
           <div
@@ -789,11 +782,10 @@ exports[`CVEPageDetailsSeverity component should render without props 1`] = `
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}
@@ -866,11 +858,10 @@ exports[`CVEPageDetailsSeverity component should render without props 1`] = `
             >
               <Component
                 className="infobox-square"
-                gutter="md"
+                hasGutter={true}
               >
                 <div
-                  className="pf-l-split infobox-square"
-                  gutter="md"
+                  className="pf-l-split pf-m-gutter infobox-square"
                 >
                   <WithLoader
                     loading={true}

--- a/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
+++ b/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Text, TextContent, TextVariants, Tooltip } from '@patternfly/react-core';
+import { Text, TextContent, TextVariants, Tooltip, Stack } from '@patternfly/react-core';
 import Label from '../Snippets/Label';
 import { CSAwIcon } from '../CSAwIcon/CSAwIcon';
 import CSAwRuleSummary from '../CSAwRuleBox/CSAwRuleSummary';
@@ -14,26 +14,27 @@ const CVETableExpandedCell = ({ description, rules, cve }) => {
         <TextContent className="expanded-cell">
             <Label>{<FormattedMessage {...messages.description} />}</Label>
             <Text component={TextVariants.p}>{description}</Text>
-
-            {rules && rules.map((rule, i) => (
-                rule && (
-                    <div key={i} className="rule">
-                        <Text component={TextVariants.p}>
-                            <Label className={'icon-with-label'}>
-                                <Tooltip content={ruleIconTooltip}>
-                                    <CSAwIcon />
-                                </Tooltip>
-                                <span className="rule-name">{rule.description || rule.rule_id}</span>
-                            </Label>
-                        </Text>
-                        <CSAwRuleSummary
-                            text={rule.summary}
-                            link={cve}
-                            truncate={false}
-                        />
-                    </div>
-                )
-            ))}
+            <Stack hasGutter>
+                {rules && rules.map((rule, i) => (
+                    rule && (
+                        <div key={i} className="rule">
+                            <Text component={TextVariants.p}>
+                                <Label className={'icon-with-label'}>
+                                    <Tooltip content={ruleIconTooltip}>
+                                        <CSAwIcon />
+                                    </Tooltip>
+                                    <span className="rule-name">{rule.description || rule.rule_id}</span>
+                                </Label>
+                            </Text>
+                            <CSAwRuleSummary
+                                text={rule.summary}
+                                link={cve}
+                                truncate={false}
+                            />
+                        </div>
+                    )
+                ))}
+            </Stack>
         </TextContent>
     );
 

--- a/src/Components/SmartComponents/Modals/BusinessRiskModal.js
+++ b/src/Components/SmartComponents/Modals/BusinessRiskModal.js
@@ -56,7 +56,7 @@ export const BusinessRiskModal = ({ cves, updateRef, intl }) => {
             onSuccessNotification={successNotification}
             title={intl.formatMessage(messages.businessRiskModalTitle)}
         >
-            <Stack gutter={'md'}>
+            <Stack hasGutter>
                 <StackItem>
                     {intl.formatMessage(messages.businessRiskModalInfo)}
                 </StackItem>

--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -147,7 +147,7 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
 
     return (
         <BaseModal items={cveList} onSave={handleSave} onSuccessNotification={successNotification} title={modalTitle}>
-            <Stack gutter={'md'}>
+            <Stack hasGutter>
                 {hasDifferentStatus &&
                     <StackItem>
                         <Alert

--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -40,7 +40,7 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
 
     return (
         <BaseModal items={cveList} onSave={handleSave} onSuccessNotification={successNotification} title={title}>
-            <Stack gutter={'md'}>
+            <Stack hasGutter>
                 <StackItem>
                     {intl.formatMessage(
                         messages.cveStatusModalSelected,

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -22,7 +22,7 @@ import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
 import { middlewareListener } from '../../../Utilities/ReducerRegistry';
 import selectAllCheckbox from '../../../Helpers/selectAllCheckboxHelper';
-import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { Text, TextContent, TextVariants, Stack, StackItem } from '@patternfly/react-core';
 import { systemExposedTableRowActions, createExposedSystemsTable } from '../../../Helpers/CVEHelper';
 import { inventoryEntitiesReducer } from '../../../Store/Reducers/InventoryEntitiesReducer';
 import DownloadReport from '../../../Helpers/DownloadReport';
@@ -196,58 +196,64 @@ const SystemsExposedTable = (props) => {
 
     return (
         <React.Fragment>
-            <TextContent>
-                <Text component={TextVariants.h2}>
-                    {props.intl.formatMessage(messages.systemsExposedTableHeader)}
-                </Text>
-            </TextContent>
-            <InventoryTable
-                items={items.data}
-                key={'inventory'}
-                ref={inventory}
-                expandable='true'
-                onRefresh={inventoryRefresh}
-                page={parameters.page}
-                total={metadata.total_items}
-                isLoaded = {!isLoading}
-                perPage={parameters.page_size }
-                hasCheckbox={items && items.length !== 0}
-                showActions={items && items.length !== 0}
-                exportConfig={{
-                    isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
-                    ...exportConfig({ downloadReport })
-                }}
-                onExpandClick={(_e, _i, isOpen, { id }) => dispatch(expandRow(id, isOpen))}
-                actions={systemExposedTableRowActions(showStatusModal, props.cveStatusDetails, selectedHosts)}
-                actionsConfig={{
-                    actions: kebabOptions,
-                    kebabToggleProps: { isDisabled: !selectedHosts || selectedHosts.length === 0 }
-                }}
-                activeFiltersConfig={{
-                    filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
-                    onDelete: (e, i) => removeFilters(i, apply)
-                }}
-                bulkSelect ={ selectOptions && {
-                    count: selectedHosts && selectedHosts.length,
-                    items: selectOptions.items,
-                    isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
-                    checked: Boolean(selectedHosts && selectedHosts.length),
-                    onSelect: () => selectOptions.handleOnCheckboxChange()
-                }}
-                filterConfig={{
-                    items: [
-                        searchFilter(
-                            messages.systemsSearchName, messages.searchFilterByName,
-                            parameters.filter, apply
-                        ),
-                        securityRuleFilter(apply, parameters, props.filterRuleValues),
-                        statusFilter(apply, parameters)
-                    ]
-                }}
+            <Stack hasGutter>
+                <StackItem>
+                    <TextContent>
+                        <Text component={TextVariants.h2}>
+                            {props.intl.formatMessage(messages.systemsExposedTableHeader)}
+                        </Text>
+                    </TextContent>
+                </StackItem>
+                <StackItem>
+                    <InventoryTable
+                        items={items.data}
+                        key={'inventory'}
+                        ref={inventory}
+                        expandable='true'
+                        onRefresh={inventoryRefresh}
+                        page={parameters.page}
+                        total={metadata.total_items}
+                        isLoaded = {!isLoading}
+                        perPage={parameters.page_size }
+                        hasCheckbox={items && items.length !== 0}
+                        showActions={items && items.length !== 0}
+                        exportConfig={{
+                            isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
+                            ...exportConfig({ downloadReport })
+                        }}
+                        onExpandClick={(_e, _i, isOpen, { id }) => dispatch(expandRow(id, isOpen))}
+                        actions={systemExposedTableRowActions(showStatusModal, props.cveStatusDetails, selectedHosts)}
+                        actionsConfig={{
+                            actions: kebabOptions,
+                            kebabToggleProps: { isDisabled: !selectedHosts || selectedHosts.length === 0 }
+                        }}
+                        activeFiltersConfig={{
+                            filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
+                            onDelete: (e, i) => removeFilters(i, apply)
+                        }}
+                        bulkSelect ={ selectOptions && {
+                            count: selectedHosts && selectedHosts.length,
+                            items: selectOptions.items,
+                            isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
+                            checked: Boolean(selectedHosts && selectedHosts.length),
+                            onSelect: () => selectOptions.handleOnCheckboxChange()
+                        }}
+                        filterConfig={{
+                            items: [
+                                searchFilter(
+                                    messages.systemsSearchName, messages.searchFilterByName,
+                                    parameters.filter, apply
+                                ),
+                                securityRuleFilter(apply, parameters, props.filterRuleValues),
+                                statusFilter(apply, parameters)
+                            ]
+                        }}
 
-            >
-                {StatusModal && <StatusModal />}
-            </InventoryTable>
+                    >
+                        {StatusModal && <StatusModal />}
+                    </InventoryTable>
+                </StackItem>
+            </Stack>
         </React.Fragment>
     );
 };


### PR DESCRIPTION
Part of [VULN-1066](https://projects.engineering.redhat.com/browse/VULN-1066).

### Fixes:
- CVEPageDetailsDescription item spacing
- CVEPageDetailsSeverity item spacing
- impact and base score box spacing
- table title bottom padding

### Mockup:
https://marvelapp.com/75dcb1j/screen/58397731

### Before:
![detail_before](https://user-images.githubusercontent.com/8426204/85381218-0e419400-b53e-11ea-849b-652263a08556.png)
### After:
![detail_after](https://user-images.githubusercontent.com/8426204/85381227-100b5780-b53e-11ea-94be-f44a0bb3bd4f.png)