### PR TITLE
fix(filters): Fix security rule filter to use checkboxes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -36,7 +36,6 @@
   "customReportNoCves": "No CVEs with selected criteria.",
   "customReportSearchTermCvssAndPublishDate": "This report includes CVEs {hasSearchTerm, select, yes {matching the search term <b>\"{searchTerm}\"</b>;} no {}} with a CVSS base score of <b>{score}</b>; published {published}",
   "customReportSecurityRuleCheckbox": "Security rule indicator",
-  "customReportSecurityRuleDropdown": "Security rule",
   "customReportSystemsExposed": "Count of exposed systems",
   "customReportTimespanAnytime": "<b>anytime</b>",
   "customReportTimespanMoreThanOneYear": "more than <b>1 year ago</b>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3519,9 +3519,9 @@
       }
     },
     "@redhat-cloud-services/vulnerabilities-client": {
-      "version": "1.0.67",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.0.67.tgz",
-      "integrity": "sha512-400IeCD7RmOSQUG68WlNF1pNH0KM0ODh04YKGSTVn3qWjEGhYpIj4VGSbTJqzQYdfiTJddBHMrDZdt5oWJijIg==",
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.0.73.tgz",
+      "integrity": "sha512-5MQqTzKKXsfLwvNb/2tjj9o+z62nAkWHSJX2MNw3igJGQnBkqYUMfGJYvF8YIxtwybU1zM/Mhf65riHFgbagXw==",
       "requires": {
         "axios": "^0.19.2",
         "yaml": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^2.2.0",
     "@redhat-cloud-services/frontend-components-utilities": "^2.1.5",
     "@redhat-cloud-services/insights-client": "^1.0.56",
-    "@redhat-cloud-services/vulnerabilities-client": "^1.0.67",
+    "@redhat-cloud-services/vulnerabilities-client": "^1.0.73",
     "babel-plugin-react-intl": "^7.5.4",
     "classnames": "^2.2.5",
     "marked": "^0.8.2",

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -35,7 +35,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
     const ruleCards = rules.length > numberOfCards && rules.slice(0, numberOfCards) || rules;
 
     const handleExposedSystemFilter = (ruleId) => {
-        const params = { security_rule: ruleId };
+        const params = { rule_key: ruleId };
         dispatch(changeExposedSystemsParameters(params));
     };
 
@@ -127,7 +127,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                             >
                                                 <Link
                                                     key={rule.rule_id}
-                                                    to={`/cves/${synopsis}/?security_rule=${rule.rule_id}`}
+                                                    to={`/cves/${synopsis}/?rule_key=${rule.rule_id}`}
                                                 >
                                                     {intl.formatMessage(messages.filterByAffectedSystems)}
                                                 </Link>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
@@ -293,6 +293,6 @@ describe('CSAW Rule Box', () => {
         const dispatchedActions = store.getActions();
         const action = dispatchedActions.filter(item => item.type === 'CHANGE_SYSTEM_CVE_LIST_PARAMETERS');
         expect(fetchMock).toBeCalledTimes(1)
-        expect(fetchMock).toHaveBeenCalledWith({ security_rule: rules[0].rule_id })
+        expect(fetchMock).toHaveBeenCalledWith({ rule_key: rules[0].rule_id })
     });
 });

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -584,14 +584,14 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                         >
                                           <Link
                                             key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                            to="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                            to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                           >
                                             <LinkAnchor
-                                              href="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                              href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                               navigate={[Function]}
                                             >
                                               <a
-                                                href="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                                href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                                 onClick={[Function]}
                                               >
                                                 Filter by affected systems
@@ -1685,14 +1685,14 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                         >
                                           <Link
                                             key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                            to="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                            to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                           >
                                             <LinkAnchor
-                                              href="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                              href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                               navigate={[Function]}
                                             >
                                               <a
-                                                href="/cves/CVE-2019-11135/?security_rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                                href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                                 onClick={[Function]}
                                               >
                                                 Filter by affected systems

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
@@ -18,8 +18,8 @@ const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
 
     const filterBySecurityRule = values => {
         apply({
-            rule_presence: values.filter(value => value === 'true' || value === 'false').join(','),
-            rule_key: values.filter(value => value !== 'true' && value !== 'false').join(','),
+            rule_presence: values.filter(value => value === 'true' || value === 'false').join(',') || undefined,
+            rule_key: values.filter(value => value !== 'true' && value !== 'false').join(',') || undefined,
             page: 1
         });
     };

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
@@ -7,26 +7,34 @@ import unionWith from 'lodash/unionWith';
 import isEqual from 'lodash/isEqual';
 
 const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
