### PR TITLE
fix(Reports page): Disable export button if config is invalid

### DIFF
--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -53,6 +53,12 @@ const ReportConfigModal = ({
                     key="export"
                     variant="primary"
                     onClick={handleDownloadButton}
+                    isDisabled={
+                        +filterData.cvss_filter.min < 0 ||
+                        +filterData.cvss_filter.max > 10 ||
+                        +filterData.cvss_filter.min > +filterData.cvss_filter.max ||
+                        userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH
+                    }
                 >
                     {intl.formatMessage(messages.configModalExportReport)}
                 </Button>,
@@ -133,7 +139,7 @@ const ReportConfigModal = ({
                 </FormGroup>
                 <FormGroup
                     label={intl.formatMessage(messages.customReportUserNotesLabel)}
-                    fieldId="horizontal-form-name"
+                    fieldId="user-notes-box"
                     helperTextInvalid={intl.formatMessage(messages.customReportUserNoteTooLong)}
                     validated={userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH && 'error'}
                 >
@@ -141,7 +147,7 @@ const ReportConfigModal = ({
                         value={userNotes}
                         onChange={(value) => setUserNotes(value)}
                         type="text"
-                        id="horizontal-form-name"
+                        id="user-notes-box"
                         resizeOrientation='vertical'
                         style={{ minHeight: '4em' }}
                         validated={userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH && 'error'}

--- a/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
+++ b/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
@@ -70,6 +70,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
           actions={
             Array [
               <Button
+                isDisabled={false}
                 variant="primary"
               >
                 Export report
@@ -609,7 +610,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                             >
                               <label
                                 class="pf-c-form__label"
-                                for="horizontal-form-name"
+                                for="user-notes-box"
                               >
                                 <span
                                   class="pf-c-form__label-text"
@@ -625,7 +626,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                               <textarea
                                 aria-invalid="false"
                                 class="pf-c-form-control pf-m-resize-vertical"
-                                id="horizontal-form-name"
+                                id="user-notes-box"
                                 style="min-height: 4em;"
                                 type="text"
                               />
@@ -668,6 +669,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
               actions={
                 Array [
                   <Button
+                    isDisabled={false}
                     variant="primary"
                   >
                     Export report
@@ -2227,7 +2229,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                     </div>
                                   </FormGroup>
                                   <FormGroup
-                                    fieldId="horizontal-form-name"
+                                    fieldId="user-notes-box"
                                     helperTextInvalid="User notes must be less than 1000 characters."
                                     label="User notes (optional)"
                                     validated={false}
@@ -2240,7 +2242,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                       >
                                         <label
                                           className="pf-c-form__label"
-                                          htmlFor="horizontal-form-name"
+                                          htmlFor="user-notes-box"
                                         >
                                           <span
                                             className="pf-c-form__label-text"
@@ -2254,7 +2256,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                         className="pf-c-form__group-control"
                                       >
                                         <TextArea
-                                          id="horizontal-form-name"
+                                          id="user-notes-box"
                                           onChange={[Function]}
                                           resizeOrientation="vertical"
                                           style={
@@ -2269,7 +2271,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                           <TextArea
                                             aria-label={null}
                                             className=""
-                                            id="horizontal-form-name"
+                                            id="user-notes-box"
                                             innerRef={null}
                                             isRequired={false}
                                             onChange={[Function]}
@@ -2287,7 +2289,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                               aria-invalid={false}
                                               aria-label={null}
                                               className="pf-c-form-control pf-m-resize-vertical"
-                                              id="horizontal-form-name"
+                                              id="user-notes-box"
                                               onChange={[Function]}
                                               required={false}
                                               style={
@@ -2312,6 +2314,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                               className="pf-c-modal-box__footer"
                             >
                               <Button
+                                isDisabled={false}
                                 key="export"
                                 variant="primary"
                               >

--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -39,7 +39,7 @@ const DownloadExecutive = () => {
     };
 
     return (<Fragment>
-        <a href onClick={() => handleDownloadButton()}>
+        <a onClick={() => handleDownloadButton()}>
             {intl.formatMessage(messages.executiveReportCardButton)}
         </a>
         { renderPDF && <DownloadButton

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -10,7 +10,7 @@ import { ChartPieSolid } from '../../PresentationalComponents/CustomIcons/Custom
 import Header from '../../PresentationalComponents/Header/Header';
 import DownloadCVEsReport from '../Reports/DownloadCVEsReport';
 import { constructFilterParameters, buildFilters } from '../Reports/ReportsHelper';
-import { CVE_REPORT_FILTERS, DEFAULT_FILTER_DATA, PDF_REPORT_USER_NOTE_MAX_LENGTH } from '../../../Helpers/constants';
+import { CVE_REPORT_FILTERS, DEFAULT_FILTER_DATA } from '../../../Helpers/constants';
 import styles from './Common/styles';
 
 const ReportsPage = () => {
@@ -103,14 +103,6 @@ const ReportsPage = () => {
                 params={constructFilterParameters(filterData)}
                 filters={buildFilters(filterData)}
                 isReportDynamic
-                buttonProps={{
-                    isDisabled:
-                            +filterData.cvss_filter.min < 0 ||
-                            +filterData.cvss_filter.max > 10 ||
-                            +filterData.cvss_filter.min > +filterData.cvss_filter.max ||
-                            userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH,
-                    style: { marginRight: '0.5em' }
-                }}
                 label={messages.configModalExportReport}
             />}
         </React.Fragment>

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -165,7 +165,6 @@ exports[`Reports page component Should match snapshots 1`] = `
                             >
                               <DownloadExecutive>
                                 <a
-                                  href={true}
                                   onClick={[Function]}
                                 >
                                   Download PDF
@@ -298,6 +297,7 @@ exports[`Reports page component Should match snapshots 1`] = `
             actions={
               Array [
                 <Button
+                  isDisabled={false}
                   onClick={[Function]}
                   variant="primary"
                 >
@@ -335,6 +335,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                 actions={
                   Array [
                     <Button
+                      isDisabled={false}
                       onClick={[Function]}
                       variant="primary"
                     >


### PR DESCRIPTION
Disable export button on the report config modal and prevent user from exporting the report if:
- user note is too long
- CVSS score filter is < 0, > 10, or min > max

Also fix some errors from the console.