### PR TITLE
fix(loading): Don't crash on CVE page when API is unreachable

### DIFF
--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -49,7 +49,7 @@ const CVEsTableWithContext = ({ context, header, entity }) => {
     const { cves, methods, selectedCves, openedCves } = context;
     const isEmpty = cves.data.length === 0;
 
-    const rows = cves.data
+    const rows = cves.data && cves.data
     .map(cve => (selectedCves.includes(cve.id) && { ...cve, selected: true }) || cve)
     .map((cve, index) => {
         const current = index % 2 === 0 ? openedCves.includes(cve.id) : undefined;


### PR DESCRIPTION
### Before if the API is unreachable the app would crash
![before](https://user-images.githubusercontent.com/8426204/99066688-a43b9100-25a9-11eb-99c3-a4f2ddf2cf00.png)

### After it is handled gracefully
![after](https://user-images.githubusercontent.com/8426204/99066677-9ede4680-25a9-11eb-802e-b7f86085bad8.png)

### If you feel crashing is more appropriate here, feel free to reject.

