### PR TITLE
fix: use display name for sotring on systems exposed page

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -471,7 +471,7 @@ export const SYSTEMS_ALLOWED_PARAMS = ['filter', 'page', 'page_size', 'opt_out',
 export const SYSTEMS_SORTING_HEADER = [{ key: 'empty' }, { key: 'display_name' }, { key: 'cve_count' }, { key: 'last_upload' }];
 
 export const SYSTEMS_EXPOSED_SORTING_HEADER =
-    [{ key: 'empty' }, { key: 'empty' }, { key: 'inventory_id' }, { key: 'status' }, { key: 'last_upload' }];
+    [{ key: 'empty' }, { key: 'empty' }, { key: 'display_name' }, { key: 'status' }, { key: 'last_upload' }];
 
 export const TRUNCATE_TEXT_THRESHOLD = 230;
 


### PR DESCRIPTION
Has to be merged after https://github.com/RedHatInsights/vulnerability-engine/pull/752 is merged for functionality.