### PR TITLE
feat(inventory): pass react-redux to inventory

### DIFF
--- a/src/Components/SmartComponents/InventoryDetail/InventoryDetail.js
+++ b/src/Components/SmartComponents/InventoryDetail/InventoryDetail.js
@@ -15,6 +15,7 @@ import {
 import propTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import * as ReactRedux from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
 import { fetchSystemDetails, optOutSystemAction } from '../../../Store/Actions/Actions';
@@ -51,6 +52,7 @@ class InventoryDetail extends React.Component {
 
     async fetchInventory() {
         const { inventoryConnector, mergeWithEntities, mergeWithDetail, INVENTORY_ACTION_TYPES } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable: {

--- a/src/Components/SmartComponents/Systems/Systems.js
+++ b/src/Components/SmartComponents/Systems/Systems.js
@@ -3,6 +3,7 @@ import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import * as reactRouterDom from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import * as ReactRedux from 'react-redux';
 import {
     Table as PfTable,
     TableBody,
@@ -73,6 +74,7 @@ const Systems = ({ intl }) => {
             mergeWithEntities,
             mergeWithDetail
         } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable: {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -3,6 +3,7 @@ import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { withRouter } from 'react-router-dom';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import { useCreateUrlParams, updateRef } from '../../../Helpers/MiscHelper';
 import {
     Table as PfTable,
@@ -121,6 +122,7 @@ const SystemsExposedTable = (props) => {
 
     const loadInventory = async () => {
         const { inventoryConnector, mergeWithEntities, mergeWithDetail } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable: {


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.