### PR TITLE
VULN-1378 fix(csaw box): Use PF label for risk of change

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -66,8 +66,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                 <StackItem>
                                     <TextContent>
                                         <Text component={TextVariants.p}
-                                            style={{ fontSize: 'var(--pf-global--FontSize--lg)' }}
-                                            className="pf-u-mb-xs">
+                                            className="pf-u-mb-xs fontsize--lg">
                                             {intl.formatMessage(messages.associatedCves)}
                                         </Text>
                                         <Text component={TextVariants.p}>
@@ -137,7 +136,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                 }
                                 <StackItem>
                                     <TextContent>
-                                        <Text style={{ fontSize: 'var(--pf-global--FontSize--lg)' }}>
+                                        <Text className='fontsize--lg'>
                                             {intl.formatMessage(messages.remediationLabel)}
                                         </Text>
                                         <Split hasGutter>
@@ -145,8 +144,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                 <Label className="label">
                                                     <AnsibeTowerIcon
                                                         size="md"
-                                                        className="pf-u-mr-xs"
-                                                        style={{ verticalAlign: '-0.25em', fontSize: 12 }}
+                                                        className="pf-u-mr-xs ansibeTowerIcon"
                                                     />
                                                     {intl.formatMessage(messages.remediationLabel)}
                                                 </Label>
