### PR TITLE
VULN-1301 fix(cve details page): Fix undefined sort param

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -79,6 +79,8 @@ const SystemsExposedTable = (props) => {
     const apply = (config) => dispatch(changeExposedSystemsParameters(config));
 
     const inventoryRefresh = ({ page, per_page: pageSize, sort }) => {
+        sort = sort || parameters?.sort;
+
         if (inventory.current && (metadata.page !== page || metadata.page_size !== pageSize)) {
             apply({ page, page_size: pageSize, sort });
         }


### PR DESCRIPTION
The param sort is lost when changing pagination, use the value stored in redux in such case