### PR TITLE
fix(SystemsExposed) Maximum update depth exceeded error resolved

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -52,6 +52,7 @@ const SystemsExposedTable = (props) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [selectedHosts, setSelectedHosts] = useState(undefined);
     const [urlParamsAllowed, setUrlParamsAllowed] = useState(false);
+    const [isFirstMount, setIsFirstMount] = useState(true);
 
     const inventory = React.createRef();
     const dispatch = useDispatch();
@@ -105,8 +106,9 @@ const SystemsExposedTable = (props) => {
     });
 
     useEffect(() => {
-        if (!inventory.current) {
+        if (!inventory.current && isFirstMount) {
             apply(urlParameters);
+            setIsFirstMount(false);
         }
         else {
             dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -49,6 +49,7 @@ const SystemsPage = ({ intl }) => {
     const [InventoryTable, setInventoryTable] = useState(() => () => <div>Loading...</div>);
     const [createUrlParams, urlParameters] = useCreateUrlParams(SYSTEMS_ALLOWED_PARAMS);
     const [urlParamsAllowed, setUrlParamsAllowed] = useState(false);
+    const [isFirstMount, setIsFirstMount] = useState(true);
     const inventory = React.createRef();
     const dispatch = useDispatch();
 
@@ -132,8 +133,9 @@ const SystemsPage = ({ intl }) => {
     };
 
     useEffect(() => {
-        if (!inventory.current) {
+        if (!inventory.current && isFirstMount) {
             apply(urlParameters);
+            setIsFirstMount(false);
         }
         else {
             dispatch(fetchSystems(parameters));


### PR DESCRIPTION
`Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render. ` error resolved in CVEDetails and Systems pages