-    let { security_rule: currentValue } = currentFilter;
-    if (currentValue === '' || !currentValue) {
-        currentValue = 'all';
+    let currentValue = [];
+    if (currentFilter.rule_presence) {
+        currentValue = currentValue.concat(currentFilter.rule_presence.split(','));
+    }
+
+    if (currentFilter.rule_key) {
+        currentValue = currentValue.concat(currentFilter.rule_key.split(','));
     }
 
     const filterBySecurityRule = values => {
-        apply({ security_rule: values === 'all' ? '' : values, page: 1 });
+        apply({
+            rule_presence: values.filter(value => value === 'true' || value === 'false').join(','),
+            rule_key: values.filter(value => value !== 'true' && value !== 'false').join(','),
+            page: 1
+        });
     };
 
     return {
         label: intl.formatMessage(messages.securityRules),
-        type: conditionalFilterType.radio,
-        urlParam: 'security_rule',
+        type: conditionalFilterType.checkbox,
         filterValues: {
             onChange: (event, value) => {
                 filterBySecurityRule(value);
             },
             items:
                 unionWith(SECURITY_RULE_OPTIONS, dynamicFilters, isEqual).map(item => ({ label: item.label, value: item.value })),
-            value: currentValue
+            value:
+                currentValue
         }
     };
 };

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
@@ -1,6 +1,6 @@
 
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
-import { SECURITY_RULE_OPTIONS } from '../../../../Helpers/constants';
+import { RULE_PRESENCE_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
 import unionWith from 'lodash/unionWith';
@@ -18,8 +18,8 @@ const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
 
     const filterBySecurityRule = values => {
         apply({
-            rule_presence: values.filter(value => value === 'true' || value === 'false').join(',') || undefined,
-            rule_key: values.filter(value => value !== 'true' && value !== 'false').join(',') || undefined,
+            rule_presence: values.filter(value => ['true', 'false'].includes(value)).join(',') || undefined,
+            rule_key: values.filter(value => !['true', 'false'].includes(value)).join(',') || undefined,
             page: 1
         });
     };
@@ -32,9 +32,8 @@ const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
                 filterBySecurityRule(value);
             },
             items:
-                unionWith(SECURITY_RULE_OPTIONS, dynamicFilters, isEqual).map(item => ({ label: item.label, value: item.value })),
-            value:
-                currentValue
+                unionWith(RULE_PRESENCE_OPTIONS, dynamicFilters, isEqual).map(item => ({ label: item.label, value: item.value })),
+            value: currentValue
         }
     };
 };

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
@@ -5,7 +5,6 @@ describe('SecurityRuleFilter', () => {
 
     it('Should render the security option items', () => {
         const options = [ 
-            { label: 'All', value: 'all' },
             { label: 'Has security rule', value: 'true' },
             { label: 'Does not have security rule', value: 'false' }
         ]
@@ -22,7 +21,6 @@ describe('SecurityRuleFilter', () => {
 
         ]
         const options = [ 
-            { label: 'All', value: 'all' },
             { label: 'Has security rule', value: 'true' },
             { label: 'Does not have security rule', value: 'false' },
             { label: 'security rule 1', value: '1' },
@@ -35,29 +33,32 @@ describe('SecurityRuleFilter', () => {
 
     it('Should use default currentValue all', () => {
         let comp = securityRuleFilter(applyMock, '')
-        expect(comp.filterValues.value).toBe('all')
+        expect(comp.filterValues.value).toMatchObject([])
 
         comp = securityRuleFilter(applyMock, undefined)
-        expect(comp.filterValues.value).toBe('all')
+        expect(comp.filterValues.value).toMatchObject([])
 
         comp = securityRuleFilter(applyMock, '5')
-        expect(comp.filterValues.value).toBe('all')
+        expect(comp.filterValues.value).toMatchObject([])
+
+        comp = securityRuleFilter(applyMock, {rule_presence: 'true', rule_key: 'some_rule'})
+        expect(comp.filterValues.value).toMatchObject(['true', 'some_rule'])
 
     })
 
     it('Should use the passed currentValue ', () => {
-        let currentFilter = { security_rule: 'last7' }
+        let currentFilter = { rule_presence: 'true', rule_key: 'some_rule' }
         let comp = securityRuleFilter(applyMock, currentFilter)
-        expect(comp.filterValues.value).toBe('last7')
+        expect(comp.filterValues.value).toMatchObject(['true', 'some_rule'])
     })
 
     it('Should call apply with params', () => {
-        let comp = securityRuleFilter(applyMock, '1')
-        comp.filterValues.onChange('event', 'all')
-        expect(applyMock).toBeCalledWith({"page": 1, "security_rule": ""})
+        let comp = securityRuleFilter(applyMock, undefined)
+        comp.filterValues.onChange('event', ['true', 'some_rule'])
+        expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "true", "rule_key": "some_rule"})
 
-        comp.filterValues.onChange('event', '')
-        expect(applyMock).toBeCalledWith({"page": 1, "security_rule": ""})
+        comp.filterValues.onChange('event', [])
+        expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "", "rule_key": ""})
 
     })
 

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
@@ -58,8 +58,6 @@ describe('SecurityRuleFilter', () => {
         expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "true", "rule_key": "some_rule"})
 
         comp.filterValues.onChange('event', [])
-        expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "", "rule_key": ""})
-
+        expect(applyMock).toBeCalledWith({"page": 1})
     })
