### PR TITLE
fix(StatusModal): activate use overall status when selected cves are …

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -70,13 +70,17 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
     }
 
     function getDefaultCheckboxState() {
+
+        const haveSameStatuses = cveList.every(
+            (val, i, arr) => (val.status_id === arr[0].status_id) && (val.cve_status_id === arr[0].cve_status_id)
+        );
         // system has the same status as cve
         if (inventoryList && inventoryList.length === 1 && inventoryList[0].status_id) {
             let [inventory] = inventoryList;
             return cveList.some(cve => (cve.status_id === inventory.status_id));
         }
 
-        if (cveList && cveList.length === 1) {
+        if (cveList && cveList.length === 1 || haveSameStatuses) {
             return true;
         }
 


### PR DESCRIPTION
fixes:  [VULN-118](https://projects.engineering.redhat.com/browse/VULN-118).
Almost everything is done. The only thing I notices is currently, when multiple cve are selected and they have the same cve status and system cve status use overall is not activated ( [mockups, CASE 4, image 1](https://marvelapp.com/prototype/75dcb1j/screen/62253695?) ). This PR fixes this issue. 