### PR TITLE
fix(report config modal): Increased width of the modal

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -15,6 +15,10 @@
     margin-right: var(--pf-global--spacer--xs);
 }
 
+.custom-report-modal {
+    width: 40rem;
+}
+
 .icon-with-label {
     &:not(:last-child) {
         margin-right: var(--pf-global--spacer--sm);
@@ -38,7 +42,7 @@
 }
 
 .custom-report-filter-wrapper {
-    width: calc(35rem - 2 * 24px);
+    width: calc(40rem - 2 * 24px);
 }
 
 .custom-report-filter-select {

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -44,7 +44,7 @@ const ReportConfigModal = ({
     return (
         <Modal
             title={intl.formatMessage(messages.configModalTitle)}
-            variant="small"
+            className="custom-report-modal"
             isOpen={isModalOpen}
             onClose={handleModalClose}
             actions={[

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -383,13 +383,13 @@ exports[`Reports page component Should match snapshots 1`] = `
                   aria-describedby=""
                   aria-label=""
                   aria-labelledby=""
-                  className=""
+                  className="custom-report-modal"
                   hasNoBodyWrapper={false}
                   isOpen={false}
                   onClose={[Function]}
                   showClose={true}
                   title="Report by CVEs"
-                  variant="small"
+                  variant="default"
                 >
                   <Portal
                     containerInfo={<div />}
@@ -415,7 +415,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                       aria-label=""
                       aria-labelledby=""
                       boxId="pf-modal-part-0"
-                      className=""
+                      className="custom-report-modal"
                       descriptorId="pf-modal-part-2"
                       hasNoBodyWrapper={false}
                       isOpen={false}
@@ -423,7 +423,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                       onClose={[Function]}
                       showClose={true}
                       title="Report by CVEs"
-                      variant="small"
+                      variant="default"
                     />
                   </Portal>
                 </Modal>


### PR DESCRIPTION
Increased width from 35rem to 40rem to closer resemble mockup, none of the modal variants:
- small (35rem)
- medium (52.5rem)
- large (70rem)
do not fit the mockup, even if they did in our current version of patternfly only the small variant is working correctly.