### PR TITLE
fix(global filter): when consuming global filter no need to pass scope

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,13 +52,12 @@ const App = ({ history, location }) => {
     }, [appNavClick]);
 
     useEffect(() => {
-        insights?.chrome?.globalFilterScope?.('vulnerability');
         insights?.chrome?.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
-            const encodedTags = insights?.chrome?.mapGlobalFilter?.(data, true).filter(item => !item.includes('Workloads'));
+            const [workloads, SID, tags] = insights?.chrome?.mapGlobalFilter?.(data, true, true);
             const sapSystem = {
-                sap_system: data?.Workloads?.SAP?.isSelected
+                sap_system: workloads?.SAP?.isSelected
             };
-            dispatch(setGlobalFilter({ tags: encodedTags, ...sapSystem, page: 1 }));
+            dispatch(setGlobalFilter({ tags, ...sapSystem, SID, page: 1 }));
         });
 
     }, []);


### PR DESCRIPTION
No need to use `globalFilterScope` as this is meant to fetch tags, SIDs and workloads for `registered_with` parameter. Also use newer way of consuming global filter data, if we pass 3rd parameter to `mapGlobalFilter` it will automatically group workloads, SID and tags to specific groups so we don't have to filter out certain parts of it.