### PR TITLE
VULN-1275 feat: Update CSAw summary to new mockups

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -92,7 +92,7 @@
   "cvssVector.value": "Value",
   "cvssVector.vector": "vector",
   "delete": "Delete",
-  "description": "Description",
+  "description": "CVE description",
   "downloadExecutive.info": "Executive report is being generated",
   "downloadExecutive.label": "Download executive report",
   "edit": "Edit",
@@ -279,6 +279,7 @@
   "vectorValues.required": "Required",
   "vectorValues.single": "Single",
   "vectorValues.unchanged": "Unchanged",
+  "viewMoreAboutThisCve": "View more information about this CVE",
   "viewMoreScurityRules": "View { rules, plural, one {# more security rule} other {# more security rules}}",
   "vulnerabilitiesHeader": "Vulnerability",
   "yes": "Yes"

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
@@ -5,8 +5,7 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import sanitizeHtml from 'sanitize-html';
 import { Truncate } from '@redhat-cloud-services/frontend-components';
-import { Stack, StackItem, TextContent } from '@patternfly/react-core';
-import { handleCVELink } from '../../../Helpers/VulnerabilityHelper';
+import { StackItem, TextContent } from '@patternfly/react-core';
 import { TRUNCATE_TEXT_THRESHOLD } from '../../../Helpers/constants';
 import messages from '../../../Messages';
 
@@ -21,13 +20,13 @@ renderer.link = function() {
 
 marked.setOptions({ renderer });
 
-const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
+const CSAwRuleSummary = ({ text, truncate, intl }) => {
     const dangerousHtml = (text) => ({ __html: sanitizeHtml(text) });
 
     return (
         <StackItem>
             <TextContent className="rule-description">
-                { truncate && text.length > TRUNCATE_TEXT_THRESHOLD
+                {truncate && text.length > TRUNCATE_TEXT_THRESHOLD
                     ? (
                         <Truncate
                             length={TRUNCATE_TEXT_THRESHOLD}
@@ -37,14 +36,7 @@ const CSAwRuleSummary = ({ text, truncate, link, intl }) => {
                             spaceBetween
                         />
                     ) : (
-                        <Stack>
-                            <StackItem>
-                                <span dangerouslySetInnerHTML={dangerousHtml(marked(text))}/>
-                            </StackItem>
-                            {link && <StackItem className="rule-link pf-u-mt-sm">
-                                {handleCVELink(link, intl.formatMessage(messages.readMore))}
-                            </StackItem>}
-                        </Stack>
+                        <span dangerouslySetInnerHTML={dangerousHtml(marked(text))} />
                     )
                 }
             </TextContent>
@@ -64,8 +56,7 @@ CSAwRuleSummary.propTypes = {
         PropTypes.object
     ]),
     truncate: PropTypes.bool,
-    text: PropTypes.string.isRequired,
-    link: PropTypes.string
+    text: PropTypes.string.isRequired
 };
 
 export default injectIntl(CSAwRuleSummary);

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.test.js
@@ -18,11 +18,4 @@ describe('CSAW Rule summary', () => {
         const wrapper = mountWithIntl(<CSAwRuleSummary truncate={false} text={text} />);
         expect(wrapper.find('Truncate')).toHaveLength(0)
     })
-
-    it('should render with link', () => {
-        const link = 'test-cve-id'
-        const wrapper = mountWithIntl(<CSAwRuleSummary truncate={false} text={text} link={link} />);
-        const href = wrapper.find('a').prop('href')
-        expect(href).toBe(`http://localhost/insights/vulnerability/cves/${link}`)
-    })
 });

--- a/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
+++ b/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
@@ -1,39 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Text, TextContent, TextVariants, Tooltip, Stack } from '@patternfly/react-core';
+import { intl } from '../../../Utilities/IntlProvider';
+import { Text, TextContent, TextVariants, Tooltip, Stack, StackItem } from '@patternfly/react-core';
 import Label from '../Snippets/Label';
 import { CSAwIcon } from '../CustomIcons/CustomIcons';
 import CSAwRuleSummary from '../CSAwRuleBox/CSAwRuleSummary';
 import messages from '../../../Messages';
