### PR TITLE
fix(status breakdown table): Rename "count" to "num. systems"

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -7,7 +7,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "loading": "Loading...",
-    "count": "Count",
+    "count": "Num. systems",
     "current": "current",
     "cve": "CVE",
     "system": "{num, plural, one {#  system} other {#  systems} }",

--- a/src/Components/PresentationalComponents/CVEPageDetailsDescription/CVEPageDetailsDescription.scss
+++ b/src/Components/PresentationalComponents/CVEPageDetailsDescription/CVEPageDetailsDescription.scss
@@ -13,6 +13,7 @@
             padding-bottom: var(--pf-global--spacer--sm);
             &:last-child {
                 text-align: right;
+                min-width: 8em;
             }
         }
         td {


### PR DESCRIPTION
And also capped the column size to prevent the label from wrapping.