### PR TITLE
Fix(pair status modal): Enhance and refactor CVE pair status modal

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -7,36 +7,29 @@ import BaseModal, { useJustificationInput, useStatusSelect } from './BaseModal';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 
-export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentStatus = false, intl, type }) => {
-    const [cveList] = useState(cves);
-    const [inventoryList] = useState(inventories);
+export const CvePairStatusModal = ({ cveList, updateRef, inventoryList, intl, type }) => {
     const {
         JustificationInput,
         justification,
         setJustification,
         setProps: setJustificationProps
-    } = useJustificationInput(getDefaultLabel());
-    const [checkboxState, setCheckboxState] = useState(getDefaultCheckboxState());
-    const { StatusSelect, statusId, setStatusId, setProps: setSelectProps } = useStatusSelect(getDefaultStatus());
-    const inventoryIds = inventoryList.map(item => item.id);
+    } = useJustificationInput(getJustification());
+    const [isOverallChecked, setOverallCheckbox] = useState(getDefaultCheckboxState());
+    const { StatusSelect, statusId, setStatusId, setProps: setSelectProps } = useStatusSelect(getCveStatus());
+    const inventoryIds = inventoryList.map(item => item.id || item.inventory_id);
     const inventoryNames = inventoryList.map(item => item.display_name);
 
     useEffect(() => {
-        setSelectProps({ isDisabled: checkboxState });
-        setJustificationProps({ disabled: checkboxState });
+        setSelectProps({ isDisabled: isOverallChecked });
+        setJustificationProps({ disabled: isOverallChecked });
         setStatusId(getCveStatus());
-        setJustification(getCveJustification());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [checkboxState, setSelectProps, setJustificationProps]);
-
-    useEffect(() => {
-        setStatusId(getCveStatus());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [checkboxState, setStatusId]);
+        setJustification(getJustification());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOverallChecked, setSelectProps, setJustificationProps]);
 
     const handleSave = () => {
         const cveIds = cveList.map(item => item.id);
-        const setStatusParams = !checkboxState
+        const setStatusParams = !isOverallChecked
             ? {
                 status_id: parseInt(statusId),
                 cve: cveIds,
@@ -47,119 +40,122 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
         return setSystemCveStatus(setStatusParams).then(updateRef);
     };
 
-    function getDefaultStatus() {
-        // system has different status
-        if (inventoryList && inventoryList.length > 0 && inventoryList[0].status_id) {
-            return getSystemsStatus();
-        }
-
-        if (cveList && cveList.length > 0) {
-            return getCveStatus();
-        }
-
-    }
-
-    function getDefaultLabel() {
-        if (inventoryList && inventoryList.length === 1 && inventoryList[0].justification) {
-            return getSystemsJustification();
-        }
-
-        if (cveList && cveList.length === 1) {
-            return getCveJustification();
-        }
-    }
-
     function getDefaultCheckboxState() {
+        switch (type) {
+            case 'systemsExposed': {
+                const sameAsOverall = inventoryList.every(item =>
+                    item.status_id === cveList[0].status_id && item.justification === cveList[0].justification
+                );
 
-        const haveSameStatuses = cveList.every(
-            (val, i, arr) => (val.status_id === arr[0].status_id) && (val.cve_status_id === arr[0].cve_status_id)
-        );
+                if (sameAsOverall) { // overall is only one therefore they are also same to each other
+                    return true;
+                }
 
-        const differFromOverall = cveList.some(item => item.status_id !== item.cve_status_id);
-        if (differFromOverall) { return false; }
+                break;
+            }
 
-        // system has the same status as cve
-        if (inventoryList && inventoryList.length === 1 && inventoryList[0].status_id) {
-            let [inventory] = inventoryList;
-            return cveList.some(cve => (cve.status_id === inventory.status_id));
-        }
+            case 'systemDetail': {
+                const sameAsEachOther = cveList.every((item, _, arr) =>
+                    item.status_id === arr[0].status_id && item.justification === arr[0].justification
+                );
 
-        if (cveList && cveList.length === 1 || haveSameStatuses) {
-            return true;
+                const sameAsOverall = cveList.every(item =>
+                    item.status_id === item.cve_status_id && item.justification === item.cve_justification
+                );
+
+                if (sameAsEachOther && sameAsOverall) {
+                    return true;
+                }
+
+                break;
+            }
         }
 
         return false;
     }
 
-    function getSystemsStatus() {
-        return (inventoryList && inventoryList[0].status_id.toString()) || '0';
-    }
-
-    function getSystemsJustification() {
-        return (inventoryList && inventoryList.length === 1 && inventoryList[0].justification) || '';
-    }
-
     function getCveStatus() {
         switch (type) {
-            case 'systemsExposed' : {
-                return (cveList && cveList.length === 1 && cveList[0].status_id.toString()) || '0';
-            }
-
-            case 'systemDetail': {
-                if (cveList) {
-                    if (checkboxState) { // use overall (CVE) status
-                        return hasDifferentStatus ? '0' : cveList[0].cve_status_id || '0';
-                    }
-                    else { // use system pair status
-                        return hasDifferentStatus ? '0' : cveList[0].status_id || '0';
-                    }
+            case 'systemsExposed': {
+                if (isOverallChecked) {
+                    return cveList[0].status_id;
                 }
                 else {
-                    return '0';
+                    const sameAsEachOther = inventoryList.every((item, _, arr) => item.status_id === arr[0].status_id);
+
+                    return sameAsEachOther ? inventoryList[0].status_id : '0';
                 }
-            }
-
-            default: {
-                return '0';
-            }
-        }
-
-    }
-
-    function getCveJustification() {
-        switch (type) {
-            case 'systemsExposed' : {
-                return (cveList && cveList.length === 1 && cveList[0].justification) || '';
             }
 
             case 'systemDetail': {
-                if (checkboxState) { // use overall (CVE) justification
-                    return (cveList && cveList.length === 1 && cveList[0].cve_justification) || '';
-                }
-                else { // use system pair justification; in case all notes are same display it
-                    return (cveList && cveList.length > 0
-                        && cveList.every(value => value.justification === cveList[0].justification)
-                        && cveList[0].justification) || '';
-                }
-            }
+                if (isOverallChecked) {
+                    const sameOverallAsEachOther = cveList.every((item, _, arr) => item.cve_status_id === arr[0].cve_status_id);
 
-            default: {
-                return '';
+                    return sameOverallAsEachOther ? cveList[0].cve_status_id : '0';
+                }
+                else {
+                    const sameAsEachOther = cveList.every((item, _, arr) => item.status_id === arr[0].status_id);
+
+                    return sameAsEachOther ? cveList[0].status_id : '0';
+                }
             }
         }
     }
+
+    function getJustification() {
+        switch (type) {
+            case 'systemsExposed': {
+                if (isOverallChecked) {
+                    return cveList[0].justification;
+                }
+                else {
+                    const sameAsEachOther = inventoryList.every((item, _, arr) =>
+                        item.justification === arr[0].justification);
+
+                    return sameAsEachOther ? inventoryList[0].justification || '' : '';
+                }
+            }
+
+            case 'systemDetail': {
+                if (isOverallChecked) {
+                    const sameOverallAsEachOther = cveList.every((item, _, arr) =>
+                        item.cve_justification === arr[0].cve_justification);
+
+                    return sameOverallAsEachOther ? cveList[0].cve_justification || '' : '';
+                }
+                else {
+                    const sameAsEachOther = cveList.every((item, _, arr) =>
+                        item.justification === arr[0].justification);
+
+                    return sameAsEachOther ? cveList[0].justification || '' : '';
+                }
+            }
+        }
+    }
+
+    const showDifferentStatusesWarning = () => {
+        switch (type) {
+            case 'systemsExposed': {
+                return inventoryList.some((item, _, arr) => item.status_id !== arr[0].status_id);
+            }
+
+            case 'systemDetail': {
+                return cveList.some((item, _, arr) => item.status_id !== arr[0].status_id);
+            }
+        }
+    };
 
     const successNotification = {
         variant: 'success',
         title: intl.formatMessage(messages.cvePairStatusModalUpdateSuccessful)
     };
 
-    const modalTitle = intl.formatMessage(messages.cvePairStatusModalTitle, { count: inventoryIds.length * cves.length });
+    const modalTitle = intl.formatMessage(messages.cvePairStatusModalTitle, { count: inventoryIds.length * cveList.length });
 
     return (
         <BaseModal items={cveList} onSave={handleSave} onSuccessNotification={successNotification} title={modalTitle}>
             <Stack hasGutter>
-                {hasDifferentStatus &&
+                {showDifferentStatusesWarning() &&
                     <StackItem>
                         <Alert
                             variant="warning"
@@ -189,8 +185,8 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
                                         label={intl.formatMessage(messages.cvePairStatusModalUseOverallCheckbox)}
                                         id="alt-form-checkbox-1"
                                         name="alt-form-checkbox-1"
-                                        isChecked={checkboxState}
-                                        onChange={checked => setCheckboxState(checked)}
+                                        isChecked={isOverallChecked}
+                                        onChange={checked => setOverallCheckbox(checked)}
                                     />
                                 </SplitItem>
                                 <SplitItem>
@@ -217,12 +213,11 @@ export const CvePairStatusModal = ({ cves, updateRef, inventories, hasDifferentS
 };
 
 CvePairStatusModal.propTypes = {
-    cves: propTypes.array,
+    cveList: propTypes.array,
     updateRef: propTypes.func,
-    inventories: propTypes.array,
-    hasDifferentStatus: propTypes.bool,
+    inventoryList: propTypes.array,
     intl: propTypes.any,
-    type: propTypes.string
+    type: propTypes.oneOf(['systemsExposed', 'systemDetail'])
 };
 
 export default injectIntl(CvePairStatusModal);

--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.test.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.test.js
@@ -34,7 +34,7 @@ describe('CvePairStatusModal component', () => {
 
         const pairStatusModal = mountWithIntl(
             <MockStore>
-                <CVEPairStatusModal open type={'systemDetail'} cves={cveSingle} inventories={systemSingle}/>
+                <CVEPairStatusModal open type={'systemDetail'} cveList={cveSingle} inventoryList={systemSingle}/>
             </MockStore>
         );
         
@@ -75,7 +75,7 @@ describe('CvePairStatusModal component', () => {
 
         const pairStatusModal = mountWithIntl(
             <MockStore>
-                <CVEPairStatusModal open type={'systemDetail'} cves={cveMultiple} inventories={systemSingle} hasDifferentStatus/>
+                <CVEPairStatusModal open type={'systemDetail'} cveList={cveMultiple} inventoryList={systemSingle}/>
             </MockStore>
         );
 
@@ -108,7 +108,7 @@ describe('CvePairStatusModal component', () => {
 
         const pairStatusModal = mountWithIntl(
             <MockStore>
-                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemSingle} />
+                <CVEPairStatusModal open type={'systemsExposed'} cveList={cveSingle} inventoryList={systemSingle} />
             </MockStore>
         );
 
@@ -141,7 +141,7 @@ describe('CvePairStatusModal component', () => {
         
         const pairStatusModal = mountWithIntl(
             <MockStore>
-                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemMultiple} hasDifferentStatus/>
+                <CVEPairStatusModal open type={'systemsExposed'} cveList={cveSingle} inventoryList={systemMultiple}/>
             </MockStore>
         );
 
@@ -175,7 +175,7 @@ describe('CvePairStatusModal component', () => {
 
         const pairStatusModal = mountWithIntl(
             <MockStore>
-                <CVEPairStatusModal open type={'systemsExposed'} cves={cveSingle} inventories={systemMultiple}/>
+                <CVEPairStatusModal open type={'systemsExposed'} cveList={cveSingle} inventoryList={systemMultiple}/>
             </MockStore>
         );
 
@@ -185,7 +185,7 @@ describe('CvePairStatusModal component', () => {
         const alertBox                    = pairStatusModal.find({ "aria-label": "Warning Alert"});
         const saveButton                  = pairStatusModal.find({ variant: 'primary' }).last();
 
-        expect(alertBox.exists()).toBeFalsy();
+        expect(alertBox.exists()).toBeTruthy();
 
         act(() => {
             setOverallCheckbox(true);

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -102,21 +102,17 @@ export const SystemCVEs = ({ entity, intl, allowedCveActions, showHeaderLabel, s
     }, []);
 
     const showStatusModal = cvesList => {
-        let hasDifferentStatus;
-        if (cvesList.length > 1) {
-            const selectedCves = Array.from(cves.data.filter(cve => cvesList.some(element => element.id === cve.id)));
-
-            hasDifferentStatus = selectedCves.some(element => {
-                return selectedCves.filter(cve => cve.status_id === element.status_id).length > 1 ? false : true;
-            });
-        }
+        let selectedCves = Array.from(cves.data.filter(cve => cvesList.some(element => element.id === cve.id)));
+        selectedCves = selectedCves.map((
+            // eslint-disable-next-line camelcase
+            { id, cve_status_id, status_id, status_justification: justification, cve_status_justification: cve_justification }) =>
+            ({ id, cve_status_id, status_id, justification, cve_justification })); // omit properties we don't need
 
         setStatusModal(() => () =>
             (<CvePairStatusModal
-                cves={cvesList}
+                cveList={selectedCves}
                 updateRef={() => updateRef(cves.meta, apply)}
-                inventories={[{ id: entity.id, display_name: entity.display_name }]}
-                hasDifferentStatus={hasDifferentStatus}
+                inventoryList={[{ id: entity.id, display_name: entity.display_name }]}
                 type={'systemDetail'}
             />)
         );

--- a/src/Components/SmartComponents/SystemCves/SystemCves.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.test.js
@@ -239,17 +239,25 @@ describe('SystemCves', () => {
         expect(action).toHaveLength(2);
     });
 
-    it('Should display status modal modal', () => {
+    it('Should display status modal', () => {
         const { context } = wrapper.find('SystemCvesTableWithContext').props();
-        act(() => context.methods.showStatusModal([{ id: 'testId', status_id: 'testStatusId' }]));
+        act(() => context.methods.showStatusModal([{ id: 'CVE-2019-6454' }])); // id of selected CVE
         wrapper.update();
         const modal = wrapper.find('CvePairStatusModal');
-        const { cves } = modal.props();
+        const { cveList } = modal.props();
         expect(modal).toBeTruthy();
-        expect(cves).toEqual([ { id: 'testId', status_id: 'testStatusId' } ]);
+        expect(cveList).toEqual([{
+            id: 'CVE-2019-6454',
+            status_id: 'testStatusId',
+            cve_justification: "testhello",
+            cve_status_id: 2,
+            status_id: "testStatusId",
+            justification: "testhello",
+            status_id: 2
+        }]);
     });
 
-    it('Should detect if cveList has different status in status modal modal', () => {
+    it('Should detect if cveList has different status in status modal', () => {
         state.cveList.payload.data =  [
             ...state.cveList.payload.data,
             {
@@ -281,8 +289,6 @@ describe('SystemCves', () => {
         act(() => context.methods.showStatusModal([{ id: 'CVE-2019-6454', status_id: 3 }, { id: 'CVE-2019-6455', status_id: 1 }]));
         wrapper.update();
         const modal = wrapper.find('CvePairStatusModal');
-        const { hasDifferentStatus } = modal.props();
         expect(modal).toBeTruthy();
-        expect(hasDifferentStatus).toBeTruthy();
     });
 });

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -168,29 +168,25 @@ const SystemsExposedTable = (props) => {
         setStatusModal(
             () => () =>
                 <CvePairStatusModal
-                    cves={cves}
+                    cveList={cves}
                     updateRef={() => {
                         updateRef(items.meta, apply);
                         fetchCveDetails(props.cve);
                     }}
-                    inventories={inventories}
+                    inventoryList={inventories}
                     type={'systemsExposed'}
                 />
 
         );
     };
 
-    const getSelectedSystemsLabel = () => {
-        // we only need display name when we have 1 system selected
-        if (selectedHosts.length === 1) {
-            const { id, display_name: displayName } = items.data.find(({ id }) => id === selectedHosts[0]);
-            return [{ id, displayName }];
-        }
-        else if (selectedHosts.length > 1) {
-            return selectedHosts.map(item => ({ id: item }));
-        }
+    const getSelectedSystemsData = () => {
+        let systemsList = items.data.filter(item => selectedHosts.includes(item.inventory_id));
+        // eslint-disable-next-line camelcase
+        systemsList = systemsList.map(({ inventory_id, display_name, status_id, status_text: justification }) =>
+            ({ inventory_id, display_name, status_id, justification })); // omit properties we don't need
 
-        return [];
+        return systemsList;
     };
 
     const kebabOptions = ['',
@@ -198,7 +194,7 @@ const SystemsExposedTable = (props) => {
             label: props.intl.formatMessage(messages.editStatus),
             onClick: () => showStatusModal(
                 [props.cveStatusDetails],
-                getSelectedSystemsLabel()
+                getSelectedSystemsData()
             ),
             props: { isDisabled: !selectedHosts || selectedHosts.length === 0 }
         }


### PR DESCRIPTION
Fixes [VULN-1181](https://issues.redhat.com/browse/VULN-1181).
[Expected behaviour mockups](https://marvelapp.com/prototype/75dcb1j/screen/62253695?).
This applies to both CVE detail and System detail pages.
- fix default states from the mockup, almost all were incorrect before
- refactor conditions and variable names  to improve readability
- moved logic for displaying "Selected pair have different statuses..." warning to Pair status modal file