### PR TITLE
fix(csaw summary): Don't show read more if there is nothing to show

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
@@ -7,6 +7,7 @@ import sanitizeHtml from 'sanitize-html';
 import { Truncate } from '@redhat-cloud-services/frontend-components/components/Truncate';
 import { Stack, StackItem, TextContent } from '@patternfly/react-core';
 import { handleCVELink } from '../../../Helpers/VulnerabilityHelper';
+import { TRUNCATE_TEXT_THRESHOLD } from '../../../Helpers/constants';
 import messages from '../../../Messages';
 
 /**
@@ -26,10 +27,10 @@ const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
     return (
         <StackItem>
             <TextContent className="rule-description">
-                { truncate
+                { truncate && text.length > TRUNCATE_TEXT_THRESHOLD
                     ? (
                         <Truncate
-                            length={230}
+                            length={TRUNCATE_TEXT_THRESHOLD}
                             expandText={intl.formatMessage(messages.readMore)}
                             collapseText={intl.formatMessage(messages.readLess)}
                             text={marked(text)}
@@ -39,9 +40,9 @@ const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
                             <StackItem>
                                 <span dangerouslySetInnerHTML={dangerousHtml(marked(text))}/>
                             </StackItem>
-                            <StackItem className="rule-link pf-u-mt-sm">
-                                {link && handleCVELink(link, intl.formatMessage(messages.readMore))}
-                            </StackItem>
+                            {link && <StackItem className="rule-link pf-u-mt-sm">
+                                {handleCVELink(link, intl.formatMessage(messages.readMore))}
+                            </StackItem>}
                         </Stack>
                     )
                 }

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -422,3 +422,5 @@ export const SYSTEMS_SORTING_HEADER = [{ key: 'empty' }, { key: 'display_name' }
 
 export const SYSTEMS_EXPOSED_SORTING_HEADER =
     [{ key: 'empty' }, { key: 'empty' }, { key: 'inventory_id' }, { key: 'status' }, { key: 'last_upload' }];
+
+export const TRUNCATE_TEXT_THRESHOLD = 230;


### PR DESCRIPTION
Fixes [VULN-1121](https://projects.engineering.redhat.com/browse/VULN-1121) - remove read more label if text is short enough, but only for Summary because Rulebox is using read more as a link.

### Before:
![truncate-1](https://user-images.githubusercontent.com/8426204/87537160-7c3f2e00-c69a-11ea-9617-2f7b13b037a6.png)
![truncate-2](https://user-images.githubusercontent.com/8426204/87537167-7d705b00-c69a-11ea-972b-38e3cdd268f8.png)

### After:
![truncate-3](https://user-images.githubusercontent.com/8426204/87537169-7ea18800-c69a-11ea-9843-a8b686f6fad3.png)
