### PR TITLE
fix(system exposed table): Fixed bulk edit status regression

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -184,7 +184,7 @@ const SystemsExposedTable = (props) => {
             return [{ id, displayName }];
         }
         else if (selectedHosts.length > 1) {
-            return selectedHosts.map(({ id }) => ({ id }));
+            return selectedHosts.map(item => ({ id: item }));
         }
 
         return [];


### PR DESCRIPTION
Fixes commit 7c2ae0d88e961bbeebe37098ffa7de52613b7d6c which has introduced a regression where selecting and trying to edit status of multiple systems from system exposed table would not load any system id, which would result in no op when changing status/justification and clicking save.