### PR TITLE
fix(Reports): Align chart pie icon and fix missing newline

### DIFF
--- a/src/Components/SmartComponents/Reports/Common/firstPagePDF.js
+++ b/src/Components/SmartComponents/Reports/Common/firstPagePDF.js
@@ -65,7 +65,7 @@ const firstPagePDF = ({ data, meta, filters, intl, isReportDynamic, reportData, 
             {
                 isReportDynamic && (
                     <Paragraph>
-                        {intl.formatMessage(messages.customReportIntroductionText)}
+                        {formatWithBold(messages.customReportIntroductionText)}
                     </Paragraph>
                 )
             }

--- a/src/Components/SmartComponents/Reports/Common/styles.js
+++ b/src/Components/SmartComponents/Reports/Common/styles.js
@@ -6,10 +6,17 @@ import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200'
 
 export default StyleSheet.create({
     bold: {
-        fontWeight: 700
+        fontWeight: global_FontWeight_bold.value
     },
     italic: {
         fontStyle: 'italic'
+    },
+
+    pieChartIcon: {
+        verticalAlign: '-0.25rem'
+    },
+    cardTitle: {
+        verticalAlign: '0.3rem'
     },
 
     userNotes: {

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -8,6 +8,7 @@ import ReportConfigModal from '../Modals/ReportConfigModal';
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';
 import { ChartPieSolid } from '../../PresentationalComponents/CustomIcons/CustomIcons';
+import styles from './Common/styles';
 
 const ReportsPage = () => {
     const [isModalOpen, setModalOpen] = useState(false);
@@ -20,8 +21,8 @@ const ReportsPage = () => {
                     <GridItem span={3}>
                         <Card>
                             <CardTitle>
-                                <ChartPieSolid />
-                                <span className="pf-u-ml-sm" style={{ verticalAlign: '0.3rem' }}>
+                                <ChartPieSolid style={styles.pieChartIcon}/>
+                                <span className="pf-u-ml-sm" style={styles.cardTitle}>
                                     {intl.formatMessage(messages.executiveReportCardTitle)}
                                 </span>
                             </CardTitle>
@@ -37,7 +38,7 @@ const ReportsPage = () => {
                         <Card>
                             <CardTitle>
                                 <FileAltIcon size="lg" color="var(--pf-global--link--Color)"/>
-                                <span className="pf-u-ml-sm" style={{ verticalAlign: '0.3rem' }}>
+                                <span className="pf-u-ml-sm" style={styles.cardTitle}>
                                     {intl.formatMessage(messages.customReportCardTitle)}
                                 </span>
                             </CardTitle>

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -190,10 +190,21 @@ exports[`Reports page component Should match snapshots 1`] = `
                                   <div
                                     className="pf-c-card__title"
                                   >
-                                    <ChartPieSolid>
+                                    <ChartPieSolid
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.25rem",
+                                        }
+                                      }
+                                    >
                                       <img
                                         alt="Static pie solid"
                                         src="test-file-stub"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.25rem",
+                                          }
+                                        }
                                       />
                                     </ChartPieSolid>
                                     <span


### PR DESCRIPTION
## New icon alignment:
![align](https://user-images.githubusercontent.com/8426204/94866451-a99cac00-043f-11eb-80d2-d4356ecb22e2.png)

## Old icon alignment:
![misaling](https://user-images.githubusercontent.com/8426204/94866577-ef597480-043f-11eb-88af-a73bbcb8fcff.png)

## Also newline was missing between first and second line, fixed:
![newline](https://user-images.githubusercontent.com/8426204/94866484-bb7e4f00-043f-11eb-952b-35210c60b934.png)


