### PR TITLE
fix(global filter): Fix global filter disappearing when closing popup

### DIFF
--- a/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
+++ b/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
@@ -4,13 +4,13 @@ import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import { LockIcon } from '@patternfly/react-icons';
 import { Main } from '@redhat-cloud-services/frontend-components';
-import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Page, Title } from '@patternfly/react-core';
+import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import messages from '../../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
 
 const NoAccessPage = ({ intl }) => {
     return (
-        <Page>
+        <React.Fragment>
             <Header
                 title={intl.formatMessage(messages.vulnerabilitiesHeader)}
                 showBreadcrumb={false}
@@ -37,7 +37,7 @@ const NoAccessPage = ({ intl }) => {
                     </EmptyState>
                 </Bullseye>
             </Main>
-        </Page>
+        </React.Fragment>
     );
 };
 

--- a/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
+++ b/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
@@ -4,14 +4,14 @@ import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import { CloudServerIcon } from '@patternfly/react-icons';
 import { Main } from '@redhat-cloud-services/frontend-components';
-import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Page, Title } from '@patternfly/react-core';
+import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 
 import messages from '../../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
 
 const UpgradePage = ({ intl }) => {
     return (
-        <Page>
+        <React.Fragment>
             <Header
                 showBreadcrumb={false}
                 title={intl.formatMessage(messages.vulnerabilitiesHeader)}
@@ -36,7 +36,7 @@ const UpgradePage = ({ intl }) => {
                     </EmptyState>
                 </Bullseye>
             </Main>
-        </Page>
+        </React.Fragment>
     );
 };
 

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -1,4 +1,3 @@
-import { Page } from '@patternfly/react-core';
 import { InvalidObject, Main } from '@redhat-cloud-services/frontend-components';
 import propTypes from 'prop-types';
 import React, { useMemo, useState, useEffect } from 'react';
@@ -79,7 +78,7 @@ const CVEDetailsPage = (props) => {
 
     if (!error) {
         return (
-            <Page>
+            <React.Fragment>
                 <CVEPageContext.Provider value={cveDetails && { isLoading: cveDetails.isLoading }}>
                     <Header
                         title={cveName}
@@ -110,7 +109,7 @@ const CVEDetailsPage = (props) => {
                         />
                     </Main>
                 </CVEPageContext.Provider>
-            </Page>
+            </React.Fragment>
         );
     } else {
         return (

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -1,5 +1,5 @@
 import React,  { useState } from 'react';
-import { Page, Grid, GridItem, Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
+import { Grid, GridItem, Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { FileAltIcon } from '@patternfly/react-icons';
 import DownloadExecutive from './DownloadExecutive';
@@ -36,7 +36,7 @@ const ReportsPage = () => {
     };
 
     return (
-        <Page>
+        <React.Fragment>
             <Header title={intl.formatMessage(messages.reportsPageTitle)} showBreadcrumb={false}/>
             <Main>
                 <Grid hasGutter lg={3} md={4} sm={12}>
@@ -113,7 +113,7 @@ const ReportsPage = () => {
                 }}
                 label={messages.configModalExportReport}
             />}
-        </Page>
+        </React.Fragment>
     );
 };
 

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -37,357 +37,338 @@ exports[`Reports page component Should match snapshots 1`] = `
       }
     >
       <ReportsPage>
-        <Page
-          defaultManagedSidebarIsOpen={true}
-          isBreadcrumbWidthLimited={false}
-          isManagedSidebar={false}
-          isNotificationDrawerExpanded={false}
-          mainTabIndex={-1}
-          onNotificationDrawerExpand={[Function]}
-          onPageResize={[Function]}
+        <Header
+          actions={Array []}
+          showBreadcrumb={false}
+          title="Reports"
         >
-          <div
-            className="pf-c-page"
-          >
-            <main
-              className="pf-c-page__main"
-              tabIndex={-1}
+          <PageHeader>
+            <section
+              className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+              widget-type="InsightsPageHeader"
             >
-              <Header
-                actions={Array []}
-                showBreadcrumb={false}
-                title="Reports"
+              <Split
+                className="pf-u-mb-lg"
+                hasGutter={true}
               >
-                <PageHeader>
-                  <section
-                    className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-                    widget-type="InsightsPageHeader"
-                  >
-                    <Split
-                      className="pf-u-mb-lg"
-                      hasGutter={true}
+                <div
+                  className="pf-l-split pf-m-gutter pf-u-mb-lg"
+                >
+                  <SplitItem>
+                    <div
+                      className="pf-l-split__item"
                     >
-                      <div
-                        className="pf-l-split pf-m-gutter pf-u-mb-lg"
+                      <PageHeaderTitle
+                        title="Reports"
                       >
-                        <SplitItem>
-                          <div
-                            className="pf-l-split__item"
-                          >
-                            <PageHeaderTitle
-                              title="Reports"
-                            >
-                              <Title
-                                className=""
-                                headingLevel="h1"
-                                size="2xl"
-                                widget-type="InsightsPageHeaderTitle"
-                              >
-                                <h1
-                                  className="pf-c-title pf-m-2xl"
-                                  widget-type="InsightsPageHeaderTitle"
-                                >
-                                   
-                                  Reports
-                                   
-                                </h1>
-                              </Title>
-                            </PageHeaderTitle>
-                          </div>
-                        </SplitItem>
-                        <SplitItem
-                          isFilled={true}
+                        <Title
+                          className=""
+                          headingLevel="h1"
+                          size="2xl"
+                          widget-type="InsightsPageHeaderTitle"
                         >
-                          <div
-                            className="pf-l-split__item pf-m-fill"
-                          />
-                        </SplitItem>
-                      </div>
-                    </Split>
-                  </section>
-                </PageHeader>
-              </Header>
-              <Connect(Main)>
-                <Main>
-                  <section
-                    className="pf-l-page__main-section pf-c-page__main-section"
-                    page-type=""
+                          <h1
+                            className="pf-c-title pf-m-2xl"
+                            widget-type="InsightsPageHeaderTitle"
+                          >
+                             
+                            Reports
+                             
+                          </h1>
+                        </Title>
+                      </PageHeaderTitle>
+                    </div>
+                  </SplitItem>
+                  <SplitItem
+                    isFilled={true}
                   >
-                    <Grid
-                      hasGutter={true}
-                      lg={3}
-                      md={4}
-                      sm={12}
+                    <div
+                      className="pf-l-split__item pf-m-fill"
+                    />
+                  </SplitItem>
+                </div>
+              </Split>
+            </section>
+          </PageHeader>
+        </Header>
+        <Connect(Main)>
+          <Main>
+            <section
+              className="pf-l-page__main-section pf-c-page__main-section"
+              page-type=""
+            >
+              <Grid
+                hasGutter={true}
+                lg={3}
+                md={4}
+                sm={12}
+              >
+                <div
+                  className="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-4-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"
+                >
+                  <GridItem>
+                    <div
+                      className="pf-l-grid__item"
                     >
-                      <div
-                        className="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-4-col-on-md pf-m-all-3-col-on-lg pf-m-gutter"
+                      <Card
+                        className="report-card"
                       >
-                        <GridItem>
-                          <div
-                            className="pf-l-grid__item"
-                          >
-                            <Card
-                              className="report-card"
+                        <article
+                          className="pf-c-card report-card"
+                          data-ouia-component-id="OUIA-Generated-Card-1"
+                          data-ouia-component-type="PF4/Card"
+                          data-ouia-safe={true}
+                          id=""
+                        >
+                          <CardTitle>
+                            <div
+                              className="pf-c-card__title"
                             >
-                              <article
-                                className="pf-c-card report-card"
-                                data-ouia-component-id="OUIA-Generated-Card-1"
-                                data-ouia-component-type="PF4/Card"
-                                data-ouia-safe={true}
-                                id=""
+                              <ChartPieSolid
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.25rem",
+                                  }
+                                }
                               >
-                                <CardTitle>
-                                  <div
-                                    className="pf-c-card__title"
-                                  >
-                                    <ChartPieSolid
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.25rem",
-                                        }
-                                      }
-                                    >
-                                      <img
-                                        alt="Static pie solid"
-                                        src="test-file-stub"
-                                        style={
-                                          Object {
-                                            "verticalAlign": "-0.25rem",
-                                          }
-                                        }
-                                      />
-                                    </ChartPieSolid>
-                                    <span
-                                      className="pf-u-ml-sm"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "0.3rem",
-                                        }
-                                      }
-                                    >
-                                      Executive report
-                                    </span>
-                                  </div>
-                                </CardTitle>
-                                <CardBody>
-                                  <div
-                                    className="pf-c-card__body"
-                                  >
-                                    An executive summary of vulnerabilities  identified by Red Hat across workloads that may impact your RHEL servers.
-                                  </div>
-                                </CardBody>
-                                <CardFooter>
-                                  <div
-                                    className="pf-c-card__footer"
-                                  >
-                                    <DownloadExecutive>
-                                      <a
-                                        href={true}
-                                        onClick={[Function]}
-                                      >
-                                        Download PDF
-                                      </a>
-                                    </DownloadExecutive>
-                                  </div>
-                                </CardFooter>
-                              </article>
-                            </Card>
-                          </div>
-                        </GridItem>
-                        <GridItem>
-                          <div
-                            className="pf-l-grid__item"
-                          >
-                            <Card
-                              className="report-card"
+                                <img
+                                  alt="Static pie solid"
+                                  src="test-file-stub"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.25rem",
+                                    }
+                                  }
+                                />
+                              </ChartPieSolid>
+                              <span
+                                className="pf-u-ml-sm"
+                                style={
+                                  Object {
+                                    "verticalAlign": "0.3rem",
+                                  }
+                                }
+                              >
+                                Executive report
+                              </span>
+                            </div>
+                          </CardTitle>
+                          <CardBody>
+                            <div
+                              className="pf-c-card__body"
                             >
-                              <article
-                                className="pf-c-card report-card"
-                                data-ouia-component-id="OUIA-Generated-Card-2"
-                                data-ouia-component-type="PF4/Card"
-                                data-ouia-safe={true}
-                                id=""
+                              An executive summary of vulnerabilities  identified by Red Hat across workloads that may impact your RHEL servers.
+                            </div>
+                          </CardBody>
+                          <CardFooter>
+                            <div
+                              className="pf-c-card__footer"
+                            >
+                              <DownloadExecutive>
+                                <a
+                                  href={true}
+                                  onClick={[Function]}
+                                >
+                                  Download PDF
+                                </a>
+                              </DownloadExecutive>
+                            </div>
+                          </CardFooter>
+                        </article>
+                      </Card>
+                    </div>
+                  </GridItem>
+                  <GridItem>
+                    <div
+                      className="pf-l-grid__item"
+                    >
+                      <Card
+                        className="report-card"
+                      >
+                        <article
+                          className="pf-c-card report-card"
+                          data-ouia-component-id="OUIA-Generated-Card-2"
+                          data-ouia-component-type="PF4/Card"
+                          data-ouia-safe={true}
+                          id=""
+                        >
+                          <CardTitle>
+                            <div
+                              className="pf-c-card__title"
+                            >
+                              <FileAltIcon
+                                color="var(--pf-global--link--Color)"
+                                noVerticalAlign={false}
+                                size="lg"
                               >
-                                <CardTitle>
-                                  <div
-                                    className="pf-c-card__title"
-                                  >
-                                    <FileAltIcon
-                                      color="var(--pf-global--link--Color)"
-                                      noVerticalAlign={false}
-                                      size="lg"
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        aria-labelledby={null}
-                                        fill="var(--pf-global--link--Color)"
-                                        height="2em"
-                                        role="img"
-                                        style={
-                                          Object {
-                                            "verticalAlign": "-0.25em",
-                                          }
-                                        }
-                                        viewBox="0 0 384 512"
-                                        width="2em"
-                                      >
-                                        <path
-                                          d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
-                                        />
-                                      </svg>
-                                    </FileAltIcon>
-                                    <span
-                                      className="pf-u-ml-sm"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "0.3rem",
-                                        }
-                                      }
-                                    >
-                                      Report by CVEs
-                                    </span>
-                                  </div>
-                                </CardTitle>
-                                <CardBody>
-                                  <div
-                                    className="pf-c-card__body"
-                                  >
-                                    A customizable PDF report of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.
-                                  </div>
-                                </CardBody>
-                                <CardFooter>
-                                  <div
-                                    className="pf-c-card__footer"
-                                  >
-                                    <a
-                                      className="create-report"
-                                      onClick={[Function]}
-                                    >
-                                      Create report
-                                    </a>
-                                  </div>
-                                </CardFooter>
-                              </article>
-                            </Card>
-                          </div>
-                        </GridItem>
-                      </div>
-                    </Grid>
-                  </section>
-                </Main>
-              </Connect(Main)>
-              <ReportConfigModal
-                columnsToInclude={
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="var(--pf-global--link--Color)"
+                                  height="2em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.25em",
+                                    }
+                                  }
+                                  viewBox="0 0 384 512"
+                                  width="2em"
+                                >
+                                  <path
+                                    d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                                  />
+                                </svg>
+                              </FileAltIcon>
+                              <span
+                                className="pf-u-ml-sm"
+                                style={
+                                  Object {
+                                    "verticalAlign": "0.3rem",
+                                  }
+                                }
+                              >
+                                Report by CVEs
+                              </span>
+                            </div>
+                          </CardTitle>
+                          <CardBody>
+                            <div
+                              className="pf-c-card__body"
+                            >
+                              A customizable PDF report of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.
+                            </div>
+                          </CardBody>
+                          <CardFooter>
+                            <div
+                              className="pf-c-card__footer"
+                            >
+                              <a
+                                className="create-report"
+                                onClick={[Function]}
+                              >
+                                Create report
+                              </a>
+                            </div>
+                          </CardFooter>
+                        </article>
+                      </Card>
+                    </div>
+                  </GridItem>
+                </div>
+              </Grid>
+            </section>
+          </Main>
+        </Connect(Main)>
+        <ReportConfigModal
+          columnsToInclude={
+            Array [
+              "publish_date",
+              "impact",
+              "cvss_filter",
+              "affecting",
+              "business_risk_id",
+              "status_id",
+            ]
+          }
+          filterData={
+            Object {
+              "business_risk_id": Array [],
+              "cvss_filter": Object {
+                "max": 10,
+                "min": 0,
+              },
+              "impact": Array [],
+              "publish_date": "all",
+              "security_rule": undefined,
+              "status_id": Array [],
+            }
+          }
+          handleDownloadButton={[Function]}
+          handleModalClose={[Function]}
+          isOpen={false}
+          reportTitle="Insights Vulnerability CVE Report"
+          setColumnsToInclude={[Function]}
+          setFilterData={[Function]}
+          setReportTitle={[Function]}
+          setUserNotes={[Function]}
+          userNotes=""
+        >
+          <Modal
+            actions={
+              Array [
+                <Button
+                  onClick={[Function]}
+                  variant="primary"
+                >
+                  Export report
+                </Button>,
+                <Button
+                  onClick={[Function]}
+                  variant="secondary"
+                >
+                  Cancel
+                </Button>,
+              ]
+            }
+            appendTo={[Function]}
+            aria-describedby=""
+            aria-label=""
+            aria-labelledby=""
+            className=""
+            hasNoBodyWrapper={false}
+            id="custom-report-modal"
+            isOpen={false}
+            onClose={[Function]}
+            ouiaSafe={true}
+            showClose={true}
+            title="Report by CVEs"
+            titleIconVariant={null}
+            titleLabel=""
+            variant="default"
+          >
+            <Portal
+              containerInfo={<div />}
+            >
+              <ModalContent
+                actions={
                   Array [
-                    "publish_date",
-                    "impact",
-                    "cvss_filter",
-                    "affecting",
-                    "business_risk_id",
-                    "status_id",
+                    <Button
+                      onClick={[Function]}
+                      variant="primary"
+                    >
+                      Export report
+                    </Button>,
+                    <Button
+                      onClick={[Function]}
+                      variant="secondary"
+                    >
+                      Cancel
+                    </Button>,
                   ]
                 }
-                filterData={
-                  Object {
-                    "business_risk_id": Array [],
-                    "cvss_filter": Object {
-                      "max": 10,
-                      "min": 0,
-                    },
-                    "impact": Array [],
-                    "publish_date": "all",
-                    "security_rule": undefined,
-                    "status_id": Array [],
-                  }
-                }
-                handleDownloadButton={[Function]}
-                handleModalClose={[Function]}
+                aria-describedby=""
+                aria-label=""
+                aria-labelledby=""
+                boxId="custom-report-modal"
+                className=""
+                descriptorId="pf-modal-part-2"
+                hasNoBodyWrapper={false}
+                id="custom-report-modal"
                 isOpen={false}
-                reportTitle="Insights Vulnerability CVE Report"
-                setColumnsToInclude={[Function]}
-                setFilterData={[Function]}
-                setReportTitle={[Function]}
-                setUserNotes={[Function]}
-                userNotes=""
-              >
-                <Modal
-                  actions={
-                    Array [
-                      <Button
-                        onClick={[Function]}
-                        variant="primary"
-                      >
-                        Export report
-                      </Button>,
-                      <Button
-                        onClick={[Function]}
-                        variant="secondary"
-                      >
-                        Cancel
-                      </Button>,
-                    ]
-                  }
-                  appendTo={[Function]}
-                  aria-describedby=""
-                  aria-label=""
-                  aria-labelledby=""
-                  className=""
-                  hasNoBodyWrapper={false}
-                  id="custom-report-modal"
-                  isOpen={false}
-                  onClose={[Function]}
-                  ouiaSafe={true}
-                  showClose={true}
-                  title="Report by CVEs"
-                  titleIconVariant={null}
-                  titleLabel=""
-                  variant="default"
-                >
-                  <Portal
-                    containerInfo={<div />}
-                  >
-                    <ModalContent
-                      actions={
-                        Array [
-                          <Button
-                            onClick={[Function]}
-                            variant="primary"
-                          >
-                            Export report
-                          </Button>,
-                          <Button
-                            onClick={[Function]}
-                            variant="secondary"
-                          >
-                            Cancel
-                          </Button>,
-                        ]
-                      }
-                      aria-describedby=""
-                      aria-label=""
-                      aria-labelledby=""
-                      boxId="custom-report-modal"
-                      className=""
-                      descriptorId="pf-modal-part-2"
-                      hasNoBodyWrapper={false}
-                      id="custom-report-modal"
-                      isOpen={false}
-                      labelId="pf-modal-part-1"
-                      onClose={[Function]}
-                      ouiaId="OUIA-Generated-Modal-default-1"
-                      ouiaSafe={true}
-                      showClose={true}
-                      title="Report by CVEs"
-                      titleIconVariant={null}
-                      titleLabel=""
-                      variant="default"
-                    />
-                  </Portal>
-                </Modal>
-              </ReportConfigModal>
-            </main>
-          </div>
-        </Page>
+                labelId="pf-modal-part-1"
+                onClose={[Function]}
+                ouiaId="OUIA-Generated-Modal-default-1"
+                ouiaSafe={true}
+                showClose={true}
+                title="Report by CVEs"
+                titleIconVariant={null}
+                titleLabel=""
+                variant="default"
+              />
+            </Portal>
+          </Modal>
+        </ReportConfigModal>
       </ReportsPage>
     </Router>
   </BrowserRouter>

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -1,4 +1,3 @@
-import { Page } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
 import {
@@ -106,7 +105,7 @@ class InventoryDetail extends React.Component {
         const { opt_out: isOptOut = false, entity, loaded } = systemDetails;
         const Wrapper = InvWrapper || React.Fragment;
         return (
-            <Page>
+            <React.Fragment>
                 <Wrapper>
                     <Header
                         title=''
@@ -152,7 +151,7 @@ class InventoryDetail extends React.Component {
                         </Main>
                     )}
                 </Wrapper>
-            </Page>
+            </React.Fragment>
         );
     }
 

--- a/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetailsPage.test.js.snap
+++ b/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetailsPage.test.js.snap
@@ -253,24 +253,31 @@ exports[`SystemDetailPage Should match the snapshots 1`] = `
                 }
               }
             >
-              <Page
-                defaultManagedSidebarIsOpen={true}
-                isBreadcrumbWidthLimited={false}
-                isManagedSidebar={false}
-                isNotificationDrawerExpanded={false}
-                mainTabIndex={-1}
-                onNotificationDrawerExpand={[Function]}
-                onPageResize={[Function]}
+              <Header
+                actions={Array []}
+                breadcrumbs={
+                  Array [
+                    Object {
+                      "loaded": true,
+                      "title": "Systems",
+                      "to": "/systems",
+                    },
+                    Object {
+                      "isActive": true,
+                      "loaded": undefined,
+                      "title": "Invalid System",
+                    },
+                  ]
+                }
+                showBreadcrumb={true}
+                title=""
               >
-                <div
-                  className="pf-c-page"
-                >
-                  <main
-                    className="pf-c-page__main"
-                    tabIndex={-1}
+                <PageHeader>
+                  <section
+                    className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+                    widget-type="InsightsPageHeader"
                   >
-                    <Header
-                      actions={Array []}
+                    <Breadcrumb
                       breadcrumbs={
                         Array [
                           Object {
@@ -285,260 +292,234 @@ exports[`SystemDetailPage Should match the snapshots 1`] = `
                           },
                         ]
                       }
-                      showBreadcrumb={true}
-                      title=""
                     >
-                      <PageHeader>
-                        <section
-                          className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
-                          widget-type="InsightsPageHeader"
+                      <Breadcrumb
+                        key="PfBreadcrumb"
+                      >
+                        <nav
+                          aria-label="Breadcrumb"
+                          className="pf-c-breadcrumb"
+                          data-ouia-component-id="OUIA-Generated-Breadcrumb-1"
+                          data-ouia-component-type="PF4/Breadcrumb"
+                          data-ouia-safe={true}
                         >
-                          <Breadcrumb
-                            breadcrumbs={
-                              Array [
-                                Object {
-                                  "loaded": true,
-                                  "title": "Systems",
-                                  "to": "/systems",
-                                },
-                                Object {
-                                  "isActive": true,
-                                  "loaded": undefined,
-                                  "title": "Invalid System",
-                                },
-                              ]
-                            }
+                          <ol
+                            className="pf-c-breadcrumb__list"
                           >
-                            <Breadcrumb
-                              key="PfBreadcrumb"
+                            <BreadcrumbItem
+                              isActive={false}
+                              key=".$Vulnerability"
+                              showDivider={false}
                             >
-                              <nav
-                                aria-label="Breadcrumb"
-                                className="pf-c-breadcrumb"
-                                data-ouia-component-id="OUIA-Generated-Breadcrumb-1"
-                                data-ouia-component-type="PF4/Breadcrumb"
-                                data-ouia-safe={true}
+                              <li
+                                className="pf-c-breadcrumb__item"
                               >
-                                <ol
-                                  className="pf-c-breadcrumb__list"
+                                <Link
+                                  to="/"
                                 >
-                                  <BreadcrumbItem
-                                    isActive={false}
-                                    key=".$Vulnerability"
-                                    showDivider={false}
+                                  <LinkAnchor
+                                    href="/"
+                                    navigate={[Function]}
                                   >
-                                    <li
-                                      className="pf-c-breadcrumb__item"
+                                    <a
+                                      href="/"
+                                      onClick={[Function]}
                                     >
-                                      <Link
-                                        to="/"
-                                      >
-                                        <LinkAnchor
-                                          href="/"
-                                          navigate={[Function]}
-                                        >
-                                          <a
-                                            href="/"
-                                            onClick={[Function]}
-                                          >
-                                            Vulnerability
-                                          </a>
-                                        </LinkAnchor>
-                                      </Link>
-                                    </li>
-                                  </BreadcrumbItem>
-                                  <BreadcrumbItem
-                                    key=".1:$Systems"
-                                    showDivider={true}
+                                      Vulnerability
+                                    </a>
+                                  </LinkAnchor>
+                                </Link>
+                              </li>
+                            </BreadcrumbItem>
+                            <BreadcrumbItem
+                              key=".1:$Systems"
+                              showDivider={true}
+                            >
+                              <li
+                                className="pf-c-breadcrumb__item"
+                              >
+                                <span
+                                  className="pf-c-breadcrumb__item-divider"
+                                >
+                                  <AngleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <li
-                                      className="pf-c-breadcrumb__item"
-                                    >
-                                      <span
-                                        className="pf-c-breadcrumb__item-divider"
-                                      >
-                                        <AngleRightIcon
-                                          color="currentColor"
-                                          noVerticalAlign={false}
-                                          size="sm"
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            aria-labelledby={null}
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            style={
-                                              Object {
-                                                "verticalAlign": "-0.125em",
-                                              }
-                                            }
-                                            viewBox="0 0 256 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                            />
-                                          </svg>
-                                        </AngleRightIcon>
-                                      </span>
-                                      <Link
-                                        to="/systems"
-                                      >
-                                        <LinkAnchor
-                                          href="/systems"
-                                          navigate={[Function]}
-                                        >
-                                          <a
-                                            href="/systems"
-                                            onClick={[Function]}
-                                          >
-                                            Systems
-                                          </a>
-                                        </LinkAnchor>
-                                      </Link>
-                                    </li>
-                                  </BreadcrumbItem>
-                                  <BreadcrumbItem
-                                    isActive={true}
-                                    key=".1:$Invalid System"
-                                    showDivider={true}
-                                  >
-                                    <li
-                                      className="pf-c-breadcrumb__item"
-                                    >
-                                      <span
-                                        className="pf-c-breadcrumb__item-divider"
-                                      >
-                                        <AngleRightIcon
-                                          color="currentColor"
-                                          noVerticalAlign={false}
-                                          size="sm"
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            aria-labelledby={null}
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            style={
-                                              Object {
-                                                "verticalAlign": "-0.125em",
-                                              }
-                                            }
-                                            viewBox="0 0 256 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                            />
-                                          </svg>
-                                        </AngleRightIcon>
-                                      </span>
-                                      <Skeleton
-                                        isDark={false}
-                                        size="md"
-                                        style={
-                                          Object {
-                                            "width": "100px",
-                                          }
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
                                         }
-                                      >
-                                        <div
-                                          className="ins-c-skeleton ins-c-skeleton__md"
-                                          style={
-                                            Object {
-                                              "width": "100px",
-                                            }
-                                          }
-                                        >
-                                           
-                                        </div>
-                                      </Skeleton>
-                                    </li>
-                                  </BreadcrumbItem>
-                                </ol>
-                              </nav>
-                            </Breadcrumb>
-                          </Breadcrumb>
-                          <Split
-                            className="pf-u-mb-lg"
-                            hasGutter={true}
-                          >
-                            <div
-                              className="pf-l-split pf-m-gutter pf-u-mb-lg"
-                            >
-                              <SplitItem>
-                                <div
-                                  className="pf-l-split__item"
-                                >
-                                  <PageHeaderTitle
-                                    title=""
-                                  >
-                                    <Title
-                                      className=""
-                                      headingLevel="h1"
-                                      size="2xl"
-                                      widget-type="InsightsPageHeaderTitle"
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
                                     >
-                                      <h1
-                                        className="pf-c-title pf-m-2xl"
-                                        widget-type="InsightsPageHeaderTitle"
-                                      >
-                                         
-                                         
-                                      </h1>
-                                    </Title>
-                                  </PageHeaderTitle>
-                                </div>
-                              </SplitItem>
-                              <SplitItem
-                                isFilled={true}
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                                <Link
+                                  to="/systems"
+                                >
+                                  <LinkAnchor
+                                    href="/systems"
+                                    navigate={[Function]}
+                                  >
+                                    <a
+                                      href="/systems"
+                                      onClick={[Function]}
+                                    >
+                                      Systems
+                                    </a>
+                                  </LinkAnchor>
+                                </Link>
+                              </li>
+                            </BreadcrumbItem>
+                            <BreadcrumbItem
+                              isActive={true}
+                              key=".1:$Invalid System"
+                              showDivider={true}
+                            >
+                              <li
+                                className="pf-c-breadcrumb__item"
                               >
-                                <div
-                                  className="pf-l-split__item pf-m-fill"
-                                />
-                              </SplitItem>
-                            </div>
-                          </Split>
-                          <InventoryDetailHead
-                            actions={
-                              Array [
-                                Object {
-                                  "onClick": [Function],
-                                  "title": "Exclude from vulnerability analysis",
-                                },
-                              ]
-                            }
-                            hideBack={true}
+                                <span
+                                  className="pf-c-breadcrumb__item-divider"
+                                >
+                                  <AngleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                                <Skeleton
+                                  isDark={false}
+                                  size="md"
+                                  style={
+                                    Object {
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="ins-c-skeleton ins-c-skeleton__md"
+                                    style={
+                                      Object {
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                     
+                                  </div>
+                                </Skeleton>
+                              </li>
+                            </BreadcrumbItem>
+                          </ol>
+                        </nav>
+                      </Breadcrumb>
+                    </Breadcrumb>
+                    <Split
+                      className="pf-u-mb-lg"
+                      hasGutter={true}
+                    >
+                      <div
+                        className="pf-l-split pf-m-gutter pf-u-mb-lg"
+                      >
+                        <SplitItem>
+                          <div
+                            className="pf-l-split__item"
                           >
-                            <div>
-                              A mock with '
-                              ' passed!
-                            </div>
-                          </InventoryDetailHead>
-                        </section>
-                      </PageHeader>
-                    </Header>
-                    <Connect(Main)>
-                      <Main>
-                        <section
-                          className="pf-l-page__main-section pf-c-page__main-section"
-                          page-type=""
+                            <PageHeaderTitle
+                              title=""
+                            >
+                              <Title
+                                className=""
+                                headingLevel="h1"
+                                size="2xl"
+                                widget-type="InsightsPageHeaderTitle"
+                              >
+                                <h1
+                                  className="pf-c-title pf-m-2xl"
+                                  widget-type="InsightsPageHeaderTitle"
+                                >
+                                   
+                                   
+                                </h1>
+                              </Title>
+                            </PageHeaderTitle>
+                          </div>
+                        </SplitItem>
+                        <SplitItem
+                          isFilled={true}
                         >
-                          <AppInfo
-                            optOutSystemHandler={[Function]}
-                          >
-                            <div>
-                              this is inventory body
-                            </div>
-                          </AppInfo>
-                        </section>
-                      </Main>
-                    </Connect(Main)>
-                  </main>
-                </div>
-              </Page>
+                          <div
+                            className="pf-l-split__item pf-m-fill"
+                          />
+                        </SplitItem>
+                      </div>
+                    </Split>
+                    <InventoryDetailHead
+                      actions={
+                        Array [
+                          Object {
+                            "onClick": [Function],
+                            "title": "Exclude from vulnerability analysis",
+                          },
+                        ]
+                      }
+                      hideBack={true}
+                    >
+                      <div>
+                        A mock with '
+                        ' passed!
+                      </div>
+                    </InventoryDetailHead>
+                  </section>
+                </PageHeader>
+              </Header>
+              <Connect(Main)>
+                <Main>
+                  <section
+                    className="pf-l-page__main-section pf-c-page__main-section"
+                    page-type=""
+                  >
+                    <AppInfo
+                      optOutSystemHandler={[Function]}
+                    >
+                      <div>
+                        this is inventory body
+                      </div>
+                    </AppInfo>
+                  </section>
+                </Main>
+              </Connect(Main)>
             </InventoryDetail>
           </Connect(InventoryDetail)>
         </injectIntl(Connect(InventoryDetail))>


### PR DESCRIPTION
Fixes [VULN-1375](https://issues.redhat.com/browse/VULN-1375).

Insight application is using PF Page component to wrap the whole page (top toolbar, left side navbar and vuln app) and Vulnerability app was using PF Page component to wrap its content (for example header and CVE table). And to my understanding you should not nest Page, only use it for the outside (whole) page. I checked and neither Drift and Compliance are using Page inside them. I did some testing and found no side effects.

Changing this fixed the problem with global filter and might prevent more bugs in the future.