### PR TITLE
fix(PDF report): Restrict user note char count and adjust item count to fit page

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -250,6 +250,7 @@
     "customReportDataToIncludeLabel": "Columns to include",
     "customReportFilterDataByLabel": "Filter data by",
     "customReportUserNotesLabel": "User notes (optional)",
+    "customReportUserNoteTooLong": "User notes must be less than 1000 characters.",
     "customReportSystemsExposed": "Count of exposed systems",
     "customReportSecurityRuleDropdown": "Security rule",
     "customReportSecurityRuleCheckbox": "Security rule indicator",

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -249,6 +249,7 @@
   "customReportDataToIncludeLabel": "Columns to include",
   "customReportFilterDataByLabel": "Filter data by",
   "customReportUserNotesLabel": "User notes (optional)",
+  "customReportUserNoteTooLong": "User notes must be less than 1000 characters.",
   "customReportSystemsExposed": "Count of exposed systems",
   "customReportSecurityRuleDropdown": "Security rule",
   "customReportSecurityRuleCheckbox": "Security rule indicator",

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -16,7 +16,7 @@ import {
 import { AngleDownIcon } from '@patternfly/react-icons';
 import CustomReportFilter from '../Reports/CustomReportFilter';
 import { constructFilterParameters, buildFilters } from '../Reports/ReportsHelper';
-import { FILTERS, DEFAULT_FILTER_DATA } from '../../../Helpers/constants';
+import { FILTERS, DEFAULT_FILTER_DATA, PDF_REPORT_USER_NOTE_MAX_LENGTH } from '../../../Helpers/constants';
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';
 import DownloadCVEsReport from '../Reports/DownloadCVEsReport';
@@ -108,7 +108,8 @@ const ReportConfigModal = ({ isOpen, onClose }) => {
                         isDisabled:
                             +filterData.cvss_filter.min < 0 ||
                             +filterData.cvss_filter.max > 10 ||
-                            +filterData.cvss_filter.min > +filterData.cvss_filter.max,
+                            +filterData.cvss_filter.min > +filterData.cvss_filter.max ||
+                            userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH,
                         style: { marginRight: '0.5em' }
                     }}
                 />,
@@ -222,6 +223,8 @@ const ReportConfigModal = ({ isOpen, onClose }) => {
                 <FormGroup
                     label={intl.formatMessage(messages.customReportUserNotesLabel)}
                     fieldId="horizontal-form-name"
+                    helperTextInvalid={intl.formatMessage(messages.customReportUserNoteTooLong)}
+                    validated={userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH && 'error'}
                 >
                     <TextArea
                         value={userNotes}
@@ -230,6 +233,7 @@ const ReportConfigModal = ({ isOpen, onClose }) => {
                         id="horizontal-form-name"
                         resizeOrientation='vertical'
                         style={{ minHeight: '4em' }}
+                        validated={userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH && 'error'}
                     />
                 </FormGroup>
             </Form>

--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -8,6 +8,7 @@ import messages from '../../../Messages';
 import firstPagePDF from './Common/firstPagePDF';
 import tablePage from './Common/tablePage';
 import DownloadReport from '../../../Helpers/DownloadReport';
+import { PDF_REPORT_PER_PAGE } from '../../../Helpers/constants';
 
 const DownloadCVEsReport = ({ filters, params, reportData, buttonProps, isReportDynamic = false }) => {
     const intl = useIntl();
@@ -35,10 +36,15 @@ const DownloadCVEsReport = ({ filters, params, reportData, buttonProps, isReport
             }
         }));
 
-        const firstPage = firstPagePDF({ cves: data.slice(0, 13), meta, filters, intl, isReportDynamic, reportData, user });
+        const firstPage = firstPagePDF({
+            cves: data.splice(0, reportData.userNotes
+                ? PDF_REPORT_PER_PAGE.firstPageWithNote
+                : PDF_REPORT_PER_PAGE.firstPageWithoutNote),
+            meta, filters, intl, isReportDynamic, reportData, user
+        });
 
-        const otherPages = data.slice(13, data.length).reduce((resultArray, item, index) => {
-            const chunkIndex = Math.floor(index / 23);
+        const otherPages = data.reduce((resultArray, item, index) => {
+            const chunkIndex = Math.floor(index / PDF_REPORT_PER_PAGE.otherPages);
             !resultArray[chunkIndex] && (resultArray[chunkIndex] = []);
             resultArray[chunkIndex].push(item);
 

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -486,3 +486,11 @@ export const DEFAULT_FILTER_DATA = {
         max: 10.0
     }
 };
+
+export const PDF_REPORT_USER_NOTE_MAX_LENGTH = 1000;
+
+export const PDF_REPORT_PER_PAGE = {
+    firstPageWithNote: 10,
+    firstPageWithoutNote: 15,
+    otherPages: 23
+};

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1304,6 +1304,11 @@ export default defineMessages({
         description: 'Label for textbox to set custom report notes',
         defaultMessage: 'User notes (optional)'
     },
+    customReportUserNoteTooLong: {
+        id: 'customReportUserNoteTooLong',
+        description: 'Error message for user that his note has too many characters to fit',
+        defaultMessage: 'User notes must be less than 1000 characters.'
+    },
     customReportSystemsExposed: {
         id: 'customReportSystemsExposed',
         description: 'Systems exposed filter criterium name',


### PR DESCRIPTION
Fixes [VULN-1231](https://projects.engineering.redhat.com/projects/VULN/issues/VULN-1231).

![error](https://user-images.githubusercontent.com/8426204/92271105-8259ca00-eee7-11ea-942d-14273f800703.png)

### 15 items if no user note
![no-note](https://user-images.githubusercontent.com/8426204/92271109-84238d80-eee7-11ea-90a4-366cfb32b7fd.png)

### 10 items if there is a user note
![yes-note](https://user-images.githubusercontent.com/8426204/92271112-8554ba80-eee7-11ea-820f-84c623662f4b.png)
