### PR TITLE
feat(paper-cut):  remove Edit Status

### DIFF
--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -53,7 +53,7 @@ const SystemCvesTableWithContext = ({ context, header, entity }) => {
         methods.selectCves(isSelected, cveName);
     };
 
-    const { cves, methods, selectedCves, openedCves } = context;
+    const { cves, methods, selectedCves, openedCves, canEditStatus } = context;
     const isEmpty = !cves.data || cves.data.length === 0;
 
     const rows = !isEmpty ? cves.data
@@ -73,8 +73,8 @@ const SystemCvesTableWithContext = ({ context, header, entity }) => {
                         cells={header}
                         rows  ={isEmpty ? noCves() : rows}
                         onSelect ={!isEmpty ? handleOnSelect : undefined}
-                        actionResolver = {!isEmpty ?
-                            (rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex) : undefined}
+                        actionResolver = { (!isEmpty && canEditStatus) &&
+                            ((rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex))}
                         sortBy ={!isEmpty
                             ? createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
                         onCollapse={!isEmpty ? (event, rowKey, isOpen) => handleOnCollapse(event, rowKey, isOpen) : undefined}

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -21,7 +21,7 @@ import {
     removeFilters
 } from '../../../Helpers/TableToolbarHelper';
 
-const SystemCveToolbarWithContext = ({ showRemediationButton, entity, intl, context }) => {
+const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
 
     const handleCveDescription = () => {
         const { cves, methods, expandCveDescription } = context;
@@ -30,9 +30,9 @@ const SystemCveToolbarWithContext = ({ showRemediationButton, entity, intl, cont
         methods.openCves(isOpen, openedCves, !expandCveDescription);
     };
 
-    const { cves, parameters, methods, selectedCves, expandCveDescription } = context;
+    const { cves, parameters, methods, selectedCves, expandCveDescription, canEditStatus, canRemediate } = context;
     const { filter } = parameters;
-    const selectedCvesCount = showRemediationButton === true ? (selectedCves && selectedCves.length) || 0 : undefined;
+    const selectedCvesCount = canRemediate && ((selectedCves && selectedCves.length) || 0);
 
     const selectOptions  = useMemo(() => selectAllCheckbox({
         selectedItems: selectedCves,
@@ -43,18 +43,19 @@ const SystemCveToolbarWithContext = ({ showRemediationButton, entity, intl, cont
     }), [selectedCves, cves, parameters, methods]);
 
     const actions = [
-        showRemediationButton && entity && <Remediation systems={entity} cves={selectedCves} /> || '',
-        {
-            label: intl.formatMessage(messages.editStatus),
-            onClick: () => methods.showStatusModal(
-                [...selectedCves].map(item => ({
-                    id: item,
-                    ...cves.data.filter(cve => item === cve.id)
-                    .map(item => ({ status_id: item.status_id, cve_status_id: item.cve_status_id }))[0]
-                })), []
-            ),
-            props: { isDisabled: !selectedCvesCount }
-        },
+        canRemediate && entity && <Remediation systems={entity} cves={selectedCves} /> || '',
+        ...(canEditStatus ?
+            [({
+                label: intl.formatMessage(messages.editStatus),
+                onClick: () => methods.showStatusModal(
+                    [...selectedCves].map(item => ({
+                        id: item,
+                        ...cves.data.filter(cve => item === cve.id)
+                        .map(item => ({ status_id: item.status_id, cve_status_id: item.cve_status_id }))[0]
+                    })), []
+                ),
+                props: { isDisabled: !selectedCvesCount }
+            })] : []),
         {
             label: expandCveDescription
                 ? intl.formatMessage(messages.kebabCollapseCves)
@@ -112,14 +113,12 @@ const SystemCveToolbarWithContext = ({ showRemediationButton, entity, intl, cont
 };
 
 SystemCveToolbarWithContext.defaultProps = {
-    showRemediationButton: false,
     totalNumber: 0,
     apply: () => undefined,
     downloadReport: () => undefined
 };
 
 SystemCveToolbarWithContext.propTypes = {
-    showRemediationButton: propTypes.bool,
     entity: propTypes.string,
     context: propTypes.object,
     intl: propTypes.any

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -26,7 +26,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 export const CVETableContext = createContext({});
 
-export const SystemCVEs = (props) => {
+export const SystemCVEs = ({ entity, intl, allowedCveActions }) => {
     const dispatch = useDispatch();
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [urlParamsAllowed, setUrlParamsAllowed] = useState(false);
@@ -47,18 +47,19 @@ export const SystemCVEs = (props) => {
         ({ SystemCvesStore }) => SystemCvesStore.expandCveDescription
     );
 
-    const cves = useMemo(() => createCveListBySystem(props.entity.id, systemCVEs), [systemCVEs]);
+    const [canRemediate, canEditStatus] = ['REMEDIATE', 'EDIT_STATUS'].map(action => allowedCveActions.includes(action));
+    const cves = useMemo(() => createCveListBySystem(entity.id, systemCVEs), [systemCVEs]);
     const [createUrlParams, urlParameters] = useCreateUrlParams(CVES_ALLOWED_PARAMS);
 
     const downloadReport = format => {
-        const params = { ...parameters, system: props.entity.id };
+        const params = { ...parameters, system: entity.id };
         DownloadReport.exec(fetchCveListBySystem, params, format, 'system-cves');
     };
 
     const processError = error => {
         const { status } = error;
         const statusCode = parseInt(status);
-        if (statusCode === 404 && props.entity.id) {
+        if (statusCode === 404 && entity.id) {
             return EmptyVulnerabilityData;
         } else {
             return GenericError;
@@ -76,7 +77,7 @@ export const SystemCVEs = (props) => {
             setIsFirstLoad(false);
         }
         else {
-            dispatch(fetchCveListBySystem({ ...parameters, system: props.entity.id }));
+            dispatch(fetchCveListBySystem({ ...parameters, system: entity.id }));
             urlParamsAllowed
                 && createUrlParams({ ...parameters })
                 || setUrlParamsAllowed(true);
@@ -103,7 +104,7 @@ export const SystemCVEs = (props) => {
             (<CvePairStatusModal
                 cves={cvesList}
                 updateRef={() => updateRef(cves.meta, apply)}
-                inventories={[{ id: props.entity.id, display_name: props.entity.display_name }]}
+                inventories={[{ id: entity.id, display_name: entity.display_name }]}
                 hasDifferentStatus={hasDifferentStatus}
                 type={'systemDetail'}
             />)
@@ -127,13 +128,15 @@ export const SystemCVEs = (props) => {
                     selectedCves,
                     openedCves,
                     expandCveDescription,
+                    canRemediate,
+                    canEditStatus,
                     methods: {
                         apply,
                         downloadReport,
                         selectCves: handleCveSelect,
                         openCves: handleCveOpen,
                         showStatusModal,
-                        fetchResource: params => fetchSystemDetailsIds({ ...params, system: props.entity.id })
+                        fetchResource: params => fetchSystemDetailsIds({ ...params, system: entity.id })
                     }
                 }}
             >
@@ -143,18 +146,18 @@ export const SystemCVEs = (props) => {
                     <StackItem>
                         <TextContent>
                             <Text component={TextVariants.h2}>
-                                {props.intl.formatMessage(messages.systemCvesTableHeader)}
+                                {intl.formatMessage(messages.systemCvesTableHeader)}
                             </Text>
                         </TextContent>
                     </StackItem>
                     <StackItem>
-                        <SystemCveTableToolbar showRemediationButton entity={props.entity.id} />
+                        <SystemCveTableToolbar entity={entity.id} />
                     </StackItem>
                 </Stack>
 
                 <SystemCveTable
                     header={SYSTEM_DETAILS_HEADER}
-                    entity={props.entity.id}
+                    entity={entity.id}
                 />
             </CVETableContext.Provider>
         );
@@ -165,13 +168,14 @@ export const SystemCVEs = (props) => {
 
 };
 
+SystemCVEs.defaultProps = {
+    allowedCveActions: []
+};
+
 SystemCVEs.propTypes = {
     entity: propTypes.object,
-    cveList: propTypes.any,
-    fetchData: propTypes.func,
-    history: propTypes.object,
-    location: propTypes.object,
-    intl: propTypes.any
+    intl: propTypes.any,
+    allowedCveActions: propTypes.array
 };
 
 export const ConnectedSystemCves = withRouter(

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
@@ -39,7 +39,10 @@ class SystemDetails extends React.Component {
         if (!isOptOut) {
             return (
                 <React.Fragment>
-                    <ConnectedSystemCves entity={{ id: entity.id, display_name: entity.display_name }} />
+                    <ConnectedSystemCves
+                        entity={{ id: entity.id, display_name: entity.display_name }}
+                        allowedCveActions={['EDIT_STATUS', 'REMEDIATE']}
+                    />
                 </React.Fragment>
             );
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import SystemCVEs from './Components/SmartComponents/SystemCves/SystemCves';
 
 const WrappedSystemCves = (props) => {
     return <Router>
-        <SystemCVEs {...props} />
+        <SystemCVEs {...props} allowedCveActions={['REMEDIATE']} />
     </Router>;
 };
 


### PR DESCRIPTION
Solves: [VULN-951](https://projects.engineering.redhat.com/browse/VULN-951).
Logic: 
 

> Pages receive what kind of actions are allowed to display for users as a prop type of array

> The page display only allowed action (show status/business risk modals, remediation ...)

I could not verify on Inventory, but I believe just an update should be enough 