### PR TITLE
fix(detail): wrap detail in router and use location and history from browser

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -77,7 +77,8 @@ const plugins = [
 export default [
     ...['esm', 'cjs'].map(env => ({
         input: {
-            index: 'src/index.js'
+            index: 'src/index.js',
+            SystemCvesStore: 'src/Store/Reducers/SystemCvesStore'
         },
         output: {
             dir: `./dist/${env}`,
@@ -90,7 +91,8 @@ export default [
         plugins
     })),
     ...Object.entries({
-        index: 'src/index.js'
+        index: 'src/index.js',
+        SystemCvesStore: 'src/Store/Reducers/SystemCvesStore'
     }).map(([key, input]) => ({
         input,
         output: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2813,9 +2813,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "2.1.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.1.0-beta.6.tgz",
-      "integrity": "sha512-P/mN151h+PPVkFN0LCuiPo8ZcadcfpmKn0Pm9Zcu+0JdEEIvtboPo03/9ClnaY3PJjSMRLW29CnwPpoizK6x2Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-2.1.2.tgz",
+      "integrity": "sha512-F4PnNSGuk6Sdfs7ivxY/b73RkQwWM50IGUHIFDMVQM2IrCkFi24Nt6mBBTk2ZlGV4pvZ0Wr3lVOgPz6b00I4Jg==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-styled-system": "^3.8.10",
     "@patternfly/react-table": "^4.5.7",
     "@react-pdf/renderer": "^1.6.8",
-    "@redhat-cloud-services/frontend-components": "^2.1.0-beta.6",
+    "@redhat-cloud-services/frontend-components": "^2.1.2",
     "@redhat-cloud-services/frontend-components-inventory-insights": "^2.0.6",
     "@redhat-cloud-services/frontend-components-notifications": "^2.1.0",
     "@redhat-cloud-services/frontend-components-pdf-generator": "^2.0.3",

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -23,6 +23,7 @@ import DownloadReport from '../../../Helpers/DownloadReport';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import SystemCveTableToolbar from './SystemCveTableToolbar';
 import { useCreateUrlParams, updateRef } from '../../../Helpers/MiscHelper';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 export const CVETableContext = createContext({});
 
@@ -180,31 +181,29 @@ export const ConnectedSystemCves = withRouter(
     injectIntl(SystemCVEs)
 );
 
-const TranslateSystemCves = ({ customItnlProvider, ...props }) => {
-    const {
-        Wrapper,
-        intlProps
-    } = customItnlProvider ? {
-        Wrapper: IntlProvider,
-        intProps: {
-            locale: navigator.language.slice(0, 2),
-            messages
-        }
-    } : {
-        wrapper: Fragment,
-        intlProps: {}
-    };
-    return <Wrapper {...intlProps} >
-        <ConnectedSystemCves { ...props } />
+const TranslateSystemCves = ({ customItnlProvider, customRouter, ...props }) => {
+    const RouterWrapper = customRouter ? Router : Fragment;
+    const Wrapper = customItnlProvider ? IntlProvider : Fragment;
+    return <Wrapper {...customItnlProvider && {
+        locale: navigator.language.slice(0, 2),
+        messages
+    } } >
+        <RouterWrapper
+            {...customRouter && { basename: `${window.location.pathname}` } }
+        >
+            <ConnectedSystemCves { ...props } />
+        </RouterWrapper>
     </Wrapper>;
 };
 
 TranslateSystemCves.propTypes = {
-    customItnlProvider: propTypes.bool
+    customItnlProvider: propTypes.bool,
+    customRouter: propTypes.bool
 };
 
 TranslateSystemCves.defaultProps = {
-    customItnlProvider: false
+    customItnlProvider: false,
+    customRouter: false
 };
 
 export default TranslateSystemCves;

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -1,6 +1,5 @@
 import { SecurityIcon, UnknownIcon } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table';
-import { useHistory, useLocation  } from 'react-router-dom';
 import findIndex from 'lodash/findIndex';
 import propTypes from 'prop-types';
 import React from 'react';
@@ -167,12 +166,18 @@ export const updateStateSet = (stateSet, names, value) => {
 };
 
 export const useCreateUrlParams = (allowedParams) => {
-    const location = useLocation();
-    const history = useHistory();
-    const urlParams = qs.parse(location.search);
+    const urlParams = qs.parse(window.location.search);
 
     const createUrlParams = (parameters) => {
-        history.push(`?${qs.stringify(constructURLParameters(parameters, allowedParams))}`);
+        window.history.pushState(
+            {},
+            '',
+            `${
+                window.location.pathname
+            }?${
+                qs.stringify(constructURLParameters(parameters, allowedParams))
+            }`
+        );
     };
 
     return [createUrlParams, urlParams];

--- a/src/Helpers/MiscHelper.test.js
+++ b/src/Helpers/MiscHelper.test.js
@@ -28,15 +28,18 @@ const mockLocation = {
 }
 
 const mockHistory = {
-    push: jest.fn()
+    pushState: jest.fn()
 }
 
 beforeEach(() => {
-    jest.spyOn(routeData, 'useLocation').mockReturnValue(mockLocation)
-});
-
-beforeEach(() => {
-    jest.spyOn(routeData, 'useHistory').mockReturnValue(mockHistory)
+    Object.defineProperty(window, 'location', {
+        writable: true,
+        value: mockLocation
+    });
+    Object.defineProperty(window, 'history', {
+        writable: true,
+        value: mockHistory
+    });
 });
 
 describe('MiscHelper', () => {
@@ -190,7 +193,7 @@ describe('MiscHelper', () => {
             page: '1',
             sort: '-public_date'
         });
-        expect(mockHistory.push).toHaveBeenCalled();
+        expect(mockHistory.pushState).toHaveBeenCalled();
     });
 
     it('Should updateRef update with the same page', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { SystemCVEs } from './Components/SmartComponents/SystemCves/SystemCves';
+import SystemCVEs from './Components/SmartComponents/SystemCves/SystemCves';
 
 const WrappedSystemCves = (props) => {
     return <Router>


### PR DESCRIPTION
This PR re-introduces wrapped SystemCves to properly show translated Cves table, it also wraps the component in Router if parent component requires it.

I had some proplems with using the component and turns out the react-router-dom was not playing nicely with `useLocation` and `useHistory` used browser's one instead.

This PR also changes rollup slightly to allow direct import of `SystemCvesStore` so we don't have to import entire component just for the store.