### PR TITLE
feat(filtering): Add filtering by advisory for system CVE table

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -213,6 +213,7 @@
   "rulesdetails.totalrisktooltip": "The <strong>likelihood</strong> that this will be a problem is {likelihood}. The <strong>impact</strong> of the problem would be {impact} if it occurred.",
   "save": "Save",
   "scheduledPatch": "Scheduled for patch",
+  "search": "Search",
   "searchFilterByCveId": "Search ID or description",
   "searchFilterByName": "Filter by name",
   "searchFilterLabel": "Find a CVE...",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3577,9 +3577,9 @@
       }
     },
     "@redhat-cloud-services/vulnerabilities-client": {
-      "version": "1.0.81",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.0.81.tgz",
-      "integrity": "sha512-1hbvLGWVo6uFv8NHrGIGmiiqxXwDy1aTU4C7Lc8hFV4LwBnKIlGnl2dlcNNV2FtDCTRjPNVYi6IXN5xfIR0fWw==",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.0.83.tgz",
+      "integrity": "sha512-R8GTvD1PxaxhJSs7kHF5w1P+kqXEX+ocZgQT3gMwYsi626mPyIclo7LnA6OCfZ1VlxQCmhNOuV45fzes5gZcwg==",
       "requires": {
         "axios": "^0.19.2",
         "yaml": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^2.2.0",
     "@redhat-cloud-services/frontend-components-utilities": "^2.1.5",
     "@redhat-cloud-services/insights-client": "^1.0.56",
-    "@redhat-cloud-services/vulnerabilities-client": "^1.0.81",
+    "@redhat-cloud-services/vulnerabilities-client": "^1.0.83",
     "babel-plugin-react-intl": "^7.5.4",
     "classnames": "^2.2.5",
     "marked": "^0.8.2",

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
@@ -4,10 +4,10 @@ import { intl } from '../../../../Utilities/IntlProvider';
 import debounce from 'lodash/debounce';
 import React from 'react';
 
-const SearchFilter = (label, placeholder, search, apply) => {
+const SearchFilter = (urlParam, label, placeholder, search, apply) => {
     const [searchValue, setSearchValue] = React.useState();
     const [handleSearch] = React.useState(() =>
-        debounce(filter =>  {if (filter !== undefined) { apply({ filter, page: 1 }); }}, 400)
+        debounce(newValue =>  {if (newValue !== undefined) { apply({ [urlParam]: newValue, page: 1 }); }}, 400)
     );
 
     React.useEffect(() => setSearchValue(search), [search]);

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -90,7 +90,7 @@ const CVEsTableToolbarWithContext = (props) => {
                 }}
                 filterConfig={{
                     items: [
-                        searchFilter(messages.cve, messages.searchFilterByCveID, filter, methods.apply),
+                        searchFilter('filter', messages.cve, messages.searchFilterByCveID, filter, methods.apply),
                         securityRuleFilter(methods.apply, params),
                         impactFilter(methods.apply, params),
                         cvssBaseScoreFilter(methods.apply, params),

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -31,7 +31,7 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
     };
 
     const { cves, parameters, methods, selectedCves, expandCveDescription, canEditStatus, canRemediate } = context;
-    const { filter } = parameters;
+    const { filter, advisory } = parameters;
     const selectedCvesCount = canRemediate && ((selectedCves && selectedCves.length) || 0);
 
     const selectOptions  = useMemo(() => selectAllCheckbox({
@@ -96,13 +96,14 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
                 }}
                 filterConfig={{
                     items: [
-                        searchFilter(messages.cve, messages.searchFilterByCveID, filter, methods.apply),
+                        searchFilter('filter', messages.cve, messages.searchFilterByCveID, filter, methods.apply),
                         securityRuleFilter(methods.apply, parameters),
                         impactFilter(methods.apply, parameters),
                         cvssBaseScoreFilter(methods.apply, parameters),
                         businessRiskFilter(methods.apply, parameters),
                         statusFilter(methods.apply, parameters),
-                        publishDateFilter(methods.apply, parameters)
+                        publishDateFilter(methods.apply, parameters),
+                        searchFilter('advisory', messages.advisory, messages.search, advisory, methods.apply)
                     ]
                 }}
                 activeFiltersConfig={{

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -727,6 +727,17 @@ exports[`SystemCves Should match snapshots 1`] = `
                                     "type": "radio",
                                     "urlParam": "publish_date",
                                   },
+                                  Object {
+                                    "filterValues": Object {
+                                      "aria-label": "search-field",
+                                      "id": "search-advisory",
+                                      "onChange": [Function],
+                                      "placeholder": "Search",
+                                      "value": undefined,
+                                    },
+                                    "label": "Advisory",
+                                    "type": "text",
+                                  },
                                 ],
                               }
                             }
@@ -1377,6 +1388,17 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         "type": "radio",
                                                         "urlParam": "publish_date",
                                                       },
+                                                      Object {
+                                                        "filterValues": Object {
+                                                          "aria-label": "search-field",
+                                                          "id": "search-advisory",
+                                                          "onChange": [Function],
+                                                          "placeholder": "Search",
+                                                          "value": undefined,
+                                                        },
+                                                        "label": "Advisory",
+                                                        "type": "text",
+                                                      },
                                                     ]
                                                   }
                                                   value=""
@@ -1443,6 +1465,13 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                   onClick={[Function]}
                                                                 >
                                                                   Publish date
+                                                                </Unknown>,
+                                                                <Unknown
+                                                                  component="button"
+                                                                  isHovered={false}
+                                                                  onClick={[Function]}
+                                                                >
+                                                                  Advisory
                                                                 </Unknown>,
                                                               ]
                                                             }
@@ -1521,6 +1550,13 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                     onClick={[Function]}
                                                                   >
                                                                     Publish date
+                                                                  </Unknown>,
+                                                                  <Unknown
+                                                                    component="button"
+                                                                    isHovered={false}
+                                                                    onClick={[Function]}
+                                                                  >
+                                                                    Advisory
                                                                   </Unknown>,
                                                                 ]
                                                               }

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -562,6 +562,17 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                 "type": "radio",
                 "urlParam": "publish_date",
               },
+              Object {
+                "filterValues": Object {
+                  "aria-label": "search-field",
+                  "id": "search-advisory",
+                  "onChange": [Function],
+                  "placeholder": "Search",
+                  "value": undefined,
+                },
+                "label": "Advisory",
+                "type": "text",
+              },
             ],
           }
         }
@@ -1211,6 +1222,17 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                     "type": "radio",
                                     "urlParam": "publish_date",
                                   },
+                                  Object {
+                                    "filterValues": Object {
+                                      "aria-label": "search-field",
+                                      "id": "search-advisory",
+                                      "onChange": [Function],
+                                      "placeholder": "Search",
+                                      "value": undefined,
+                                    },
+                                    "label": "Advisory",
+                                    "type": "text",
+                                  },
                                 ]
                               }
                               value=""
@@ -1277,6 +1299,13 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                               onClick={[Function]}
                                             >
                                               Publish date
+                                            </Unknown>,
+                                            <Unknown
+                                              component="button"
+                                              isHovered={false}
+                                              onClick={[Function]}
+                                            >
+                                              Advisory
                                             </Unknown>,
                                           ]
                                         }
@@ -1355,6 +1384,13 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                                 onClick={[Function]}
                                               >
                                                 Publish date
+                                              </Unknown>,
+                                              <Unknown
+                                                component="button"
+                                                isHovered={false}
+                                                onClick={[Function]}
+                                              >
+                                                Advisory
                                               </Unknown>,
                                             ]
                                           }

--- a/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
+++ b/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
@@ -710,6 +710,17 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                           "type": "radio",
                                           "urlParam": "publish_date",
                                         },
+                                        Object {
+                                          "filterValues": Object {
+                                            "aria-label": "search-field",
+                                            "id": "search-advisory",
+                                            "onChange": [Function],
+                                            "placeholder": "Search",
+                                            "value": undefined,
+                                          },
+                                          "label": "Advisory",
+                                          "type": "text",
+                                        },
                                       ],
                                     }
                                   }
@@ -1360,6 +1371,17 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                               "type": "radio",
                                                               "urlParam": "publish_date",
                                                             },
+                                                            Object {
+                                                              "filterValues": Object {
+                                                                "aria-label": "search-field",
+                                                                "id": "search-advisory",
+                                                                "onChange": [Function],
+                                                                "placeholder": "Search",
+                                                                "value": undefined,
+                                                              },
+                                                              "label": "Advisory",
+                                                              "type": "text",
+                                                            },
                                                           ]
                                                         }
                                                         value=""
@@ -1426,6 +1448,13 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                                         onClick={[Function]}
                                                                       >
                                                                         Publish date
+                                                                      </Unknown>,
+                                                                      <Unknown
+                                                                        component="button"
+                                                                        isHovered={false}
+                                                                        onClick={[Function]}
+                                                                      >
+                                                                        Advisory
                                                                       </Unknown>,
                                                                     ]
                                                                   }
@@ -1504,6 +1533,13 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                                           onClick={[Function]}
                                                                         >
                                                                           Publish date
+                                                                        </Unknown>,
+                                                                        <Unknown
+                                                                          component="button"
+                                                                          isHovered={false}
+                                                                          onClick={[Function]}
+                                                                        >
+                                                                          Advisory
                                                                         </Unknown>,
                                                                       ]
                                                                     }

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -49,7 +49,7 @@ import {
 } from '../../../Helpers/constants';
 
 const SystemsExposedTable = (props) => {
-    const [InventoryTable, setInventoryTable] = useState(()=> () => <div>Loading...</div>);
+    const [InventoryTable, setInventoryTable] = useState(() => () => <div>Loading...</div>);
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [selectedHosts, setSelectedHosts] = useState(undefined);
     const [urlParamsAllowed, setUrlParamsAllowed] = useState(false);
@@ -118,7 +118,7 @@ const SystemsExposedTable = (props) => {
         }
     }, [parameters]);
 
-    useEffect(()=>{
+    useEffect(() => {
         if (selectedHosts) {
             dispatch(selectMultipleEntities(selectedHosts));
         }
@@ -173,7 +173,7 @@ const SystemsExposedTable = (props) => {
                         updateRef(items.meta, apply);
                         fetchCveDetails(props.cve);
                     }}
-                    inventories={ inventories }
+                    inventories={inventories}
                     type={'systemsExposed'}
                 />
 
@@ -204,7 +204,7 @@ const SystemsExposedTable = (props) => {
         }
     ];
 
-    const selectOptions  = useMemo(() => selectAllCheckbox({
+    const selectOptions = useMemo(() => selectAllCheckbox({
         selectedItems: selectedHosts || [],
         selectorHandler: handleSelect,
         items: items.data && items || { data: [], meta: { total_items: 0 } },
@@ -260,8 +260,8 @@ const SystemsExposedTable = (props) => {
                         onRefresh={inventoryRefresh}
                         page={parameters.page}
                         total={metadata.total_items}
-                        isLoaded = {!isLoading}
-                        perPage={parameters.page_size }
+                        isLoaded={!isLoading}
+                        perPage={parameters.page_size}
                         hasCheckbox={items && items.length !== 0}
                         showActions={items && items.length !== 0}
                         exportConfig={{
@@ -284,7 +284,7 @@ const SystemsExposedTable = (props) => {
                             filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
                             onDelete: (e, i) => removeFilters(i, apply)
                         }}
-                        bulkSelect ={ selectOptions && {
+                        bulkSelect={selectOptions && {
                             count: selectedHosts && selectedHosts.length,
                             items: selectOptions.items,
                             isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
@@ -294,7 +294,9 @@ const SystemsExposedTable = (props) => {
                         filterConfig={{
                             items: [
                                 searchFilter(
-                                    messages.systemsSearchName, messages.searchFilterByName,
+                                    'filter',
+                                    messages.systemsSearchName,
+                                    messages.searchFilterByName,
                                     parameters.filter, apply
                                 ),
                                 securityRuleFilter(apply, parameters, props.filterRuleValues),

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -78,6 +78,7 @@ const SystemsTableToolbar = ({ selectedHosts, intl, parameters, systems, methods
             filterConfig={{
                 items: [
                     searchFilter(
+                        'filter',
                         messages.systemsSearchName,
                         messages.searchFilterByName,
                         parameters.filter,

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -31,6 +31,7 @@ export function getAffectedSystemsByCVE(synopsis, apiProps) {
         'tags',
         'sap_system',
         'show_advisories',
+        'advisory',
         'security_rule'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
@@ -51,7 +52,8 @@ export function getSystems(apiProps) {
         'uuid',
         'tags',
         'sap_system',
-        'opt_out'
+        'opt_out',
+        'excluded'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
     let result = api.getSystemsList(...parameterArray);
@@ -108,7 +110,8 @@ export function getCveListBySystem(apiProps) {
         'business_risk_id',
         'security_rule',
         'rule_presence',
-        'show_advisories'
+        'show_advisories',
+        'advisory'
     ];
     if (apiProps && system) {
         Object.keys(apiProps).forEach(key => (apiProps[key] === undefined || apiProps[key] === '') && delete apiProps[key]);

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -11,7 +11,7 @@ export const exportConfig = (methods) => (
 );
 
 export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
-    const { filter } = currentFilters;
+    const { filter: nameFilter, advisory: advisoryFilter } = currentFilters;
 
     const buildChip = (key, parameter) => (
         FILTERS[key].items.reduce((object, item) => {
@@ -68,12 +68,20 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
         return array;
     }, []);
 
-    filter && filterChips.push(
+    nameFilter && filterChips.push(
         { key: 'filter',
             category: intl.formatMessage(messages.searchLabel),
-            chips: [{ name: filter }]
+            chips: [{ name: nameFilter }]
         }
     );
+
+    advisoryFilter && filterChips.push(
+        { key: 'advisory',
+            category: intl.formatMessage(messages.advisory),
+            chips: [{ name: advisoryFilter }]
+        }
+    );
+
     return filterChips;
 };
 
@@ -91,7 +99,7 @@ export const removeFilters = (chips, apply) => {
             const value = defaultValues.join(',');
             obj.affecting = value === 'false,false' ? '' : defaultValues.join(',');
         }
-        else if (item.key === 'filter' || (item.multiValue && item.multiValue.length === 1)) {
+        else if (item.key === 'filter' || item.key === 'advisory' || (item.multiValue && item.multiValue.length === 1)) {
             obj[item.key] = '';
         }
         else {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -487,7 +487,8 @@ export const CVES_ALLOWED_PARAMS = [
     'status_id',
     'rule_presence',
     'affecting',
-    'show_advisories'
+    'show_advisories',
+    'advisory'
 ];
 
 export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = [

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -32,6 +32,11 @@ export default defineMessages({
         description: 'Delete label for general usage',
         defaultMessage: 'Delete'
     },
+    search: {
+        id: 'search',
+        description: 'Search label for general usage',
+        defaultMessage: 'Search'
+    },
     loading: {
         id: 'loading',
         description: 'Loading label for general usage',
@@ -64,7 +69,7 @@ export default defineMessages({
     },
     advisory: {
         id: 'advisory',
-        description: 'advisory column',
+        description: 'Advisory label for filter and column header',
         defaultMessage: 'Advisory'
     },
     notAvailable: {


### PR DESCRIPTION
Resolves [VULN-1331](https://issues.redhat.com/browse/VULN-1331). When filtering advisories total number of items is incorrect and also you have to specify the full name of the advisory to be able to filter by it - both of these are backend issues and are addressed in [VULN-1337](https://issues.redhat.com/projects/VULN/issues/VULN-1337).