### PR TITLE
fix: include N/A CVSS CVEs in executive report

### DIFF
--- a/src/Components/SmartComponents/Reports/BuildExecReport.js
+++ b/src/Components/SmartComponents/Reports/BuildExecReport.js
@@ -33,6 +33,9 @@ const BuildExecReport = ({ data,  intl }) => {
             let { [field]: fieldData } = data;
 
             let value = fieldData.count ? fieldData.count : fieldData;
+            if (field === 'na' && value.count === 0) {
+                continue;  // if there's no CVE with N/A CVSS do not display N/A in graph/table
+            }
 
             if (percentageInfo && fieldData.percentage) {
                 value = intl.formatMessage(messages.executiveReportOfTotal, { count: value, percentage: fieldData.percentage });

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -239,7 +239,8 @@ export const recentCvesHeader =  [
 export const CVSSMapping = {
     '8to10': '8.0 - 10.0',
     '4to7.9': '4.0 - 7.9',
-    '0to3.9': '0.0 - 3.9'
+    '0to3.9': '0.0 - 3.9',
+    na: 'N/A'
 };
 
 export const recentCvesMapping = {


### PR DESCRIPTION
Executive report breakdown by CVSS with zero CVEs with N/A CVSS
![zero_na](https://user-images.githubusercontent.com/6339153/87294545-381a2500-c504-11ea-90bc-d683f0b66765.png)

Executive report breakdown by CVSS with at least one CVE with N/A CVSS
![zeroo_na](https://user-images.githubusercontent.com/6339153/87294670-5bdd6b00-c504-11ea-89b1-23cf654d6036.png)