-
 })

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -344,10 +344,6 @@ exports[`CVEs Should render without props 1`] = `
                                 "filterValues": Object {
                                   "items": Array [
                                     Object {
-                                      "label": "All",
-                                      "value": "all",
-                                    },
-                                    Object {
                                       "label": "Has security rule",
                                       "value": "true",
                                     },
@@ -357,11 +353,10 @@ exports[`CVEs Should render without props 1`] = `
                                     },
                                   ],
                                   "onChange": [Function],
-                                  "value": "all",
+                                  "value": Array [],
                                 },
                                 "label": "Security rules",
-                                "type": "radio",
-                                "urlParam": "security_rule",
+                                "type": "checkbox",
                               },
                               Object {
                                 "filterValues": Object {
@@ -999,10 +994,6 @@ exports[`CVEs Should render without props 1`] = `
                                                     "filterValues": Object {
                                                       "items": Array [
                                                         Object {
-                                                          "label": "All",
-                                                          "value": "all",
-                                                        },
-                                                        Object {
                                                           "label": "Has security rule",
                                                           "value": "true",
                                                         },
@@ -1012,11 +1003,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         },
                                                       ],
                                                       "onChange": [Function],
-                                                      "value": "all",
+                                                      "value": Array [],
                                                     },
                                                     "label": "Security rules",
-                                                    "type": "radio",
-                                                    "urlParam": "security_rule",
+                                                    "type": "checkbox",
                                                   },
                                                   Object {
                                                     "filterValues": Object {

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
@@ -240,10 +240,6 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                 "filterValues": Object {
                   "items": Array [
                     Object {
-                      "label": "All",
-                      "value": "all",
-                    },
-                    Object {
                       "label": "Has security rule",
                       "value": "true",
                     },
@@ -253,11 +249,10 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                     },
                   ],
                   "onChange": [Function],
-                  "value": "all",
+                  "value": Array [],
                 },
                 "label": "Security rules",
-                "type": "radio",
-                "urlParam": "security_rule",
+                "type": "checkbox",
               },
               Object {
                 "filterValues": Object {
@@ -895,10 +890,6 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                                     "filterValues": Object {
                                       "items": Array [
                                         Object {
-                                          "label": "All",
-                                          "value": "all",
-                                        },
-                                        Object {
                                           "label": "Has security rule",
                                           "value": "true",
                                         },
@@ -908,11 +899,10 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                                         },
                                       ],
                                       "onChange": [Function],
-                                      "value": "all",
+                                      "value": Array [],
                                     },
                                     "label": "Security rules",
-                                    "type": "radio",
-                                    "urlParam": "security_rule",
+                                    "type": "checkbox",
                                   },
                                   Object {
                                     "filterValues": Object {

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -138,7 +138,7 @@ const ReportConfigModal = ({ isOpen, onClose }) => {
                         label={intl.formatMessage(messages.customOnlyCvesWithRulesLabel)}
                         isChecked={filterData.security_rule === 'true'}
                         onChange={(newValue) =>
-                            setFilterData({ ...filterData, security_rule: newValue ? 'true' : 'all' })
+                            setFilterData({ ...filterData, security_rule: newValue ? 'true' : 'true,false' })
                         }
                         className="pf-u-mt-md"
                     />

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -138,7 +138,7 @@ const ReportConfigModal = ({ isOpen, onClose }) => {
                         label={intl.formatMessage(messages.customOnlyCvesWithRulesLabel)}
                         isChecked={filterData.security_rule === 'true'}
                         onChange={(newValue) =>
-                            setFilterData({ ...filterData, security_rule: newValue ? 'true' : 'true,false' })
+                            setFilterData({ ...filterData, security_rule: newValue ? 'true' : undefined })
                         }
                         className="pf-u-mt-md"
                     />

--- a/src/Components/SmartComponents/Reports/ReportsHelper.js
+++ b/src/Components/SmartComponents/Reports/ReportsHelper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FILTERS, PUBLIC_DATE_OPTIONS, SECURITY_RULE_OPTIONS, DEFAULT_FILTER_DATA } from '../../../Helpers/constants';
+import { FILTERS, PUBLIC_DATE_OPTIONS, RULE_PRESENCE_OPTIONS, DEFAULT_FILTER_DATA } from '../../../Helpers/constants';
 import { formatDate } from '../../../Helpers/MiscHelper';
 import { intl } from '../../../Utilities/IntlProvider';
 import { Text } from '@react-pdf/renderer';
@@ -34,7 +34,7 @@ export const buildFilters = filterData => {
                 break;
 
             case 'security_rule':
-                newValues[key].values = SECURITY_RULE_OPTIONS.find(val => val.value === value).label;
+                newValues[key].values = RULE_PRESENCE_OPTIONS.find(val => val.value === value).label;
                 break;
 
             case 'cvss_filter':

--- a/src/Components/SmartComponents/Reports/ReportsHelper.js
+++ b/src/Components/SmartComponents/Reports/ReportsHelper.js
@@ -70,7 +70,7 @@ export function constructFilterParameters(filterParams) {
         publish_date: filterParams.publish_date,
         public_from: from,
         public_to: to,
-        security_rule: filterParams.security_rule === 'all' ? undefined : filterParams.security_rule
+        rule_presence: filterParams.security_rule
     };
 
     return newParams;

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -396,7 +396,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                             "public_from": undefined,
                             "public_to": undefined,
                             "publish_date": "all",
-                            "security_rule": undefined,
+                            "rule_presence": "true,false",
                             "status_id": "",
                           }
                         }
@@ -473,7 +473,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                                 "public_from": undefined,
                                 "public_to": undefined,
                                 "publish_date": "all",
-                                "security_rule": undefined,
+                                "rule_presence": "true,false",
                                 "status_id": "",
                               }
                             }

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -396,7 +396,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                             "public_from": undefined,
                             "public_to": undefined,
                             "publish_date": "all",
-                            "rule_presence": "true,false",
+                            "rule_presence": undefined,
                             "status_id": "",
                           }
                         }
@@ -473,7 +473,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                                 "public_from": undefined,
                                 "public_to": undefined,
                                 "publish_date": "all",
-                                "rule_presence": "true,false",
+                                "rule_presence": undefined,
                                 "status_id": "",
                               }
                             }

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -498,10 +498,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                     "filterValues": Object {
                                       "items": Array [
                                         Object {
-                                          "label": "All",
-                                          "value": "all",
-                                        },
-                                        Object {
                                           "label": "Has security rule",
                                           "value": "true",
                                         },
@@ -511,11 +507,10 @@ exports[`SystemCves Should match snapshots 1`] = `
                                         },
                                       ],
                                       "onChange": [Function],
