### PR TITLE
chore(clean up): Clean up eslint-disable comments

### DIFF
--- a/src/Components/SmartComponents/Remediation/Remediation.js
+++ b/src/Components/SmartComponents/Remediation/Remediation.js
@@ -57,7 +57,7 @@ class Remediation extends Component {
                     id: `vulnerabilities:${id}`,
                     description: id
                 };
-                // eslint-disable-next-line camelcase
+
                 if (rules?.rule_id) {
                     issue.id = `${issue.id}:${rules.rule_id}`;
                 }

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -17,7 +17,6 @@ const SystemCvesTableWithContext = ({ context, header, entity }) => {
     const { cves, methods, selectedCves, openedCves, canEditStatus } = context;
 
     // TODO Material for refatoring when we'll introduce "manage column"
-    // eslint-disable-next-line camelcase
     if (!cves?.meta?.patch_access) {
         header = header.filter(item => item.key !== 'advisory');
     }

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -116,7 +116,6 @@ class InventoryDetail extends React.Component {
                                 loaded: true
                             },
                             {
-                                // eslint-disable-next-line camelcase
                                 title: entity?.display_name || this.props.intl.formatMessage(messages.invalidSystem),
                                 isActive: true,
                                 loaded

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -205,7 +205,6 @@ const SystemsExposedTable = (props) => {
         fetchResource: ops => fetchAffectedSystemsIdsByCve(props.cve, { ...parameters, ...ops })
     }), [items, selectedHosts, parameters]);
 
-    // eslint-disable-next-line camelcase
     const sortingHeader = items?.meta?.patch_access
         ? SYSTEMS_EXPOSED_SORTING_HEADER
         : SYSTEMS_EXPOSED_SORTING_HEADER.filter(item => item.key !== 'advisory');


### PR DESCRIPTION
we can finally use optional chaining and accessing non-camelcase variables without warnings