### PR TITLE
fix(CVE tables): Fixed table stretching when expanding description

### DIFF
--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -4955,7 +4955,7 @@ exports[`CVEs Should render without props 1`] = `
                                         </HeaderCell>
                                         <HeaderCell
                                           aria-sort="none"
-                                          className="pf-c-table__sort pf-m-nowrap"
+                                          className="pf-c-table__sort pf-m-wrap"
                                           data-key={2}
                                           data-label="CVE ID"
                                           key="2-header"
@@ -4963,7 +4963,7 @@ exports[`CVEs Should render without props 1`] = `
                                         >
                                           <th
                                             aria-sort="none"
-                                            className="pf-c-table__sort pf-m-nowrap"
+                                            className="pf-c-table__sort pf-m-wrap"
                                             data-key={2}
                                             data-label="CVE ID"
                                             onMouseEnter={[Function]}
@@ -8293,14 +8293,14 @@ exports[`CVEs Should render without props 1`] = `
                                               </td>
                                             </BodyCell>
                                             <BodyCell
-                                              className="pf-m-nowrap"
+                                              className="pf-m-wrap"
                                               data-key={2}
                                               data-label="CVE ID"
                                               isVisible={true}
                                               key="col-2-row-0"
                                             >
                                               <td
-                                                className="pf-m-nowrap"
+                                                className="pf-m-wrap"
                                                 data-key={2}
                                                 data-label="CVE ID"
                                                 onMouseEnter={[Function]}
@@ -9666,7 +9666,7 @@ exports[`CVEs Should render without props 1`] = `
                                               />
                                             </BodyCell>
                                             <BodyCell
-                                              className="pf-m-nowrap"
+                                              className="pf-m-wrap"
                                               colSpan={7}
                                               data-key={2}
                                               data-label="CVE ID"
@@ -9676,7 +9676,7 @@ exports[`CVEs Should render without props 1`] = `
                                               parentId={0}
                                             >
                                               <td
-                                                className="pf-m-nowrap"
+                                                className="pf-m-wrap"
                                                 colSpan={7}
                                                 data-key={2}
                                                 data-label="CVE ID"

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -1943,7 +1943,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                             </HeaderCell>
                             <HeaderCell
                               aria-sort="none"
-                              className="pf-c-table__sort pf-m-nowrap"
+                              className="pf-c-table__sort pf-m-wrap"
                               data-key={2}
                               data-label="CVE ID"
                               key="2-header"
@@ -1951,7 +1951,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                             >
                               <th
                                 aria-sort="none"
-                                className="pf-c-table__sort pf-m-nowrap"
+                                className="pf-c-table__sort pf-m-wrap"
                                 data-key={2}
                                 data-label="CVE ID"
                                 onMouseEnter={[Function]}
@@ -5281,14 +5281,14 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   </td>
                                 </BodyCell>
                                 <BodyCell
-                                  className="pf-m-nowrap"
+                                  className="pf-m-wrap"
                                   data-key={2}
                                   data-label="CVE ID"
                                   isVisible={true}
                                   key="col-2-row-0"
                                 >
                                   <td
-                                    className="pf-m-nowrap"
+                                    className="pf-m-wrap"
                                     data-key={2}
                                     data-label="CVE ID"
                                     onMouseEnter={[Function]}
@@ -6654,7 +6654,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   />
                                 </BodyCell>
                                 <BodyCell
-                                  className="pf-m-nowrap"
+                                  className="pf-m-wrap"
                                   colSpan={7}
                                   data-key={2}
                                   data-label="CVE ID"
@@ -6664,7 +6664,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   parentId={0}
                                 >
                                   <td
-                                    className="pf-m-nowrap"
+                                    className="pf-m-wrap"
                                     colSpan={7}
                                     data-key={2}
                                     data-label="CVE ID"

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -5071,7 +5071,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                     </HeaderCell>
                                     <HeaderCell
                                       aria-sort="none"
-                                      className="pf-c-table__sort pf-m-nowrap"
+                                      className="pf-c-table__sort pf-m-wrap"
                                       data-key={2}
                                       data-label="CVE ID"
                                       key="2-header"
@@ -5079,7 +5079,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                     >
                                       <th
                                         aria-sort="none"
-                                        className="pf-c-table__sort pf-m-nowrap"
+                                        className="pf-c-table__sort pf-m-wrap"
                                         data-key={2}
                                         data-label="CVE ID"
                                         onMouseEnter={[Function]}
@@ -8502,14 +8502,14 @@ exports[`SystemCves Should match snapshots 1`] = `
                                           </td>
                                         </BodyCell>
                                         <BodyCell
