### PR TITLE
chore(packages): Bump FCE PDF generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3318,9 +3318,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-pdf-generator": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.2.4.tgz",
-      "integrity": "sha512-WChock9a9TufeVV6SABQfgH9Wlq1FG6P9JZNFN2bteEltxTxP6tTCrdr+EG1cy4Db2AMdV6YzNwGhncj/AR/Cw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-pdf-generator/-/frontend-components-pdf-generator-2.3.3.tgz",
+      "integrity": "sha512-WIKyKsGHN2DrTeO/BnjJ/BGHncRDJQwpYGNsXzYhhhMfZlra/hGtb4zzdo/HQ99zV+pJfBlACOqqqQwl88KFcQ==",
       "requires": {
         "@patternfly/react-charts": "^6.3.9",
         "@patternfly/react-core": ">=4.18.5",
@@ -34163,9 +34163,9 @@
       },
       "dependencies": {
         "d3-array": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.7.0.tgz",
-          "integrity": "sha512-4T2QVIgIvsuWo3ZxlweERUA37nc8uEIykD8bbpnbdgROio1TIh9uoMmi5E1SckAjFdb9b7hTWV0dExnxNqaAVg=="
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.7.1.tgz",
+          "integrity": "sha512-dYWhEvg1L2+osFsSqNHpXaPQNugLT4JfyvbLE046I2PDcgYGFYc0w24GSJwbmcjjZYOPC3PNP2S782bWUM967Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@redhat-cloud-services/frontend-components": "^2.3.14",
     "@redhat-cloud-services/frontend-components-inventory-insights": "^2.5.6",
     "@redhat-cloud-services/frontend-components-notifications": "^2.1.0",
-    "@redhat-cloud-services/frontend-components-pdf-generator": "^2.2.4",
+    "@redhat-cloud-services/frontend-components-pdf-generator": "^2.3.3",
     "@redhat-cloud-services/frontend-components-remediations": "^2.1.4",
     "@redhat-cloud-services/frontend-components-translations": "^2.0.4",
     "@redhat-cloud-services/frontend-components-utilities": "^2.1.5",


### PR DESCRIPTION
Fixes [VULN-1193](https://projects.engineering.redhat.com/browse/VULN-1193) and unblocks [VULN-1061](https://projects.engineering.redhat.com/browse/VULN-1061) and subsequently https://github.com/RedHatInsights/vulnerability-ui/pull/513.