### PR TITLE
fix(status edit): Pass justification note when bulk editing

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -136,8 +136,10 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
                 if (checkboxState) { // use overall (CVE) justification
                     return (cveList && cveList.length === 1 && cveList[0].cve_justification) || '';
                 }
-                else { // use system pair justification
-                    return (cveList && cveList.length === 1 && cveList[0].justification) || '';
+                else { // use system pair justification; in case all notes are same display it
+                    return (cveList && cveList.length > 0
+                        && cveList.every(value => value.justification === cveList[0].justification)
+                        && cveList[0].justification) || '';
                 }
             }
 

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -51,7 +51,12 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
                     [...selectedCves].map(item => ({
                         id: item,
                         ...cves.data.filter(cve => item === cve.id)
-                        .map(item => ({ status_id: item.status_id, cve_status_id: item.cve_status_id }))[0]
+                        .map(item => ({
+                            status_id: item.status_id,
+                            cve_status_id: item.cve_status_id,
+                            justification: item.status_justification,
+                            cve_justification: item.cve_status_justification
+                        }))[0]
                     })), []
                 ),
                 props: { isDisabled: !selectedCvesCount }


### PR DESCRIPTION
Fixes subtask 4 from [VULN-1181](https://projects.engineering.redhat.com/projects/VULN/issues/VULN-1181).

Steps:
1. Go to System detail table
2. Edit 2 CVEs status - uncheck "Use overall CVE status" and set justification note to the same string, e.g. "note"

Previously if you would select and bulk edit these 2 CVEs (or even selected one of them and edited status from toolbar kebab menu), the justification note would be blank even thought it should be the string you have previously chosen, now it correctly shows the note (case 4 right from [mockup](https://marvelapp.com/prototype/75dcb1j/screen/62253695)). 