+import { handleCVELink } from '../../../Helpers/VulnerabilityHelper';
 
 const CVETableExpandedCell = ({ description, rules, cve }) => {
     const ruleIconTooltip = <FormattedMessage {...messages.rulesIconTooltip} />;
 
     return (
         <TextContent className="expanded-cell">
-            <Label>{<FormattedMessage {...messages.description} />}</Label>
+            <Label className='pf-u-mb-sm'>{<FormattedMessage {...messages.description} />}</Label>
             <Text component={TextVariants.p}>{description}</Text>
             <Stack hasGutter>
                 {rules && rules.map((rule, i) => (
                     rule && (
-                        <div key={i} className="rule">
-                            <Text component={TextVariants.p}>
-                                <Label className={'icon-with-label'}>
-                                    <Tooltip content={ruleIconTooltip}>
-                                        <CSAwIcon />
-                                    </Tooltip>
-                                    <span className="rule-name">{rule.description || rule.rule_id}</span>
-                                </Label>
-                            </Text>
+                        <div key={i}>
+                            <Label className='icon-with-label pf-u-mb-sm'>
+                                <Tooltip content={ruleIconTooltip}>
+                                    <CSAwIcon />
+                                </Tooltip>
+                                <span className="rule-name">{rule.description || rule.rule_id}</span>
+                            </Label>
                             <CSAwRuleSummary
                                 text={rule.summary}
-                                link={cve}
                                 truncate={false}
                             />
                         </div>
                     )
                 ))}
+                <StackItem className="rule-link">
+                    {handleCVELink(cve, intl.formatMessage(messages.viewMoreAboutThisCve))}
+                </StackItem>
             </Stack>
         </TextContent>
     );

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -10561,11 +10561,11 @@ exports[`CVEs Should render without props 1`] = `
                                                                               className="vuln-label pf-u-mb-sm"
                                                                             >
                                                                               <FormattedMessage
-                                                                                defaultMessage="CVE Description"
+                                                                                defaultMessage="CVE description"
                                                                                 description="Expanded cell containing CVE desciption title"
                                                                                 id="description"
                                                                               >
-                                                                                CVE Description
+                                                                                CVE description
                                                                               </FormattedMessage>
                                                                             </span>
                                                                           </Label>

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -10554,16 +10554,18 @@ exports[`CVEs Should render without props 1`] = `
                                                                         <div
                                                                           className="pf-c-content expanded-cell"
                                                                         >
-                                                                          <Label>
+                                                                          <Label
+                                                                            className="pf-u-mb-sm"
+                                                                          >
                                                                             <span
-                                                                              className="vuln-label undefined"
+                                                                              className="vuln-label pf-u-mb-sm"
                                                                             >
                                                                               <FormattedMessage
-                                                                                defaultMessage="Description"
-                                                                                description="Label for column"
+                                                                                defaultMessage="CVE Description"
+                                                                                description="Expanded cell containing CVE desciption title"
                                                                                 id="description"
                                                                               >
-                                                                                Description
+                                                                                CVE Description
                                                                               </FormattedMessage>
                                                                             </span>
                                                                           </Label>
@@ -10582,7 +10584,21 @@ exports[`CVEs Should render without props 1`] = `
                                                                           >
                                                                             <div
                                                                               className="pf-l-stack pf-m-gutter"
-                                                                            />
+                                                                            >
+                                                                              <StackItem
+                                                                                className="rule-link"
+                                                                              >
+                                                                                <div
+                                                                                  className="pf-l-stack__item rule-link"
+                                                                                >
+                                                                                  <a
+                                                                                    href="http://localhost/insights/vulnerability/cves/CVE-2020-0543"
+                                                                                  >
+                                                                                    View more information about this CVE
+                                                                                  </a>
+                                                                                </div>
+                                                                              </StackItem>
+                                                                            </div>
                                                                           </Stack>
                                                                         </div>
                                                                       </TextContent>

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -7517,16 +7517,18 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                             <div
                                                               className="pf-c-content expanded-cell"
                                                             >
-                                                              <Label>
+                                                              <Label
+                                                                className="pf-u-mb-sm"
+                                                              >
                                                                 <span
-                                                                  className="vuln-label undefined"
+                                                                  className="vuln-label pf-u-mb-sm"
                                                                 >
                                                                   <FormattedMessage
-                                                                    defaultMessage="Description"
-                                                                    description="Label for column"
+                                                                    defaultMessage="CVE Description"
+                                                                    description="Expanded cell containing CVE desciption title"
                                                                     id="description"
                                                                   >
-                                                                    Description
+                                                                    CVE Description
                                                                   </FormattedMessage>
                                                                 </span>
                                                               </Label>
@@ -7545,7 +7547,21 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                               >
                                                                 <div
                                                                   className="pf-l-stack pf-m-gutter"
-                                                                />
+                                                                >
+                                                                  <StackItem
+                                                                    className="rule-link"
+                                                                  >
+                                                                    <div
+                                                                      className="pf-l-stack__item rule-link"
+                                                                    >
+                                                                      <a
+                                                                        href="http://localhost/insights/vulnerability/cves/CVE-2020-0543"
+                                                                      >
+                                                                        View more information about this CVE
+                                                                      </a>
+                                                                    </div>
+                                                                  </StackItem>
+                                                                </div>
                                                               </Stack>
                                                             </div>
                                                           </TextContent>

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -7524,11 +7524,11 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                                   className="vuln-label pf-u-mb-sm"
                                                                 >
                                                                   <FormattedMessage
-                                                                    defaultMessage="CVE Description"
+                                                                    defaultMessage="CVE description"
                                                                     description="Expanded cell containing CVE desciption title"
                                                                     id="description"
                                                                   >
-                                                                    CVE Description
+                                                                    CVE description
                                                                   </FormattedMessage>
                                                                 </span>
                                                               </Label>

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -12067,16 +12067,18 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                     <div
                                                                       className="pf-c-content expanded-cell"
                                                                     >
-                                                                      <Label>
+                                                                      <Label
+                                                                        className="pf-u-mb-sm"
+                                                                      >
                                                                         <span
-                                                                          className="vuln-label undefined"
+                                                                          className="vuln-label pf-u-mb-sm"
                                                                         >
                                                                           <FormattedMessage
-                                                                            defaultMessage="Description"
-                                                                            description="Label for column"
+                                                                            defaultMessage="CVE Description"
+                                                                            description="Expanded cell containing CVE desciption title"
                                                                             id="description"
                                                                           >
-                                                                            Description
+                                                                            CVE Description
                                                                           </FormattedMessage>
                                                                         </span>
                                                                       </Label>
@@ -12095,7 +12097,21 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                       >
                                                                         <div
                                                                           className="pf-l-stack pf-m-gutter"
-                                                                        />
+                                                                        >
+                                                                          <StackItem
+                                                                            className="rule-link"
+                                                                          >
+                                                                            <div
+                                                                              className="pf-l-stack__item rule-link"
+                                                                            >
+                                                                              <a
+                                                                                href="http://localhost/insights/vulnerability/cves/CVE-2020-0543"
+                                                                              >
+                                                                                View more information about this CVE
+                                                                              </a>
+                                                                            </div>
+                                                                          </StackItem>
+                                                                        </div>
                                                                       </Stack>
                                                                     </div>
                                                                   </TextContent>

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -12074,11 +12074,11 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                           className="vuln-label pf-u-mb-sm"
                                                                         >
                                                                           <FormattedMessage
-                                                                            defaultMessage="CVE Description"
+                                                                            defaultMessage="CVE description"
                                                                             description="Expanded cell containing CVE desciption title"
                                                                             id="description"
                                                                           >
-                                                                            CVE Description
+                                                                            CVE description
                                                                           </FormattedMessage>
                                                                         </span>
                                                                       </Label>

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -8286,11 +8286,11 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                               className="vuln-label pf-u-mb-sm"
                                                             >
                                                               <FormattedMessage
-                                                                defaultMessage="CVE Description"
+                                                                defaultMessage="CVE description"
                                                                 description="Expanded cell containing CVE desciption title"
                                                                 id="description"
                                                               >
-                                                                CVE Description
+                                                                CVE description
                                                               </FormattedMessage>
                                                             </span>
                                                           </Label>

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -8279,16 +8279,18 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                         <div
                                                           className="pf-c-content expanded-cell"
                                                         >
-                                                          <Label>
+                                                          <Label
+                                                            className="pf-u-mb-sm"
+                                                          >
                                                             <span
-                                                              className="vuln-label undefined"
+                                                              className="vuln-label pf-u-mb-sm"
                                                             >
                                                               <FormattedMessage
-                                                                defaultMessage="Description"
-                                                                description="Label for column"
+                                                                defaultMessage="CVE Description"
+                                                                description="Expanded cell containing CVE desciption title"
                                                                 id="description"
                                                               >
-                                                                Description
+                                                                CVE Description
                                                               </FormattedMessage>
                                                             </span>
                                                           </Label>
@@ -8309,122 +8311,111 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                               className="pf-l-stack pf-m-gutter"
                                                             >
                                                               <div
-                                                                className="rule"
                                                                 key="0"
                                                               >
-                                                                <Text
-                                                                  component="p"
+                                                                <Label
+                                                                  className="icon-with-label pf-u-mb-sm"
                                                                 >
-                                                                  <p
-                                                                    className=""
-                                                                    data-pf-content={true}
+                                                                  <span
+                                                                    className="vuln-label icon-with-label pf-u-mb-sm"
                                                                   >
-                                                                    <Label
-                                                                      className="icon-with-label"
+                                                                    <Tooltip
+                                                                      content={
+                                                                        <FormattedMessage
+                                                                          defaultMessage="Denotes a security rule. Security rules are written by Red Hat to help you configure your systems"
+                                                                          description="Tooltip"
+                                                                          id="rules.iconTooolip"
+                                                                        />
+                                                                      }
                                                                     >
-                                                                      <span
-                                                                        className="vuln-label icon-with-label"
-                                                                      >
-                                                                        <Tooltip
-                                                                          content={
-                                                                            <FormattedMessage
-                                                                              defaultMessage="Denotes a security rule. Security rules are written by Red Hat to help you configure your systems"
-                                                                              description="Tooltip"
-                                                                              id="rules.iconTooolip"
-                                                                            />
-                                                                          }
-                                                                        >
-                                                                          <Popper
-                                                                            appendTo={[Function]}
-                                                                            distance={15}
-                                                                            enableFlip={true}
-                                                                            flipBehavior={
-                                                                              Array [
-                                                                                "top",
-                                                                                "right",
-                                                                                "bottom",
-                                                                                "left",
-                                                                                "top",
-                                                                                "right",
-                                                                                "bottom",
-                                                                              ]
-                                                                            }
-                                                                            isVisible={false}
-                                                                            onBlur={[Function]}
-                                                                            onDocumentClick={false}
-                                                                            onDocumentKeyDown={[Function]}
-                                                                            onFocus={[Function]}
-                                                                            onMouseEnter={[Function]}
-                                                                            onMouseLeave={[Function]}
-                                                                            onTriggerEnter={[Function]}
-                                                                            placement="top"
-                                                                            popper={
-                                                                              <div
-                                                                                className="pf-c-tooltip"
-                                                                                id="pf-tooltip-4"
-                                                                                role="tooltip"
-                                                                                style={
-                                                                                  Object {
-                                                                                    "maxWidth": null,
-                                                                                    "opacity": 0,
-                                                                                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                                                                  }
-                                                                                }
-                                                                              >
-                                                                                <TooltipArrow />
-                                                                                <TooltipContent
-                                                                                  isLeftAligned={false}
-                                                                                >
-                                                                                  <FormattedMessage
-                                                                                    defaultMessage="Denotes a security rule. Security rules are written by Red Hat to help you configure your systems"
-                                                                                    description="Tooltip"
-                                                                                    id="rules.iconTooolip"
-                                                                                  />
-                                                                                </TooltipContent>
-                                                                              </div>
-                                                                            }
-                                                                            popperMatchesTriggerWidth={false}
-                                                                            positionModifiers={
+                                                                      <Popper
+                                                                        appendTo={[Function]}
+                                                                        distance={15}
+                                                                        enableFlip={true}
+                                                                        flipBehavior={
+                                                                          Array [
+                                                                            "top",
+                                                                            "right",
+                                                                            "bottom",
+                                                                            "left",
+                                                                            "top",
+                                                                            "right",
+                                                                            "bottom",
+                                                                          ]
+                                                                        }
+                                                                        isVisible={false}
+                                                                        onBlur={[Function]}
+                                                                        onDocumentClick={false}
+                                                                        onDocumentKeyDown={[Function]}
+                                                                        onFocus={[Function]}
+                                                                        onMouseEnter={[Function]}
+                                                                        onMouseLeave={[Function]}
+                                                                        onTriggerEnter={[Function]}
+                                                                        placement="top"
+                                                                        popper={
+                                                                          <div
+                                                                            className="pf-c-tooltip"
+                                                                            id="pf-tooltip-4"
+                                                                            role="tooltip"
+                                                                            style={
                                                                               Object {
-                                                                                "bottom": "pf-m-bottom",
-                                                                                "left": "pf-m-left",
-                                                                                "right": "pf-m-right",
-                                                                                "top": "pf-m-top",
+                                                                                "maxWidth": null,
+                                                                                "opacity": 0,
+                                                                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
                                                                               }
                                                                             }
-                                                                            trigger={
-                                                                              <CSAwIcon
-                                                                                aria-describedby="pf-tooltip-4"
-                                                                              />
-                                                                            }
-                                                                            zIndex={9999}
                                                                           >
-                                                                            <FindRefWrapper
-                                                                              onFoundRef={[Function]}
+                                                                            <TooltipArrow />
+                                                                            <TooltipContent
+                                                                              isLeftAligned={false}
                                                                             >
-                                                                              <CSAwIcon
-                                                                                aria-describedby="pf-tooltip-4"
-                                                                              >
-                                                                                <img
-                                                                                  alt="Customer security awareness icon"
-                                                                                  className="csaw-icon"
-                                                                                  src="test-file-stub"
-                                                                                />
-                                                                              </CSAwIcon>
-                                                                            </FindRefWrapper>
-                                                                          </Popper>
-                                                                        </Tooltip>
-                                                                        <span
-                                                                          className="rule-name"
+                                                                              <FormattedMessage
+                                                                                defaultMessage="Denotes a security rule. Security rules are written by Red Hat to help you configure your systems"
+                                                                                description="Tooltip"
+                                                                                id="rules.iconTooolip"
+                                                                              />
+                                                                            </TooltipContent>
+                                                                          </div>
+                                                                        }
+                                                                        popperMatchesTriggerWidth={false}
+                                                                        positionModifiers={
+                                                                          Object {
+                                                                            "bottom": "pf-m-bottom",
+                                                                            "left": "pf-m-left",
+                                                                            "right": "pf-m-right",
+                                                                            "top": "pf-m-top",
+                                                                          }
+                                                                        }
+                                                                        trigger={
+                                                                          <CSAwIcon
+                                                                            aria-describedby="pf-tooltip-4"
+                                                                          />
+                                                                        }
+                                                                        zIndex={9999}
+                                                                      >
+                                                                        <FindRefWrapper
+                                                                          onFoundRef={[Function]}
                                                                         >
-                                                                          testDescription
-                                                                        </span>
-                                                                      </span>
-                                                                    </Label>
-                                                                  </p>
-                                                                </Text>
+                                                                          <CSAwIcon
+                                                                            aria-describedby="pf-tooltip-4"
+                                                                          >
+                                                                            <img
+                                                                              alt="Customer security awareness icon"
+                                                                              className="csaw-icon"
+                                                                              src="test-file-stub"
+                                                                            />
+                                                                          </CSAwIcon>
+                                                                        </FindRefWrapper>
+                                                                      </Popper>
+                                                                    </Tooltip>
+                                                                    <span
+                                                                      className="rule-name"
+                                                                    >
+                                                                      testDescription
+                                                                    </span>
+                                                                  </span>
+                                                                </Label>
                                                                 <injectIntl(CSAwRuleSummary)
-                                                                  link="CVE-2020-0543"
                                                                   text="testSummary"
                                                                   truncate={false}
                                                                 >
@@ -8467,7 +8458,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                                         "wrapRichTextChunksInFragment": undefined,
                                                                       }
                                                                     }
-                                                                    link="CVE-2020-0543"
+                                                                    link={null}
                                                                     text="testSummary"
                                                                     truncate={false}
                                                                   >
@@ -8481,39 +8472,14 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                                           <div
                                                                             className="pf-c-content rule-description"
                                                                           >
-                                                                            <Stack>
-                                                                              <div
-                                                                                className="pf-l-stack"
-                                                                              >
-                                                                                <StackItem>
-                                                                                  <div
-                                                                                    className="pf-l-stack__item"
-                                                                                  >
-                                                                                    <span
-                                                                                      dangerouslySetInnerHTML={
-                                                                                        Object {
-                                                                                          "__html": "<p>testSummary</p>
+                                                                            <span
+                                                                              dangerouslySetInnerHTML={
+                                                                                Object {
+                                                                                  "__html": "<p>testSummary</p>
 ",
-                                                                                        }
-                                                                                      }
-                                                                                    />
-                                                                                  </div>
-                                                                                </StackItem>
-                                                                                <StackItem
-                                                                                  className="rule-link pf-u-mt-sm"
-                                                                                >
-                                                                                  <div
-                                                                                    className="pf-l-stack__item rule-link pf-u-mt-sm"
-                                                                                  >
-                                                                                    <a
-                                                                                      href="http://localhost/insights/vulnerability/cves/CVE-2020-0543"
-                                                                                    >
-                                                                                      Read more
-                                                                                    </a>
-                                                                                  </div>
-                                                                                </StackItem>
-                                                                              </div>
-                                                                            </Stack>
+                                                                                }
+                                                                              }
+                                                                            />
                                                                           </div>
                                                                         </TextContent>
                                                                       </div>
@@ -8521,6 +8487,19 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                                   </CSAwRuleSummary>
                                                                 </injectIntl(CSAwRuleSummary)>
                                                               </div>
+                                                              <StackItem
+                                                                className="rule-link"
+                                                              >
+                                                                <div
+                                                                  className="pf-l-stack__item rule-link"
+                                                                >
+                                                                  <a
+                                                                    href="http://localhost/insights/vulnerability/cves/CVE-2020-0543"
+                                                                  >
+                                                                    View more information about this CVE
+                                                                  </a>
+                                                                </div>
+                                                              </StackItem>
                                                             </div>
                                                           </Stack>
                                                         </div>

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -97,6 +97,11 @@ export default defineMessages({
         description: 'Read less label for general usage',
         defaultMessage: 'Read less'
     },
+    viewMoreAboutThisCve: {
+        id: 'viewMoreAboutThisCve',
+        description: 'Link in csaw summary to open the CVE detail',
+        defaultMessage: 'View more information about this CVE'
+    },
     cveStatus: {
         id: 'cveStatus',
         description: 'Cve status label for general usage',
@@ -139,8 +144,8 @@ export default defineMessages({
     },
     description: {
         id: 'description',
-        description: 'Label for column',
-        defaultMessage: 'Description'
+        description: 'Expanded cell containing CVE desciption title',
+        defaultMessage: 'CVE description'
     },
     associatedCves: {
         id: 'associatedCves',


### PR DESCRIPTION
Fixes [VULN-1275](https://issues.redhat.com/browse/VULN-1275).
[Mockup link](https://marvelapp.com/prototype/5f47fef/screen/75473599)

This includes:
- replacing `Description` label with `CVE description`
- replacing multiple `Read more` links with one `View more info about this CVE`
- adding `View more info about this CVE` link to expanded desc of CVEs without security rule
- spacing improvements

This does not include:
- replacing security rule icons with insight-labels

## Before:
![before](https://user-images.githubusercontent.com/8426204/102632242-1c6c1800-414f-11eb-87d3-9cb2c3224a88.png)

## After:
![after](https://user-images.githubusercontent.com/8426204/102632186-02cad080-414f-11eb-91a7-bcb4f290b5cb.png)
![after2](https://user-images.githubusercontent.com/8426204/102632163-fc3c5900-414e-11eb-8f69-d8e3942a2cf2.png)

## Mockup:
![mockup](https://user-images.githubusercontent.com/8426204/102632176-ff374980-414e-11eb-9076-79b6d5fb4137.png)