### PR TITLE
chore(semantic-release): Add workflow publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,10 @@
     "translations:compile": "npm run build; node node_modules/@redhat-cloud-services/frontend-components-utilities/files/esm/mergeMessages.js"
   },
   "release": {
+    "branches": [
+        {"name": "ci-stable"},
+        {"name": "master", "channel": "beta", "prerelease": "beta"}
+    ],
     "analyzeCommits": {
       "preset": "angular",
       "releaseRules": [


### PR DESCRIPTION
The intetion is to publish the npm package when the code is stable `ci-stable` and publish a bete version on master