### PR TITLE
fix(csaw rulebox): Fix spacing and tooltips

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -44,7 +44,10 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                         <GridItem span={12}>
                             <TextContent className={'icon-with-label'}>
                                 <Text component={TextVariants.h3}>
-                                    <Tooltip content={intl.formatMessage(messages.rulesIconTooltip)}>
+                                    <Tooltip
+                                        content={intl.formatMessage(messages.rulesIconTooltip)}
+                                        trigger='mouseenter focus click'
+                                    >
                                         <CSAwIcon />
                                     </Tooltip>
                                     {rule.description}
@@ -130,8 +133,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                 <StackItem>
                                     <TextContent>
                                         <Text component={TextVariants.h4}>
-                                            {intl.formatMessage(messages.remediatioLabel)}
-
+                                            {intl.formatMessage(messages.remediationLabel)}
                                         </Text>
                                         <Split hasGutter>
                                             <SplitItem>
@@ -141,14 +143,15 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                                 </Label>
                                             </SplitItem>
                                             <SplitItem className="icon-with-label" isFilled>
-                                                { !rule.playbook_count ? intl.formatMessage(messages.no)
-
+                                                { !rule.playbook_count
+                                                    ? intl.formatMessage(messages.no)
                                                     : (
                                                         <Fragment>
                                                             <CheckCircleIcon className="ansible-success" />
                                                             {intl.formatMessage(messages.yes)}
                                                             <Tooltip
                                                                 content={intl.formatMessage(messages.ansibleRemediationTooltip)}
+                                                                trigger='mouseenter focus click'
                                                             >
                                                                 <OutlinedQuestionCircleIcon
                                                                     color={'var(--pf-global--secondary-color--100)'}
@@ -157,11 +160,10 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                                             </Tooltip>
                                                         </Fragment>
                                                     )
-
                                                 }
                                             </SplitItem>
                                         </Split>
-                                        <Split hasGutter>
+                                        <Split hasGutter className="pf-u-mt-md">
                                             <SplitItem>
                                                 <Label className="label">
                                                     {intl.formatMessage(messages.riskOfChange)}
@@ -170,17 +172,19 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters,  intl })
                                             <SplitItem isFilled className="icon-with-label">
                                                 { RISK_OF_CHANGE_LABEL[rule.change_risk] }
 
-                                                <Tooltip content={RISK_OF_CHANGE_TOOLTIP[rule.change_risk]}>
+                                                <Tooltip
+                                                    content={RISK_OF_CHANGE_TOOLTIP[rule.change_risk]}
+                                                    trigger='mouseenter focus click'
+                                                >
                                                     <OutlinedQuestionCircleIcon
                                                         color={'var(--pf-global--secondary-color--100)'}
                                                         className="l-sm-spacer"
                                                     />
                                                 </Tooltip>
 
-                                                <br/>
-                                                {
-                                                    rule.reboot_required && <strong><Reboot red /></strong>
-                                                }
+                                                <div className="pf-u-mt-sm">
+                                                    { rule.reboot_required && <strong><Reboot red /></strong> }
+                                                </div>
                                             </SplitItem>
                                         </Split>
                                     </TextContent>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -178,7 +178,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                   maxWidth="18.75rem"
                                   position="top"
                                   tippyProps={Object {}}
-                                  trigger="mouseenter focus"
+                                  trigger="mouseenter focus click"
                                   zIndex={9999}
                                 >
                                   <PopoverBase
@@ -236,7 +236,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       }
                                     }
                                     theme="pf-tooltip"
-                                    trigger="mouseenter focus"
+                                    trigger="mouseenter focus click"
                                     zIndex={9999}
                                   >
                                     <CSAwIcon>
@@ -680,7 +680,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                               maxWidth="18.75rem"
                                               position="top"
                                               tippyProps={Object {}}
-                                              trigger="mouseenter focus"
+                                              trigger="mouseenter focus click"
                                               zIndex={9999}
                                             >
                                               <PopoverBase
@@ -738,7 +738,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   }
                                                 }
                                                 theme="pf-tooltip"
-                                                trigger="mouseenter focus"
+                                                trigger="mouseenter focus click"
                                                 zIndex={9999}
                                               >
                                                 <OutlinedQuestionCircleIcon
@@ -808,10 +808,11 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       </div>
                                     </Component>
                                     <Component
+                                      className="pf-u-mt-md"
                                       hasGutter={true}
                                     >
                                       <div
-                                        className="pf-l-split pf-m-gutter"
+                                        className="pf-l-split pf-m-gutter pf-u-mt-md"
                                       >
                                         <Component>
                                           <div
@@ -889,7 +890,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                               maxWidth="18.75rem"
                                               position="top"
                                               tippyProps={Object {}}
-                                              trigger="mouseenter focus"
+                                              trigger="mouseenter focus click"
                                               zIndex={9999}
                                             >
                                               <PopoverBase
@@ -947,7 +948,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   }
                                                 }
                                                 theme="pf-tooltip"
-                                                trigger="mouseenter focus"
+                                                trigger="mouseenter focus click"
                                                 zIndex={9999}
                                               >
                                                 <OutlinedQuestionCircleIcon
@@ -1012,7 +1013,9 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                 </Portal>
                                               </PopoverBase>
                                             </Tooltip>
-                                            <br />
+                                            <div
+                                              className="pf-u-mt-sm"
+                                            />
                                           </div>
                                         </Component>
                                       </div>

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -102,7 +102,7 @@ export default defineMessages({
         description: 'Remediate label for general usage ',
         defaultMessage: 'Remediate'
     },
-    remediatioLabel: {
+    remediationLabel: {
         id: 'remediation',
         description: 'Remediation label for general usage ',
         defaultMessage: 'Remediation'


### PR DESCRIPTION
## Part of [VULN-1116](https://projects.engineering.redhat.com/browse/VULN-1116).

- Outlined question circle icon's tooltip should toggle on both click and hover
- Space between "ansible remediation" and "risk of change" should be 16px between

## Before:
![csaw-before](https://user-images.githubusercontent.com/8426204/87175545-1852e900-c2d9-11ea-9dc3-ec0084939d16.png)
## After:
![csaw-after](https://user-images.githubusercontent.com/8426204/87175554-1ab54300-c2d9-11ea-88a4-ac93209e26fb.png)
## Mockup:
![csaw-mock](https://user-images.githubusercontent.com/8426204/87175562-1d179d00-c2d9-11ea-8de7-d765e9dfde6f.png)