### PR TITLE
feat(CVE report): Translate status, business risk and impact options

### DIFF
--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -8,7 +8,7 @@ import messages from '../../../Messages';
 import firstPagePDF from './Common/firstPagePDF';
 import tablePage from './Common/tablePage';
 import DownloadReport from '../../../Helpers/DownloadReport';
-import { PDF_REPORT_PER_PAGE } from '../../../Helpers/constants';
+import { PDF_REPORT_PER_PAGE, STATUS_OPTIONS, BUSINESS_RISK_OPTIONS, impactList } from '../../../Helpers/constants';
 import { Text, View } from '@react-pdf/renderer';
 import styles from './Common/styles';
 import { useDispatch } from 'react-redux';
@@ -69,6 +69,11 @@ const DownloadCVEsReport = ({
             ...cve,
             attributes: {
                 ...cve.attributes,
+                status: STATUS_OPTIONS.find(item =>
+                    item.value === cve.attributes.status_id.toString()).label,
+                business_risk: BUSINESS_RISK_OPTIONS.find(item =>
+                    item.value === cve.attributes.business_risk_id.toString()).label,
+                impact: impactList[cve.attributes.impact].title,
                 cvss_score: parseFloat(cve.attributes.cvss3_score || cve.attributes.cvss2_score).toFixed(1)
             }
         }));

--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -73,7 +73,7 @@ const DownloadCVEsReport = ({
                     item.value === cve.attributes.status_id.toString()).label,
                 business_risk: BUSINESS_RISK_OPTIONS.find(item =>
                     item.value === cve.attributes.business_risk_id.toString()).label,
-                impact: impactList[cve.attributes.impact].title,
+                impact: impactList[cve.attributes.impact]?.title || intl.formatMessage(messages.impactListUnknown),
                 cvss_score: parseFloat(cve.attributes.cvss3_score || cve.attributes.cvss2_score).toFixed(1)
             }
         }));

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -232,7 +232,6 @@ export const BUSINESS_RISK_OPTIONS = [
         value: '3',
         label: intl.formatMessage(messages.high)
     },
-
     {
         value: '2',
         label: intl.formatMessage(messages.medium)


### PR DESCRIPTION
[SPUR page 6](https://docs.google.com/document/d/1z-T2LHa5_BWxle9DFEW7ENobZSWYC9UH4F6GI5jLluU/edit#)

CVE report was using status/BR/impact label from response, bypassing intl. I fixed this by reading status/BR/impact ID from the response and mapping translated label on our side.

This has two improvements:
- in english labels are not using title case (Not Reviewed -> Not reviewed)
- they are translatable

I was a bit concerned about the performance, so I did some tests, but there seems to be no slowdown from this change.