@@ -157,10 +155,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                     : (
                                                         <Fragment>
                                                             <CheckCircleIcon
-                                                                style={{
-                                                                    color: 'var(--pf-global--success-color--100)',
-                                                                    verticalAlign: '-0.15em'
-                                                                }}
+                                                                className="checkCircleIcon"
                                                             />
                                                             {intl.formatMessage(messages.yes)}
                                                             <Tooltip
@@ -168,8 +163,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                                 trigger='mouseenter focus click'
                                                             >
                                                                 <OutlinedQuestionCircleIcon
-                                                                    color={'var(--pf-global--secondary-color--100)'}
-                                                                    className="l-sm-spacer"
+                                                                    className="l-sm-spacer outlinedQuestionCircleIcon"
                                                                 />
                                                             </Tooltip>
                                                         </Fragment>
@@ -191,8 +185,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                     trigger='mouseenter focus click'
                                                 >
                                                     <OutlinedQuestionCircleIcon
-                                                        color={'var(--pf-global--secondary-color--100)'}
-                                                        className="l-sm-spacer"
+                                                        className="l-sm-spacer outlinedQuestionCircleIcon"
                                                     />
                                                 </Tooltip>
 
@@ -200,11 +193,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                     { rule.reboot_required &&
                                                         <Text>
                                                             <PowerOffIcon
-                                                                style={{
-                                                                    color: 'var(--pf-global--danger-color--100)',
-                                                                    verticalAlign: '-0.125em'
-                                                                }}
-                                                                className="pf-u-mr-xs"
+                                                                className="pf-u-mr-xs powerOffIcon"
                                                             />
                                                             {intl.formatMessage(messages.rebootRequired)}
                                                         </Text>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.scss
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.scss
@@ -14,3 +14,26 @@
     box-shadow: var(--pf-global--BoxShadow--md);
     border: 1px solid var(--pf-global--BorderColor--dark-100);
 }
+
+.fontsize--lg {
+    font-size: var(--pf-global--FontSize--lg);
+}
+
+.ansibeTowerIcon {
+    vertical-align: -0.25em;
+    font-size: 12px;
+}
+
+.checkCircleIcon {
+    color: var(--pf-global--success-color--100);
+    vertical-align: -0.15em;
+}
+
+.powerOffIcon {
+    color: var(--pf-global--danger-color--100);
+    vertical-align: '-0.125em'
+}
+
+.outlinedQuestionCircleIcon {
+    color: var(--pf-global--secondary-color--100)
+}

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -408,22 +408,12 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       className="pf-c-content"
                                     >
                                       <Text
-                                        className="pf-u-mb-xs"
+                                        className="pf-u-mb-xs fontsize--lg"
                                         component="p"
-                                        style={
-                                          Object {
-                                            "fontSize": "var(--pf-global--FontSize--lg)",
-                                          }
-                                        }
                                       >
                                         <p
-                                          className="pf-u-mb-xs"
+                                          className="pf-u-mb-xs fontsize--lg"
                                           data-pf-content={true}
-                                          style={
-                                            Object {
-                                              "fontSize": "var(--pf-global--FontSize--lg)",
-                                            }
-                                          }
                                         >
                                           Associated CVEs:
                                         </p>
@@ -565,20 +555,11 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       className="pf-c-content"
                                     >
                                       <Text
-                                        style={
-                                          Object {
-                                            "fontSize": "var(--pf-global--FontSize--lg)",
-                                          }
-                                        }
+                                        className="fontsize--lg"
                                       >
                                         <p
-                                          className=""
+                                          className="fontsize--lg"
                                           data-pf-content={true}
-                                          style={
-                                            Object {
-                                              "fontSize": "var(--pf-global--FontSize--lg)",
-                                            }
-                                          }
                                         >
                                           Remediation
                                         </p>
@@ -600,28 +581,21 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   className="vuln-label label"
                                                 >
                                                   <AnsibeTowerIcon
-                                                    className="pf-u-mr-xs"
+                                                    className="pf-u-mr-xs ansibeTowerIcon"
                                                     color="currentColor"
                                                     noVerticalAlign={false}
                                                     size="md"
-                                                    style={
-                                                      Object {
-                                                        "fontSize": 12,
-                                                        "verticalAlign": "-0.25em",
-                                                      }
-                                                    }
                                                   >
                                                     <svg
                                                       aria-hidden={true}
                                                       aria-labelledby={null}
-                                                      className="pf-u-mr-xs"
+                                                      className="pf-u-mr-xs ansibeTowerIcon"
                                                       fill="currentColor"
                                                       height="1.5em"
                                                       role="img"
                                                       style={
                                                         Object {
-                                                          "fontSize": 12,
-                                                          "verticalAlign": "-0.25em",
+                                                          "verticalAlign": "-0.1875em",
                                                         }
                                                       }
                                                       viewBox="20 20 390 390"
@@ -645,26 +619,21 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                               className="pf-l-split__item pf-m-fill icon-with-label"
                                             >
                                               <CheckCircleIcon
+                                                className="checkCircleIcon"
                                                 color="currentColor"
                                                 noVerticalAlign={false}
                                                 size="sm"
-                                                style={
-                                                  Object {
-                                                    "color": "var(--pf-global--success-color--100)",
-                                                    "verticalAlign": "-0.15em",
-                                                  }
-                                                }
                                               >
                                                 <svg
                                                   aria-hidden={true}
                                                   aria-labelledby={null}
+                                                  className="checkCircleIcon"
                                                   fill="currentColor"
                                                   height="1em"
                                                   role="img"
                                                   style={
                                                     Object {
-                                                      "color": "var(--pf-global--success-color--100)",
-                                                      "verticalAlign": "-0.15em",
+                                                      "verticalAlign": "-0.125em",
                                                     }
                                                   }
                                                   viewBox="0 0 512 512"
@@ -737,8 +706,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   trigger={
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-11"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     />
@@ -750,8 +719,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   >
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-11"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     >
@@ -759,8 +728,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         aria-describedby="pf-tooltip-11"
                                                         aria-hidden={true}
                                                         aria-labelledby={null}
-                                                        className="l-sm-spacer"
-                                                        fill="var(--pf-global--secondary-color--100)"
+                                                        className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                        fill="currentColor"
                                                         height="1em"
                                                         role="img"
                                                         style={
@@ -812,18 +781,30 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                             <div
                                               className="pf-l-split__item pf-m-fill icon-with-label"
                                             >
-                                              <span
+                                              <Label
                                                 style={
                                                   Object {
                                                     "backgroundColor": "#FFF5EC",
                                                     "color": "#773D00",
-                                                    "fontSize": "var(--pf-global--FontSize--sm)",
-                                                    "padding": "0.4em",
                                                   }
                                                 }
                                               >
-                                                Moderate
-                                              </span>
+                                                <span
+                                                  className="pf-c-label"
+                                                  style={
+                                                    Object {
+                                                      "backgroundColor": "#FFF5EC",
+                                                      "color": "#773D00",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="pf-c-label__content"
+                                                  >
+                                                    Moderate
+                                                  </span>
+                                                </span>
+                                              </Label>
                                               <Tooltip
                                                 content="These will likely require an outage window."
                                                 trigger="mouseenter focus click"
@@ -885,8 +866,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   trigger={
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-12"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     />
@@ -898,8 +879,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   >
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-12"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     >
@@ -907,8 +888,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         aria-describedby="pf-tooltip-12"
                                                         aria-hidden={true}
                                                         aria-labelledby={null}
-                                                        className="l-sm-spacer"
-                                                        fill="var(--pf-global--secondary-color--100)"
+                                                        className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                        fill="currentColor"
                                                         height="1em"
                                                         role="img"
                                                         style={
@@ -1363,22 +1344,12 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       className="pf-c-content"
                                     >
                                       <Text
-                                        className="pf-u-mb-xs"
+                                        className="pf-u-mb-xs fontsize--lg"
                                         component="p"
-                                        style={
-                                          Object {
-                                            "fontSize": "var(--pf-global--FontSize--lg)",
-                                          }
-                                        }
                                       >
                                         <p
-                                          className="pf-u-mb-xs"
+                                          className="pf-u-mb-xs fontsize--lg"
                                           data-pf-content={true}
-                                          style={
-                                            Object {
-                                              "fontSize": "var(--pf-global--FontSize--lg)",
-                                            }
-                                          }
                                         >
                                           Associated CVEs:
                                         </p>
@@ -1520,20 +1491,11 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       className="pf-c-content"
                                     >
                                       <Text
-                                        style={
-                                          Object {
-                                            "fontSize": "var(--pf-global--FontSize--lg)",
-                                          }
-                                        }
+                                        className="fontsize--lg"
                                       >
                                         <p
-                                          className=""
+                                          className="fontsize--lg"
                                           data-pf-content={true}
-                                          style={
-                                            Object {
-                                              "fontSize": "var(--pf-global--FontSize--lg)",
-                                            }
-                                          }
                                         >
                                           Remediation
                                         </p>
@@ -1555,28 +1517,21 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   className="vuln-label label"
                                                 >
                                                   <AnsibeTowerIcon
-                                                    className="pf-u-mr-xs"
+                                                    className="pf-u-mr-xs ansibeTowerIcon"
                                                     color="currentColor"
                                                     noVerticalAlign={false}
                                                     size="md"
-                                                    style={
-                                                      Object {
-                                                        "fontSize": 12,
-                                                        "verticalAlign": "-0.25em",
-                                                      }
-                                                    }
                                                   >
                                                     <svg
                                                       aria-hidden={true}
                                                       aria-labelledby={null}
-                                                      className="pf-u-mr-xs"
+                                                      className="pf-u-mr-xs ansibeTowerIcon"
                                                       fill="currentColor"
                                                       height="1.5em"
                                                       role="img"
                                                       style={
                                                         Object {
-                                                          "fontSize": 12,
-                                                          "verticalAlign": "-0.25em",
+                                                          "verticalAlign": "-0.1875em",
                                                         }
                                                       }
                                                       viewBox="20 20 390 390"
@@ -1600,26 +1555,21 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                               className="pf-l-split__item pf-m-fill icon-with-label"
                                             >
                                               <CheckCircleIcon
+                                                className="checkCircleIcon"
                                                 color="currentColor"
                                                 noVerticalAlign={false}
                                                 size="sm"
-                                                style={
-                                                  Object {
-                                                    "color": "var(--pf-global--success-color--100)",
-                                                    "verticalAlign": "-0.15em",
-                                                  }
-                                                }
                                               >
                                                 <svg
                                                   aria-hidden={true}
                                                   aria-labelledby={null}
+                                                  className="checkCircleIcon"
                                                   fill="currentColor"
                                                   height="1em"
                                                   role="img"
                                                   style={
                                                     Object {
-                                                      "color": "var(--pf-global--success-color--100)",
-                                                      "verticalAlign": "-0.15em",
+                                                      "verticalAlign": "-0.125em",
                                                     }
                                                   }
                                                   viewBox="0 0 512 512"
@@ -1692,8 +1642,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   trigger={
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-5"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     />
@@ -1705,8 +1655,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   >
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-5"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     >
@@ -1714,8 +1664,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         aria-describedby="pf-tooltip-5"
                                                         aria-hidden={true}
                                                         aria-labelledby={null}
-                                                        className="l-sm-spacer"
-                                                        fill="var(--pf-global--secondary-color--100)"
+                                                        className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                        fill="currentColor"
                                                         height="1em"
                                                         role="img"
                                                         style={
@@ -1767,18 +1717,30 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                             <div
                                               className="pf-l-split__item pf-m-fill icon-with-label"
                                             >
-                                              <span
+                                              <Label
                                                 style={
                                                   Object {
                                                     "backgroundColor": "#FFF5EC",
                                                     "color": "#773D00",
-                                                    "fontSize": "var(--pf-global--FontSize--sm)",
-                                                    "padding": "0.4em",
                                                   }
                                                 }
                                               >
-                                                Moderate
-                                              </span>
+                                                <span
+                                                  className="pf-c-label"
+                                                  style={
+                                                    Object {
+                                                      "backgroundColor": "#FFF5EC",
+                                                      "color": "#773D00",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="pf-c-label__content"
+                                                  >
+                                                    Moderate
+                                                  </span>
+                                                </span>
+                                              </Label>
                                               <Tooltip
                                                 content="These will likely require an outage window."
                                                 trigger="mouseenter focus click"
@@ -1840,8 +1802,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   trigger={
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-6"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     />
@@ -1853,8 +1815,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                   >
                                                     <OutlinedQuestionCircleIcon
                                                       aria-describedby="pf-tooltip-6"
-                                                      className="l-sm-spacer"
-                                                      color="var(--pf-global--secondary-color--100)"
+                                                      className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                      color="currentColor"
                                                       noVerticalAlign={false}
                                                       size="sm"
                                                     >
@@ -1862,8 +1824,8 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         aria-describedby="pf-tooltip-6"
                                                         aria-hidden={true}
                                                         aria-labelledby={null}
-                                                        className="l-sm-spacer"
-                                                        fill="var(--pf-global--secondary-color--100)"
+                                                        className="l-sm-spacer outlinedQuestionCircleIcon"
+                                                        fill="currentColor"
                                                         height="1em"
                                                         role="img"
                                                         style={

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -6,6 +6,7 @@ import AdvisoryColumn from '../Components/PresentationalComponents/AdvisoryColum
 import messages from '../Messages';
 import { intl } from '../Utilities/IntlProvider';
 import { formatWithBold } from '../Components/SmartComponents/Reports/ReportsHelper';
+import { Label as Pflabel } from '@patternfly/react-core/dist/esm/components/Label/index';
 
 export const DEFAULT_PAGE_SIZE = 20;
 export const RH_KB_URL = 'https://access.redhat.com/node';
@@ -326,44 +327,36 @@ export const RISK_OF_CHANGE_TOOLTIP = {
 
 export const RISK_OF_CHANGE_LABEL = {
     1: (
-        <span style={{
-            padding: '0.4em',
-            fontSize: 'var(--pf-global--FontSize--sm)',
+        <Pflabel style={{
             backgroundColor: 'var(--pf-global--palette--blue-50)',
             color: 'var(--pf-global--palette--blue-600)'
         }}>
             {intl.formatMessage(messages.impactListVeryLow)}
-        </span>
+        </Pflabel>
     ),
     2: (
-        <span style={{
-            padding: '0.4em',
-            fontSize: 'var(--pf-global--FontSize--sm)',
+        <Pflabel style={{
             backgroundColor: '#fdf7e7',
             color: 'var(--pf-global--palette--gold-700)'
         }}>
             {intl.formatMessage(messages.impactListLow)}
-        </span>
+        </Pflabel>
     ),
     3: (
-        <span style={{
-            padding: '0.4em',
-            fontSize: 'var(--pf-global--FontSize--sm)',
+        <Pflabel style={{
             backgroundColor: '#FFF5EC',
             color: '#773D00'
         }}>
             {intl.formatMessage(messages.impactListModerate)}
-        </span>
+        </Pflabel>
     ),
     4: (
-        <span style={{
-            padding: '0.4em',
-            fontSize: 'var(--pf-global--FontSize--sm)',
+        <Pflabel style={{
             backgroundColor: '#FAEAE8',
             color: 'var(--pf-global--palette--red-300)'
         }}>
             {intl.formatMessage(messages.impactListHigh)}
-        </span>
+        </Pflabel>
     )
 };
 


### PR DESCRIPTION
1.  refactor a bit the component. Use classes instead of styles
2. use PF label for the risk of change 
![Screenshot from 2020-11-19 10-44-50](https://user-images.githubusercontent.com/3369346/99649860-03d7e780-2a55-11eb-8a33-58921059ce43.png)
![Screenshot from 2020-11-19 10-45-15](https://user-images.githubusercontent.com/3369346/99649862-04707e00-2a55-11eb-81d7-de9b412c2f67.png)
![Screenshot from 2020-11-19 10-45-45](https://user-images.githubusercontent.com/3369346/99649866-05091480-2a55-11eb-9d2e-055a11088030.png)



![Screenshot from 2020-11-19 10-44-25](https://user-images.githubusercontent.com/3369346/99649856-02a6ba80-2a55-11eb-8f99-9017cb3f5c26.png)
