### PR TITLE
feat(systems): set systems table to full view

### DIFF
--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -219,6 +219,7 @@ const SystemsPage = ({ intl }) => {
                             onSort: (items.length > 0) && onSort,
                             sortBy: (items.length > 0) && sortBy()
                         }}
+                        isFullView
                         ref={inventory}
                         items={items}
                         page={metadata && metadata.page || 1 }


### PR DESCRIPTION
### Inventory full view [1]

In order to show proper RBAC state in systems table we need to pass `fullView` prop to inventory component. This applies only to systems page as it's only place where inventory table is just one component on screen. Without this prop the `unAuthorized` component would be in table, which is not correct based on our mocks.

[1] https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/inventory.md#using-rbac-with-inventory