### PR TITLE
fix(filtering): Correctly format month of publish date

### DIFF
--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -62,7 +62,7 @@ export function formatDate(date = new Date()) {
     const toFormat = new Date(date);
     if (toFormat instanceof Date && !isNaN(toFormat)) {
         const year = toFormat.getFullYear();
-        const month = toFormat.getMonth();
+        const month = toFormat.getMonth() + 1; // month is zero indexed
         const day = toFormat.getDate();
         return `${year}-${prepend(month)}-${prepend(day)}`;
     }

--- a/src/Helpers/MiscHelper.test.js
+++ b/src/Helpers/MiscHelper.test.js
@@ -15,8 +15,8 @@ import {
     constructURLParameters
 } from './MiscHelper';
 import { 
-    substractDays, 
-    substractYears 
+    subtractDays, 
+    subtractYears 
 } from './constants';
 
 const mockLocation = {
@@ -174,11 +174,11 @@ describe('MiscHelper', () => {
     ${{}}                                        | ${{}}
     ${{ publish_date: 'notValid' }}              | ${{ public_from: undefined, public_to: undefined, publish_date: undefined}}
     ${{ publish_date: 'all' }}                   | ${{ public_from: undefined, public_to: undefined, publish_date: 'all'}}
-    ${{ publish_date: 'last7' }}                 | ${{ public_from: formatDate(substractDays(7)), public_to: undefined, publish_date: 'last7'}}
-    ${{ publish_date: 'last30' }}                | ${{ public_from: formatDate(substractDays(30)), public_to: undefined, publish_date: 'last30'}}
-    ${{ publish_date: 'last90' }}                | ${{ public_from: formatDate(substractDays(90)), public_to: undefined, publish_date: 'last90'}}
-    ${{ publish_date: 'lastYear' }}              | ${{ public_from: formatDate(substractYears(1)), public_to: undefined, publish_date: 'lastYear'}}
-    ${{ publish_date: 'MoreThanYear' }}          | ${{ public_from: undefined, public_to: formatDate(substractYears(1)), publish_date: 'MoreThanYear'}}
+    ${{ publish_date: 'last7' }}                 | ${{ public_from: formatDate(subtractDays(7)), public_to: undefined, publish_date: 'last7'}}
+    ${{ publish_date: 'last30' }}                | ${{ public_from: formatDate(subtractDays(30)), public_to: undefined, publish_date: 'last30'}}
+    ${{ publish_date: 'last90' }}                | ${{ public_from: formatDate(subtractDays(90)), public_to: undefined, publish_date: 'last90'}}
+    ${{ publish_date: 'lastYear' }}              | ${{ public_from: formatDate(subtractYears(1)), public_to: undefined, publish_date: 'lastYear'}}
+    ${{ publish_date: 'MoreThanYear' }}          | ${{ public_from: undefined, public_to: formatDate(subtractYears(1)), publish_date: 'MoreThanYear'}}
  
     `('constructFilterParameters - publish_filter', ({ publish_filter, expected_data }) => {
         const filter = constructFilterParameters(publish_filter);

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -112,22 +112,22 @@ export const CVSS_OPTIONS = [
     { value: 'from-1to-1', label: 'N/A' }
 ];
 
-export const substractDays = (toSubstract, currDate = new Date()) => {
-    return currDate.setDate(currDate.getDate() - toSubstract);
+export const subtractDays = (toSubtract, currDate = new Date()) => {
+    return currDate.setDate(currDate.getDate() - toSubtract);
 };
 
-export const substractYears = (toSubstract, currDate = new Date()) => {
-    return currDate.setFullYear(currDate.getFullYear() - toSubstract);
+export const subtractYears = (toSubtract, currDate = new Date()) => {
+    return currDate.setFullYear(currDate.getFullYear() - toSubtract);
 };
 
 //Public date labels to value
 export const PUBLIC_DATE_OPTIONS = [
     { value: 'all', label: intl.formatMessage(messages.optionsAll) },
-    { value: 'last7', label: intl.formatMessage(messages.lastxdays, { days: 7 }), from: substractDays(7) },
-    { value: 'last30', label: intl.formatMessage(messages.lastxdays, { days: 30 }), from: substractDays(30) },
-    { value: 'last90', label: intl.formatMessage(messages.lastxdays, { days: 90 }), from: substractDays(90) },
-    { value: 'lastYear', label: intl.formatMessage(messages.lastYear), from: substractYears(1) },
-    { value: 'MoreThanYear', label: intl.formatMessage(messages.moreThanYear), to: substractYears(1) }
+    { value: 'last7', label: intl.formatMessage(messages.lastxdays, { days: 7 }), from: subtractDays(7) },
+    { value: 'last30', label: intl.formatMessage(messages.lastxdays, { days: 30 }), from: subtractDays(30) },
+    { value: 'last90', label: intl.formatMessage(messages.lastxdays, { days: 90 }), from: subtractDays(90) },
+    { value: 'lastYear', label: intl.formatMessage(messages.lastYear), from: subtractYears(1) },
+    { value: 'MoreThanYear', label: intl.formatMessage(messages.moreThanYear), to: subtractYears(1) }
 ];
 
 export const AFFECTING_SYSTEMS_OPTIONS = [


### PR DESCRIPTION
Fixes [VULN-1170](https://projects.engineering.redhat.com/projects/VULN/issues/VULN-1170).
Also refactors `substractDays` and `substractYears` inside `constants.js` file to `subtractDays` and `subtractYears`.

**Explanation:**
Inside `MiscHelper.js > formatDate` function month was get using [`date.getMonth` function which returns month but zero indexed](https://www.w3schools.com/jsref/jsref_getmonth.asp). This subtracted a month from the date which not only showed incorrect CVEs for the timespan but could create error in case the previous month didn't have day number of today (31st of June for example).

**Testing setup:**
I mocked today's date inside `currDate` default parameter (remember month is zero indexed here too) inside `constants.js > subtractYears` and `subtractDays` function.
![mock](https://user-images.githubusercontent.com/8426204/90744668-5677fb00-e2d0-11ea-8d04-50d28c089ef5.png)

Then added console log for filter params into `ReportsHelper.js > constructFilterParameters` function
![console](https://user-images.githubusercontent.com/8426204/90745929-ab1b7600-e2d0-11ea-8189-eae0865b37ad.png)

Then went to reports page, and added publish date filter inside report config modal and by clicking options I could see what date would be sent to API.

