### PR TITLE
fix(CVE detail header): Fixed infobox styling

### DIFF
--- a/src/Components/PresentationalComponents/CVEInfoBox/CVEInfoBox.scss
+++ b/src/Components/PresentationalComponents/CVEInfoBox/CVEInfoBox.scss
@@ -1,7 +1,7 @@
 @import "../../../App";
 
 .infobox-square {
-    background-color: var(--pf-global--BackgroundColor--150);
+    background-color: var(--pf-global--BackgroundColor--200);
     border: var(--pf-global--BorderColor--300) var(--pf-global--BorderWidth--sm)
         solid;
     height: 65px;

--- a/src/Components/PresentationalComponents/CvssVector/CvssVector.scss
+++ b/src/Components/PresentationalComponents/CvssVector/CvssVector.scss
@@ -1,5 +1,8 @@
 .severity-info-box {
     > div {
+        h6 {
+            margin: 0;
+        }
         > div:nth-child(3) {
             h6 {
                 .ins-c-skeleton {


### PR DESCRIPTION
Fixes [VULN-1114](https://projects.engineering.redhat.com/browse/VULN-1114).
- Add background to the infobox (using bgcolor-200 which is a bit darker then previous bgcolor-150, which was removed by patternfly)
- Fix h6 (bold labels) having bottom margin

### Before:
![infobox-before](https://user-images.githubusercontent.com/8426204/88164832-fb8dae00-cc14-11ea-90d4-8f01431bf814.png)

### After:
![infobox-after](https://user-images.githubusercontent.com/8426204/88164829-f9c3ea80-cc14-11ea-93b4-a1605cdfc0c4.png)