### PR TITLE
Fix UMD imports in FCE packages.

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
@@ -4,7 +4,7 @@ import marked from 'marked';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import sanitizeHtml from 'sanitize-html';
-import { Truncate } from '@redhat-cloud-services/frontend-components/components/Truncate';
+import { Truncate } from '@redhat-cloud-services/frontend-components/components/cjs/Truncate';
 import { Stack, StackItem, TextContent } from '@patternfly/react-core';
 import { handleCVELink } from '../../../Helpers/VulnerabilityHelper';
 import { TRUNCATE_TEXT_THRESHOLD } from '../../../Helpers/constants';

--- a/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
+++ b/src/Components/PresentationalComponents/CVEPageDetailsSeverity/CVEPageDetailsSeverity.js
@@ -1,6 +1,6 @@
 import { Popover, Stack, StackItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { parseCvssScore } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { parseCvssScore } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import propTypes from 'prop-types';
 import React from 'react';
 import { getImpactDetails } from '../../../Helpers/MiscHelper';

--- a/src/Components/SmartComponents/Reports/Common/tablePage.js
+++ b/src/Components/SmartComponents/Reports/Common/tablePage.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, Link } from '@react-pdf/renderer';
 import { Table, CSAwIcon } from '@redhat-cloud-services/frontend-components-pdf-generator';
-import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import { CVES_PATH } from '../../../../Helpers/constants';
 import messages from '../../../../Messages';
 import styles from './styles';

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -1,6 +1,6 @@
 import { Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, ServerAltIcon } from '@patternfly/react-icons';
-import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import React from 'react';
 import { BUSINESS_RISK_OPTIONS, STATUS_OPTIONS } from './constants';
 import { FormattedMessage } from 'react-intl';

--- a/src/Helpers/CVEHelper.test.js
+++ b/src/Helpers/CVEHelper.test.js
@@ -1,5 +1,5 @@
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { processDate } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import Immutable from 'seamless-immutable';
 import { 
     createCveDetailsPage, 

--- a/src/Helpers/DownloadReport.js
+++ b/src/Helpers/DownloadReport.js
@@ -1,4 +1,4 @@
-import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 
 class DownloadReport  {
     constructor() {

--- a/src/Helpers/DownloadReport.test.js
+++ b/src/Helpers/DownloadReport.test.js
@@ -1,6 +1,6 @@
 import DownloadReport from './DownloadReport'
-jest.mock('@redhat-cloud-services/frontend-components-utilities/files/helpers');
-import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+jest.mock('@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers');
+import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 
 let defaultParams;
 

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -1,7 +1,7 @@
 import { Tooltip, Split, SplitItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Shield } from '@redhat-cloud-services/frontend-components';
-import { parseCvssScore, processDate } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { parseCvssScore, processDate } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import { flatMap } from 'lodash';
 import React from 'react';
 import { Link } from 'react-router-dom';

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -6,7 +6,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ReducerRegistry from './Utilities/ReducerRegistry';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import messages from '../locales/en.json';
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -6,7 +6,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ReducerRegistry from './Utilities/ReducerRegistry';
 import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import messages from '../locales/en.json';
 


### PR DESCRIPTION
This is a part of a larger effort to remove PF background images from chrome build. Old imports were referencing UMD versions of FCE packages which indirectly leads to importing the whole "@patternfly/react-core" package and that injects PF about modal background images to chrome build. And those are pretty big.

cc @jiridostal @katerinapat can you please verify that this does not introduce any bugs?