### PR TITLE
Pass pf react core to inventory to properly render inventory

### DIFF
--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -17,6 +17,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as ReactRedux from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import { withRouter } from 'react-router-dom';
 import { fetchSystemDetails, optOutSystemAction } from '../../../Store/Actions/Actions';
 import { systemDetailsPageStore } from '../../../Store/Reducers/SystemDetailsPageStore';
@@ -66,7 +67,8 @@ class InventoryDetail extends React.Component {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
 
         ReducerRegistry.register({
@@ -76,7 +78,8 @@ class InventoryDetail extends React.Component {
 
         this.setState({
             InventoryHeader: inventoryConnector(ReducerRegistry.getStore()).InventoryDetailHead,
-            InventoryBody: inventoryConnector(ReducerRegistry.getStore()).AppInfo
+            InventoryBody: inventoryConnector(ReducerRegistry.getStore()).AppInfo,
+            InvWrapper: inventoryConnector(ReducerRegistry.getStore()).DetailWrapper
         });
         this.state.removeListener();
     }
@@ -108,40 +111,43 @@ class InventoryDetail extends React.Component {
     };
 
     render() {
-        const { InventoryHeader, InventoryBody } = this.state;
+        const { InventoryHeader, InventoryBody, InvWrapper } = this.state;
         const { systemDetails = {}, errors } = this.props;
         const { opt_out: isOptOut = false, entity } = systemDetails;
 
+        const Wrapper = InvWrapper || React.Fragment;
         return (
             <Page>
-                <VulnerabilityHeader title=''>
-                    {InventoryHeader && !errors && (
-                        <InventoryHeader
-                            hideBack
-                            actions={
-                                entity && [
-                                    isOptOut
-                                        ? {
-                                            title: this.props.intl.formatMessage(messages.inventoryKebabOptionsResume),
-                                            onClick: () => this.optOutSystem(false)
-                                        }
-                                        : {
-                                            title: this.props.intl.formatMessage(messages.inventoryKebabOptionsExclude),
-                                            onClick: () => this.optOutSystem(true)
-                                        }
-                                ]
-                            }
-                        />
-                    )}
-                </VulnerabilityHeader>
+                <Wrapper>
+                    <VulnerabilityHeader title=''>
+                        {InventoryHeader && !errors && (
+                            <InventoryHeader
+                                hideBack
+                                actions={
+                                    entity && [
+                                        isOptOut
+                                            ? {
+                                                title: this.props.intl.formatMessage(messages.inventoryKebabOptionsResume),
+                                                onClick: () => this.optOutSystem(false)
+                                            }
+                                            : {
+                                                title: this.props.intl.formatMessage(messages.inventoryKebabOptionsExclude),
+                                                onClick: () => this.optOutSystem(true)
+                                            }
+                                    ]
+                                }
+                            />
+                        )}
+                    </VulnerabilityHeader>
 
-                {InventoryBody && (
-                    <Main>
-                        <React.Fragment>
-                            <InventoryBody optOutSystemHandler={this.optOutSystem} />
-                        </React.Fragment>
-                    </Main>
-                )}
+                    {InventoryBody && (
+                        <Main>
+                            <React.Fragment>
+                                <InventoryBody optOutSystemHandler={this.optOutSystem} />
+                            </React.Fragment>
+                        </Main>
+                    )}
+                </Wrapper>
             </Page>
         );
     }

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -4,6 +4,7 @@ import messages from '../../../Messages';
 import { withRouter } from 'react-router-dom';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import { useCreateUrlParams, updateRef, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
 import {
     Table as PfTable,
@@ -139,7 +140,8 @@ const SystemsExposedTable = (props) => {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
         ReducerRegistry.register({
             ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER)),

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -4,6 +4,7 @@ import messages from '../../../Messages';
 import * as reactRouterDom from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import {
     Table as PfTable,
     TableBody,
@@ -93,7 +94,8 @@ const SystemsPage = ({ intl }) => {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
 
         ReducerRegistry.register({


### PR DESCRIPTION
There is a new feature brewing in chrome, building chrome with webpack [1]. This PR passes newly required dependencies. In future we'll use Federated modules [2] so there won't be a need for these changes, but this is required as a mid-step solution.

Also, for enabling A/B testing of inventory detail we are working on new inventory component, for now this component will be undefined so use `React.Fragment` as fallback.

[1] https://github.com/RedHatInsights/insights-chrome/pull/842
[2] https://webpack.js.org/concepts/module-federation/