-                                      "value": "all",
+                                      "value": Array [],
                                     },
                                     "label": "Security rules",
-                                    "type": "radio",
-                                    "urlParam": "security_rule",
+                                    "type": "checkbox",
                                   },
                                   Object {
                                     "filterValues": Object {
@@ -1153,10 +1148,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         "filterValues": Object {
                                                           "items": Array [
                                                             Object {
-                                                              "label": "All",
-                                                              "value": "all",
-                                                            },
-                                                            Object {
                                                               "label": "Has security rule",
                                                               "value": "true",
                                                             },
@@ -1166,11 +1157,10 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                             },
                                                           ],
                                                           "onChange": [Function],
-                                                          "value": "all",
+                                                          "value": Array [],
                                                         },
                                                         "label": "Security rules",
-                                                        "type": "radio",
-                                                        "urlParam": "security_rule",
+                                                        "type": "checkbox",
                                                       },
                                                       Object {
                                                         "filterValues": Object {

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -348,10 +348,6 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                 "filterValues": Object {
                   "items": Array [
                     Object {
-                      "label": "All",
-                      "value": "all",
-                    },
-                    Object {
                       "label": "Has security rule",
                       "value": "true",
                     },
@@ -361,11 +357,10 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                     },
                   ],
                   "onChange": [Function],
-                  "value": "all",
+                  "value": Array [],
                 },
                 "label": "Security rules",
-                "type": "radio",
-                "urlParam": "security_rule",
+                "type": "checkbox",
               },
               Object {
                 "filterValues": Object {
@@ -1002,10 +997,6 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                     "filterValues": Object {
                                       "items": Array [
                                         Object {
-                                          "label": "All",
-                                          "value": "all",
-                                        },
-                                        Object {
                                           "label": "Has security rule",
                                           "value": "true",
                                         },
@@ -1015,11 +1006,10 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                         },
                                       ],
                                       "onChange": [Function],
-                                      "value": "all",
+                                      "value": Array [],
                                     },
                                     "label": "Security rules",
-                                    "type": "radio",
-                                    "urlParam": "security_rule",
+                                    "type": "checkbox",
                                   },
                                   Object {
                                     "filterValues": Object {

--- a/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
+++ b/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
@@ -496,10 +496,6 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                           "filterValues": Object {
                                             "items": Array [
                                               Object {
-                                                "label": "All",
-                                                "value": "all",
-                                              },
-                                              Object {
                                                 "label": "Has security rule",
                                                 "value": "true",
                                               },
@@ -509,11 +505,10 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                               },
                                             ],
                                             "onChange": [Function],
-                                            "value": "all",
+                                            "value": Array [],
                                           },
                                           "label": "Security rules",
-                                          "type": "radio",
-                                          "urlParam": "security_rule",
+                                          "type": "checkbox",
                                         },
                                         Object {
                                           "filterValues": Object {
@@ -1151,10 +1146,6 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                               "filterValues": Object {
                                                                 "items": Array [
                                                                   Object {
-                                                                    "label": "All",
-                                                                    "value": "all",
-                                                                  },
-                                                                  Object {
                                                                     "label": "Has security rule",
                                                                     "value": "true",
                                                                   },
@@ -1164,11 +1155,10 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                                   },
                                                                 ],
                                                                 "onChange": [Function],
-                                                                "value": "all",
+                                                                "value": Array [],
                                                               },
                                                               "label": "Security rules",
-                                                              "type": "radio",
-                                                              "urlParam": "security_rule",
+                                                              "type": "checkbox",
                                                             },
                                                             Object {
                                                               "filterValues": Object {

--- a/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
@@ -316,10 +316,6 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                               "filterValues": Object {
                                 "items": Array [
                                   Object {
-                                    "label": "All",
-                                    "value": "all",
-                                  },
-                                  Object {
                                     "label": "Has security rule",
                                     "value": "true",
                                   },
@@ -333,11 +329,10 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                   },
                                 ],
                                 "onChange": [Function],
-                                "value": "all",
+                                "value": Array [],
                               },
                               "label": "Security rules",
-                              "type": "radio",
-                              "urlParam": "security_rule",
+                              "type": "checkbox",
                             },
                             Object {
                               "filterValues": Object {

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -1,4 +1,4 @@
-let BASE_ROUTE = '/api/vulnerability/';
+let BASE_ROUTE = '/api/vulnerability/v1';
 import { GitApi } from '@redhat-cloud-services/vulnerabilities-client';
 import instance from '../Utilities/interceptors';
 import { constructParameters } from './MiscHelper';
@@ -25,8 +25,11 @@ export function getAffectedSystemsByCVE(synopsis, apiProps) {
         'sort',
         'status_id',
         'data_format',
-        'security_rule',
-        'rule_name'
+        'uuid',
+        'rule_key',
+        'rule_presence',
+        'tags',
+        'security_rule'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
     let result = api.getAffectedSystemsByCve(synopsis, ...parameterArray);
@@ -34,7 +37,19 @@ export function getAffectedSystemsByCVE(synopsis, apiProps) {
 }
 
 export function getSystems(apiProps) {
-    let parameterNames = ['filter', 'limit', 'offset', 'page', 'page_size', 'sort', 'data_format', 'stale', 'uuid', 'opt_out'];
+    let parameterNames = [
+        'filter',
+        'limit',
+        'offset',
+        'page',
+        'page_size',
+        'sort',
+        'data_format',
+        'stale',
+        'uuid',
+        'tags',
+        'opt_out'
+    ];
     let parameterArray = constructParameters(apiProps, parameterNames);
     let result = api.getSystemsList(...parameterArray);
     return result;
@@ -57,6 +72,7 @@ export function getCveListByAccount(apiProps) {
         'business_risk_id',
         'status_id',
         'security_rule',
+        'rule_presence',
         'show_all'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -48,6 +48,7 @@ export function getSystems(apiProps) {
         'stale',
         'uuid',
         'tags',
+        'sap_system',
         'opt_out'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
@@ -102,7 +103,8 @@ export function getCveListBySystem(apiProps) {
         'status_id',
         'data_format',
         'business_risk_id',
-        'security_rule'
+        'security_rule',
+        'rule_presence'
     ];
     if (apiProps && system) {
         Object.keys(apiProps).forEach(key => (apiProps[key] === undefined || apiProps[key] === '') && delete apiProps[key]);
@@ -154,6 +156,8 @@ export function getAffectedSystemsIdsByCve(synopsis, apiProps) {
         'sort',
         'status_id',
         'data_format',
+        'rule_key',
+        'rule_presence',
         'security_rule'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
@@ -185,6 +189,7 @@ export function getCveIdsList(apiProps) {
         'business_risk_id',
         'status_id',
         'security_rule',
+        'rule_presence',
         'show_all'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
@@ -209,7 +214,8 @@ export function getCveIdsBySystem(apiProps) {
         'status_id',
         'data_format',
         'business_risk_id',
-        'security_rule'
+        'security_rule',
+        'rule_presence'
     ];
     if (apiProps && system) {
         Object.keys(apiProps).forEach(key => (apiProps[key] === undefined || apiProps[key] === '') && delete apiProps[key]);

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -2,8 +2,6 @@ import messages from '../Messages';
 import { FILTERS } from './constants';
 import { intl } from '../Utilities/IntlProvider';
 
-const concatArrays = (...arrays) => [].concat(...arrays.filter(a => a !== undefined && a !== '')); // concat possibly empty arrays
-
 export const handleChangePage = (_event, page, apply) => apply({ page });
 
 export const handleSetPageSize = (_event, perPage, apply) => apply({ page_size: perPage, page: 1 });
@@ -46,9 +44,9 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
     const filterChips = Object.keys(FILTERS).reduce((array, key) => {
         if (key === 'security_rule'
             && (!['', undefined].includes(currentFilters.rule_presence) || !['', undefined].includes(currentFilters.rule_key))) {
-            const multiValue = concatArrays(
-                currentFilters.rule_presence && currentFilters.rule_presence.split(','),
-                currentFilters.rule_key && currentFilters.rule_key.split(','));
+            const multiValue = [].concat(
+                currentFilters.rule_presence ? currentFilters.rule_presence.split(',') : [],
+                currentFilters.rule_key ? currentFilters.rule_key.split(',') : []);
             array.push({ key, multiValue, category: FILTERS[key].title, chips: buildChips(multiValue, key) });
         }
         else if (key !== 'show_all' && Object.keys(currentFilters).includes(key)
@@ -77,10 +75,9 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
 export const removeFilters = (chips, apply) => {
     const emptyFilter = chips.reduce((obj, item) => {
         if (item.key === 'security_rule') {
-            obj.rule_presence = item.multiValue.filter(value =>
-                !item.chips.some(chip => chip.value === value) && ['true', 'false'].includes(value)).join(',') || '';
-            obj.rule_key = item.multiValue.filter(value =>
-                !item.chips.some(chip => chip.value === value) && !['true', 'false'].includes(value)).join(',') || '';
+            const remainingValues = item.multiValue.filter(value => !item.chips.some(chip => chip.value === value));
+            obj.rule_presence = remainingValues.filter(value => ['true', 'false'].includes(value)).join(',') || '';
+            obj.rule_key = remainingValues.filter(value => !['true', 'false'].includes(value)).join(',') || '';
         }
         else if (item.key === 'filter' || (item.multiValue && item.multiValue.length === 1)) {
             obj[item.key] = '';

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -2,28 +2,33 @@ import messages from '../Messages';
 import { FILTERS } from './constants';
 import { intl } from '../Utilities/IntlProvider';
 
+const concatArrays = (...arrays) => [].concat(...arrays.filter(a => a !== undefined && a !== '')); // concat possibly empty arrays
+
 export const handleChangePage = (_event, page, apply) => apply({ page });
 
 export const handleSetPageSize = (_event, perPage, apply) => apply({ page_size: perPage, page: 1 });
 
 export const exportConfig = (methods) => (
-    { onSelect: (_event, fileType) =>   methods.downloadReport(fileType) }
+    { onSelect: (_event, fileType) => methods.downloadReport(fileType) }
 );
 
-export const buildActiveFilters = (currentFilters, filterRulevalues = []) => {
-
+export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
     const { filter } = currentFilters;
 
     const buildChip = (key, parameter) => (
         FILTERS[key].items.reduce((object, item) => {
             if (parameter === item.value) {
                 object.name = item.label;
-                object.value = item.value ;
+                object.value = item.value;
             }
-            else if (key === 'security_rule' && !['true', 'false'].includes(parameter))
+            else if (key === 'security_rule')
             {
-                const filteredRule = filterRulevalues.find(({ value }) => value === parameter);
-                object.name = filteredRule && filteredRule.label || parameter ;
+                const filteredRule = filterRuleValues.find(({ value }) => value === parameter);
+
+                ['true', 'false'].includes(parameter)
+                    ? object.name = FILTERS.security_rule.items.find(e => e.value === parameter).label
+                    : object.name = filteredRule && filteredRule.label || parameter;
+
                 object.value = parameter;
             }
 
@@ -39,12 +44,19 @@ export const buildActiveFilters = (currentFilters, filterRulevalues = []) => {
     };
 
     const filterChips = Object.keys(FILTERS).reduce((array, key) => {
-        if (key !== 'show_all' && Object.keys(currentFilters).includes(key) && !['', undefined].includes(currentFilters[key])) {
-
+        if (key === 'security_rule'
+            && (!['', undefined].includes(currentFilters.rule_presence) || !['', undefined].includes(currentFilters.rule_key))) {
+            const multiValue = concatArrays(
+                currentFilters.rule_presence && currentFilters.rule_presence.split(','),
+                currentFilters.rule_key && currentFilters.rule_key.split(','));
+            array.push({ key, multiValue, category: FILTERS[key].title, chips: buildChips(multiValue, key) });
+        }
+        else if (key !== 'show_all' && Object.keys(currentFilters).includes(key)
+            && !['', undefined].includes(currentFilters[key])) {
             const multiValue = typeof currentFilters[key] === 'string' && currentFilters[key].split(',');
             const filteredValues = (multiValue && multiValue.length > 1)
-                                            && buildChips(multiValue, key)
-                                            || [buildChip(key, currentFilters[key])];
+                && buildChips(multiValue, key)
+                || [buildChip(key, currentFilters[key])];
 
             array.push({ key, multiValue, category: FILTERS[key].title, chips: filteredValues });
         }
@@ -62,9 +74,15 @@ export const buildActiveFilters = (currentFilters, filterRulevalues = []) => {
     return filterChips;
 };
 
-export const removeFilters = (chips, apply) =>{
-    const emptyFilter = chips.reduce((obj, item) =>{
-        if (item.key === 'filter' || (item.multiValue && item.multiValue.length === 1)) {
+export const removeFilters = (chips, apply) => {
+    const emptyFilter = chips.reduce((obj, item) => {
+        if (item.key === 'security_rule') {
+            obj.rule_presence = item.multiValue.filter(value =>
+                !item.chips.some(chip => chip.value === value) && ['true', 'false'].includes(value)).join(',') || '';
+            obj.rule_key = item.multiValue.filter(value =>
+                !item.chips.some(chip => chip.value === value) && !['true', 'false'].includes(value)).join(',') || '';
+        }
+        else if (item.key === 'filter' || (item.multiValue && item.multiValue.length === 1)) {
             obj[item.key] = '';
         }
         else {

--- a/src/Helpers/TableToolbarHelper.test.js
+++ b/src/Helpers/TableToolbarHelper.test.js
@@ -7,7 +7,7 @@ import {
 } from './TableToolbarHelper';
 
 const mockGeneralFilters = {
-    security_rule: "true",
+    rule_presence: "true",
     show_all: "true",
     sort: "-public_date",
 };
@@ -149,7 +149,7 @@ describe('TableToolbarHelper', () => {
 
     it('Should remove filters', () => {
         removeFilters([mockGeneralChip], mockApply);
-        expect(mockApply).toHaveBeenCalledWith({ security_rule: '' });
+        expect(mockApply).toHaveBeenCalledWith({ rule_presence: '', rule_key: '' });
     });
 
     it('Should remove search filters and multi value filters with only one value safely', () => {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -254,7 +254,6 @@ export const FILTERS = {
     security_rule: {
         title: intl.formatMessage(messages.securityRules),
         items: SECURITY_RULE_OPTIONS.map(item => ({ ...item })),
-        dropdownOverrideTitle: intl.formatMessage(messages.customReportSecurityRuleDropdown),
         checkboxOverrideTitle: intl.formatMessage(messages.customReportSecurityRuleCheckbox)
     }
 };
@@ -460,7 +459,6 @@ export const CVES_ALLOWED_PARAMS = [
     'impact',
     'business_risk_id',
     'status_id',
-    'security_rule',
     'rule_presence'
 ];
 
@@ -469,7 +467,6 @@ export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = [
     'page',
     'page_size',
     'status_id',
-    'security_rule',
     'sort',
     'tags',
     'uuid',
@@ -491,7 +488,7 @@ export const DEFAULT_FILTER_DATA = {
     status_id: [],
     impact: [],
     publish_date: 'all',
-    security_rule: 'all',
+    security_rule: 'true,false',
     cvss_filter: {
         min: 0.0,
         max: 10.0

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -99,7 +99,6 @@ export const ReadOnlyNotification = {
 };
 
 export const SECURITY_RULE_OPTIONS = [
-    { value: 'all', label: intl.formatMessage(messages.optionsAll) },
     { value: 'true', label: intl.formatMessage(messages.withSecurityRule) },
     { value: 'false', label: intl.formatMessage(messages.withoutSecurityRule) }
 ];
@@ -461,10 +460,22 @@ export const CVES_ALLOWED_PARAMS = [
     'impact',
     'business_risk_id',
     'status_id',
-    'security_rule'
+    'security_rule',
+    'rule_presence'
 ];
 
-export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = ['filter', 'page', 'page_size', 'status_id', 'security_rule', 'sort'];
+export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = [
+    'filter',
+    'page',
+    'page_size',
+    'status_id',
+    'security_rule',
+    'sort',
+    'tags',
+    'uuid',
+    'rule_key',
+    'rule_presence'
+];
 
 export const SYSTEMS_ALLOWED_PARAMS = ['filter', 'page', 'page_size', 'opt_out', 'sort'];
 

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -98,7 +98,7 @@ export const ReadOnlyNotification = {
     detail: intl.formatMessage(messages.readOnlyNotificationBody)
 };
 
-export const SECURITY_RULE_OPTIONS = [
+export const RULE_PRESENCE_OPTIONS = [
     { value: 'true', label: intl.formatMessage(messages.withSecurityRule) },
     { value: 'false', label: intl.formatMessage(messages.withoutSecurityRule) }
 ];
@@ -253,7 +253,7 @@ export const FILTERS = {
     },
     security_rule: {
         title: intl.formatMessage(messages.securityRules),
-        items: SECURITY_RULE_OPTIONS.map(item => ({ ...item })),
+        items: RULE_PRESENCE_OPTIONS.map(item => ({ ...item })),
         checkboxOverrideTitle: intl.formatMessage(messages.customReportSecurityRuleCheckbox)
     }
 };
@@ -488,7 +488,7 @@ export const DEFAULT_FILTER_DATA = {
     status_id: [],
     impact: [],
     publish_date: 'all',
-    security_rule: 'true,false',
+    security_rule: undefined,
     cvss_filter: {
         min: 0.0,
         max: 10.0

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1329,11 +1329,6 @@ export default defineMessages({
         description: 'Systems exposed filter criterium name',
         defaultMessage: 'Count of exposed systems'
     },
-    customReportSecurityRuleDropdown: {
-        id: 'customReportSecurityRuleDropdown',
-        description: 'Security rule filter criterium name inside dropdown',
-        defaultMessage: 'Security rule'
-    },
     customReportSecurityRuleCheckbox: {
         id: 'customReportSecurityRuleCheckbox',
         description: 'Security rule filter criterium name inside checkbox',

--- a/src/Store/Reducers/CVEDetailsPageStore.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.js
@@ -18,7 +18,7 @@ export const initialState = Immutable({
         page: 1,
         page_size: 20,
         selectedHosts: [],
-        security_rule: undefined,
+        rule_presence: undefined,
         status_id: undefined
     },
     cveDetails: {

--- a/src/Store/Reducers/CVEDetailsPageStore.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.js
@@ -18,7 +18,6 @@ export const initialState = Immutable({
         page: 1,
         page_size: 20,
         selectedHosts: [],
-        rule_presence: undefined,
         status_id: undefined
     },
     cveDetails: {


### PR DESCRIPTION
Fixes [VULN-909](https://issues.redhat.com/projects/VULN/issues/VULN-909).
Removes uses of `security_rule` API param to unblock [VULN-1267](https://issues.redhat.com/projects/VULN/issues/VULN-1267).
SecurityRuleFilter component test coverage stays 100%.