### PR TITLE
fix(PDF report): Add footer

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -265,6 +265,7 @@
     "customReportTimespanWithinLastXDays": "within <b>last {count} days</b>",
     "customReportTimespanWithinLastYear": "within <b>last year</b>",
     "customReportTimespanMoreThanOneYear": "more than <b>1 year ago</b>",
-    "customReportAnd": "; and"
+    "customReportAnd": "; and",
+    "customReportFooter": "This icon indicates that this CVE has an associated security rule written by Red Hat. See the Vulnerability application for more details."
   }
 }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -264,5 +264,6 @@
   "customReportTimespanWithinLastXDays": "within <b>last {count} days</b>",
   "customReportTimespanWithinLastYear": "within <b>last year</b>",
   "customReportTimespanMoreThanOneYear": "more than <b>1 year ago</b>",
-  "customReportAnd": "; and"
+  "customReportAnd": "; and",
+  "customReportFooter": "This icon indicates that this CVE has an associated security rule written by Red Hat. See the Vulnerability application for more details."
 }

--- a/src/Components/SmartComponents/Reports/BuildExecReport.js
+++ b/src/Components/SmartComponents/Reports/BuildExecReport.js
@@ -13,6 +13,7 @@ import {
 } from '@redhat-cloud-services/frontend-components-pdf-generator';
 import { Text } from '@react-pdf/renderer';
 import messages from '../../../Messages';