-                                          className="pf-m-nowrap"
+                                          className="pf-m-wrap"
                                           data-key={2}
                                           data-label="CVE ID"
                                           isVisible={true}
                                           key="col-2-row-0"
                                         >
                                           <td
-                                            className="pf-m-nowrap"
+                                            className="pf-m-wrap"
                                             data-key={2}
                                             data-label="CVE ID"
                                             onMouseEnter={[Function]}
@@ -10196,7 +10196,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                           />
                                         </BodyCell>
                                         <BodyCell
-                                          className="pf-m-nowrap"
+                                          className="pf-m-wrap"
                                           colSpan={6}
                                           data-key={2}
                                           data-label="CVE ID"
@@ -10206,7 +10206,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                           parentId={0}
                                         >
                                           <td
-                                            className="pf-m-nowrap"
+                                            className="pf-m-wrap"
                                             colSpan={6}
                                             data-key={2}
                                             data-label="CVE ID"

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -1757,7 +1757,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                         </HeaderCell>
                         <HeaderCell
                           aria-sort="none"
-                          className="pf-c-table__sort pf-m-nowrap"
+                          className="pf-c-table__sort pf-m-wrap"
                           data-key={2}
                           data-label="CVE ID"
                           key="2-header"
@@ -1765,7 +1765,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                         >
                           <th
                             aria-sort="none"
-                            className="pf-c-table__sort pf-m-nowrap"
+                            className="pf-c-table__sort pf-m-wrap"
                             data-key={2}
                             data-label="CVE ID"
                             onMouseEnter={[Function]}
@@ -5743,14 +5743,14 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               </td>
                             </BodyCell>
                             <BodyCell
-                              className="pf-m-nowrap"
+                              className="pf-m-wrap"
                               data-key={2}
                               data-label="CVE ID"
                               isVisible={true}
                               key="col-2-row-0"
                             >
                               <td
-                                className="pf-m-nowrap"
+                                className="pf-m-wrap"
                                 data-key={2}
                                 data-label="CVE ID"
                                 onMouseEnter={[Function]}
@@ -7105,7 +7105,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               />
                             </BodyCell>
                             <BodyCell
-                              className="pf-m-nowrap"
+                              className="pf-m-wrap"
                               colSpan={6}
                               data-key={2}
                               data-label="CVE ID"
@@ -7115,7 +7115,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               parentId={0}
                             >
                               <td
-                                className="pf-m-nowrap"
+                                className="pf-m-wrap"
                                 colSpan={6}
                                 data-key={2}
                                 data-label="CVE ID"

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -336,7 +336,7 @@ export const VULNERABILITIES_HEADER = [
         title: intl.formatMessage(messages.cveId),
         key: 'synopsis',
         transforms: [sortable],
-        columnTransforms: [nowrap],
+        columnTransforms: [wrappable],
         cellFormatters: [expandable]
     },
     {
@@ -417,7 +417,7 @@ export const SYSTEM_DETAILS_HEADER = [
         title: intl.formatMessage(messages.cveId),
         key: 'synopsis',
         transforms: [sortable],
-        columnTransforms: [nowrap],
+        columnTransforms: [wrappable],
         cellFormatters: [expandable]
     },
     {


### PR DESCRIPTION
Fixes [VULN-1314](https://issues.redhat.com/browse/VULN-1314).

I had to revert non-wrapping of CVE synopsis, because description is in the same column as synopsis which applied non-wrap to it and this caused the table to stretch. From my testing the synopsis does wrap pretty well either way, it never wraps like this [(VULN-1307)](https://issues.redhat.com/browse/VULN-1307):
![Screenshot from 2020-10-09 18-45-12](https://user-images.githubusercontent.com/8426204/96113500-8c0e1e80-0ee4-11eb-8c25-286514abb1f0.png)

Maybe it wraps uglily in different browser or different setup, then we can find other workaround to VULN-1307.
