### PR TITLE
fix(ExecutiveReport): overwflow is moved to second page

### DIFF
--- a/src/Components/SmartComponents/Reports/BuildExecReport.js
+++ b/src/Components/SmartComponents/Reports/BuildExecReport.js
@@ -16,6 +16,8 @@ import messages from '../../../Messages';
 
 const BuildExecReport = ({ data,  intl }) => {
 
+    const safeCharLength = { colChars: 70, rows: 15 };
+
     const {
         cves_by_severity: cvesBySeverity,
         recent_cves: recentCves,
@@ -73,7 +75,30 @@ const BuildExecReport = ({ data,  intl }) => {
         true
     );
 
-    return (
+    const calculateTopCves = () => {
+        let panelGroups = { firstPage: [], secondPage: [] };
+        let totalRows = 0;
+
+        topCves.forEach(cve => {
+            const rows = Math.ceil(cve.description.length / safeCharLength.colChars);
+            totalRows += rows;
+            const panel = (
+                <Panel key={cve.synopsis} title={cve.synopsis} description={cve.description}>
+                    <PanelItem title={intl.formatMessage(messages.executiveReportPanelTitle)}>
+                        {Number.parseFloat(cve.cvss3_score).toFixed(1)}
+                    </PanelItem>
+                    <PanelItem title={intl.formatMessage(messages.systemsExposed)}>
+                        {cve.systems_affected.toString()}
+                    </PanelItem>
+                </Panel>
+            );
+            totalRows <= 15 && panelGroups.firstPage.push(panel) || panelGroups.secondPage.push(panel);
+
+        });
+        return panelGroups;
+    };
+
+    return [(
         <Fragment key="first-section">
             <Paragraph>
                 {intl.formatMessage(messages.executiveReportHeader)}
@@ -116,19 +141,15 @@ const BuildExecReport = ({ data,  intl }) => {
                 </Column>
             </Section>
             <Section title={intl.formatMessage(messages.executiveReportTop3)} withColumn={false}>
-                {topCves.map(cve => (
-                    <Panel key={cve.synopsis} title={cve.synopsis} description={cve.description}>
-                        <PanelItem title={intl.formatMessage(messages.executiveReportPanelTitle)}>
-                            {Number.parseFloat(cve.cvss3_score).toFixed(1)}
-                        </PanelItem>
-                        <PanelItem title={intl.formatMessage(messages.systemsExposed)}>
-                            {cve.systems_affected.toString()}
-                        </PanelItem>
-                    </Panel>
-                ))}
+                {
+                    calculateTopCves().firstPage
+
+                }
             </Section>
         </Fragment>
-    );
+    ),
+    ...calculateTopCves().secondPage
+    ];
 };
 
 BuildExecReport.propTypes = {

--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -18,7 +18,7 @@ const DownloadExecutive = () => {
         const report = buildExecReport({ data, intl });
 
         setLoading(false);
-        return [report];
+        return [...report];
 
     };
 


### PR DESCRIPTION
[overflowBefore.pdf](https://github.com/RedHatInsights/vulnerability-ui/files/5005719/overflowBefore.pdf)
[overflowAfter.pdf](https://github.com/RedHatInsights/vulnerability-ui/files/5005720/overflowAfter.pdf)

possible fix for: [VULN-634](https://projects.engineering.redhat.com/browse/VULN-634) 
[notOverflow.pdf](https://github.com/RedHatInsights/vulnerability-ui/files/5005730/notOverflow.pdf)