+import styles from './Common/styles';
 
 const BuildExecReport = ({ data,  intl }) => {
 
@@ -105,10 +106,10 @@ const BuildExecReport = ({ data,  intl }) => {
             </Paragraph>
             <Paragraph>
                 {intl.formatMessage(messages.executiveReportSubHeader, {
-                    systems: <Text style={{ fontWeight: 700 }}>
+                    systems: <Text style={styles.bold}>
                         {intl.formatMessage(messages.executiveReportHeaderSystems, { systems: systemTotal })}
                     </Text>,
-                    cves: <Text style={{ fontWeight: 700 }}>
+                    cves: <Text style={styles.bold}>
                         {intl.formatMessage(messages.executiveReportHeaderCVEs, { cves: cvesTotal })}
                     </Text>
                 })}

--- a/src/Components/SmartComponents/Reports/Common/firstPagePDF.js
+++ b/src/Components/SmartComponents/Reports/Common/firstPagePDF.js
@@ -6,6 +6,7 @@ import messages from '../../../../Messages';
 import tablePage from './tablePage';
 import { PUBLIC_DATE_OPTIONS, DEFAULT_FILTER_DATA } from '../../../../Helpers/constants';
 import { formatWithBold } from '../ReportsHelper';
+import styles from './styles';
 
 const firstPagePDF = ({ cves, meta, filters, intl, isReportDynamic, reportData, user }) => {
     // if data isn't converted to object convert it
@@ -74,14 +75,14 @@ const firstPagePDF = ({ cves, meta, filters, intl, isReportDynamic, reportData, 
 
             {
                 reportData && reportData.userNotes ?
-                    (<View style={{ backgroundColor: '#F0F0F0', padding: '8px', marginBottom: '16px' }}>
-                        <Paragraph style={{ marginBottom: '4px' }}><Text style={{ fontWeight: 700 }}>
+                    (<View style={styles.userNotes}>
+                        <Paragraph style={styles.userNotesTitle}><Text style={styles.bold}>
                             {intl.formatMessage(messages.customReportUserNoteLabel)}
                         </Text></Paragraph>
-                        <Paragraph style={{ marginBottom: '0px' }}><Text>{reportData.userNotes}</Text></Paragraph>
+                        <Paragraph><Text>{reportData.userNotes}</Text></Paragraph>
                         <Paragraph>
                             { user && user.identity &&
-                                <Text style={{ fontStyle: 'italic' }}>
+                                <Text style={styles.italic}>
                                     - {user.identity.user.first_name} {user.identity.user.last_name}
                                 </Text>
                             }

--- a/src/Components/SmartComponents/Reports/Common/styles.js
+++ b/src/Components/SmartComponents/Reports/Common/styles.js
@@ -1,0 +1,57 @@
+/* eslint-disable camelcase */
+import { StyleSheet } from '@react-pdf/renderer';
+import global_FontWeight_bold from '@patternfly/react-tokens/dist/js/global_FontWeight_bold';
+import global_link_Color from '@patternfly/react-tokens/dist/js/global_link_Color';
+import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
+
+export default StyleSheet.create({
+    bold: {
+        fontWeight: 700
+    },
+    italic: {
+        fontStyle: 'italic'
+    },
+
+    userNotes: {
+        backgroundColor: '#F0F0F0',
+        padding: '8px',
+        marginBottom: '16px'
+    },
+    userNotesTitle: {
+        marginBottom: '4px'
+    },
+
+    link: {
+        color: global_link_Color.value
+    },
+    bodyCell: {
+        width: '72px',
+        textAlign: 'left',
+        fontSize: 8,
+        paddingBottom: 2,
+        paddingTop: 2
+    },
+    headerCell: {
+        width: '72px',
+        textAlign: 'left',
+        color: global_Color_200.value,
+        fontWeight: global_FontWeight_bold.value,
+        fontSize: 8
+    },
+    cveCellAlign: {
+        position: 'absolute',
+        left: '12px'
+    },
+
+    footer: {
+        marginBottom: 20
+    },
+    footerIcon: {
+        position: 'absolute',
+        left: '7px',
+        top: '1px'
+    },
+    footerText: {
+        position: 'absolute', left: '20px'
+    }
+});

--- a/src/Components/SmartComponents/Reports/Common/tablePage.js
+++ b/src/Components/SmartComponents/Reports/Common/tablePage.js
@@ -1,37 +1,11 @@
-/* eslint-disable camelcase */
-
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, StyleSheet, Link } from '@react-pdf/renderer';
+import { View, Text, Link } from '@react-pdf/renderer';
 import { Table, CSAwIcon } from '@redhat-cloud-services/frontend-components-pdf-generator';
-import global_FontWeight_bold from '@patternfly/react-tokens/dist/js/global_FontWeight_bold';
-import global_link_Color from '@patternfly/react-tokens/dist/js/global_link_Color';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { CVES_PATH } from '../../../../Helpers/constants';
 import messages from '../../../../Messages';
-
-const styles = StyleSheet.create({
-    link: { color: global_link_Color.value },
-    bodyCell: {
-        width: '72px',
-        textAlign: 'left',
-        fontSize: 8,
-        paddingBottom: 2,
-        paddingTop: 2
-    },
-    headerCell: {
-        width: '72px',
-        textAlign: 'left',
-        color: global_Color_200.value,
-        fontWeight: global_FontWeight_bold.value,
-        fontSize: 8
-    },
-    cveCellAlign: {
-        position: 'absolute',
-        left: '12px'
-    }
-});
+import styles from './styles';
 
 const tablePage = ({ data, page, intl, header }) => {
     // eslint-disable-next-line react/prop-types

--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -2,17 +2,20 @@
 import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
+import { DownloadButton, CSAwIcon } from '@redhat-cloud-services/frontend-components-pdf-generator';
 import { getCveListByAccount } from '../../../Helpers/APIHelper';
 import messages from '../../../Messages';
 import firstPagePDF from './Common/firstPagePDF';
 import tablePage from './Common/tablePage';
 import DownloadReport from '../../../Helpers/DownloadReport';
 import { PDF_REPORT_PER_PAGE } from '../../../Helpers/constants';
+import { Text, View } from '@react-pdf/renderer';
+import styles from './Common/styles';
 
 const DownloadCVEsReport = ({ filters, params, reportData, buttonProps, isReportDynamic = false }) => {
     const intl = useIntl();
     const [loading, setLoading] = useState(false);
+    const [securityRulesPresent, setSecurityRulesPresent] = useState(false);
 
     const dataFetch = async () => {
         let user;
@@ -35,6 +38,8 @@ const DownloadCVEsReport = ({ filters, params, reportData, buttonProps, isReport
                 cvss_score: parseFloat(cve.attributes.cvss3_score || cve.attributes.cvss2_score).toFixed(1)
             }
         }));
+
+        setSecurityRulesPresent(data.some(cve => cve.attributes.rules.length > 0));
 
         const firstPage = firstPagePDF({
             cves: data.splice(0, reportData.userNotes
@@ -69,6 +74,16 @@ const DownloadCVEsReport = ({ filters, params, reportData, buttonProps, isReport
                 allPagesHaveTitle={false}
                 size={'A4'}
                 orientation={'landscape'}
+                footer={
+                    securityRulesPresent && (
+                        <View style={styles.footer}>
+                            <Text>*</Text>
+                            <CSAwIcon style={styles.footerIcon}/>
+                            <Text style={styles.footerText}>
+                                {intl.formatMessage(messages.customReportFooter)}
+                            </Text>
+                        </View>)
+                }
             />
         </div>
     );

--- a/src/Components/SmartComponents/Reports/ReportsHelper.js
+++ b/src/Components/SmartComponents/Reports/ReportsHelper.js
@@ -3,6 +3,7 @@ import { FILTERS, PUBLIC_DATE_OPTIONS, SECURITY_RULE_OPTIONS, DEFAULT_FILTER_DAT
 import { formatDate } from '../../../Helpers/MiscHelper';
 import { intl } from '../../../Utilities/IntlProvider';
 import { Text } from '@react-pdf/renderer';
+import styles from './Common/styles';
 
 export const buildFilters = filterData => {
     let newValues = {};
@@ -76,5 +77,5 @@ export function constructFilterParameters(filterParams) {
 }
 
 export const formatWithBold = (msg, params) => {
-    return intl.formatMessage(msg, { ...params, b: (...chunks) => <Text style={{ fontWeight: 700 }}>{chunks}</Text> });
+    return intl.formatMessage(msg, { ...params, b: (...chunks) => <Text style={styles.bold}>{chunks}</Text> });
 };

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1383,5 +1383,10 @@ export default defineMessages({
         id: 'customReportAnd',
         description: 'Prefix for last filter string segment',
         defaultMessage: '; and'
+    },
+    customReportFooter: {
+        id: 'customReportFooter',
+        description: 'Footer text stating what does security rule icon mean',
+        defaultMessage: 'This icon indicates that this CVE has an associated security rule written by Red Hat. See the Vulnerability application for more details.'
     }
 });


### PR DESCRIPTION
Fixes [VULN-1061](https://projects.engineering.redhat.com/browse/VULN-1061).

Currently asterisk is shown inside the footer, but first CVE with security rule doesn't have asterisks, see comment.

### Example:
![footer](https://user-images.githubusercontent.com/8426204/91997732-b3e16280-ed3a-11ea-8e4d-610812b811c7.png)

### Notice no footer when only CVEs without security ruels are present:
![footer2](https://user-images.githubusercontent.com/8426204/91997742-b5ab2600-ed3a-11ea-8083-1e76bbacb01b.png)

