### PR TITLE
VULN-1369 fix(executive report): Do not render 2nd page if it's empty

### DIFF
--- a/src/Components/SmartComponents/Reports/BuildExecReport.js
+++ b/src/Components/SmartComponents/Reports/BuildExecReport.js
@@ -14,6 +14,7 @@ import {
 import { Text } from '@react-pdf/renderer';
 import messages from '../../../Messages';
 import styles from './Common/styles';
+import { insertIf } from '../../../Helpers/MiscHelper';
 
 const BuildExecReport = ({ data, intl }) => {
 
@@ -99,13 +100,15 @@ const BuildExecReport = ({ data, intl }) => {
                     </PanelItem>
                 </Panel>
             );
-            totalRows <= 15 && panelGroups.firstPage.push(panel) || panelGroups.secondPage.push(panel);
+            totalRows <= safeCharLength.rows && panelGroups.firstPage.push(panel) || panelGroups.secondPage.push(panel);
 
         });
         return panelGroups;
     };
 
-    return [(
+    const topCvesPerPage = calculateTopCves();
+
+    const firstPage = (
         <Fragment key="first-section">
             <Paragraph>
                 {intl.formatMessage(messages.executiveReportHeader)}
@@ -149,13 +152,16 @@ const BuildExecReport = ({ data, intl }) => {
             </Section>
             <Section title={intl.formatMessage(messages.executiveReportTop3)} withColumn={false}>
                 {
-                    calculateTopCves().firstPage
+                    topCvesPerPage.firstPage
 
                 }
             </Section>
         </Fragment>
-    ),
-    calculateTopCves().secondPage
+    );
+
+    return [
+        firstPage,
+        ...insertIf(topCvesPerPage.secondPage.length > 0, topCvesPerPage.secondPage)
     ];
 };
 

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -216,3 +216,7 @@ export const shallowWithIntl = (Component) => {
 
     return wrapper;
 };
+
+export const insertIf = (condition, ...elements) => {
+    return condition ? elements : [];
+};


### PR DESCRIPTION
Insert the second page only if it has CVEs to display. 
also, some enhancements to avoid running `topCvesPerPage` function twice
[vulnerability_executive-report--2021-01-07(18).pdf](https://github.com/RedHatInsights/vulnerability-ui/files/5782202/vulnerability_executive-report--2021-01-07.18.pdf)
