### PR TITLE
chore: bring back rule div class

### DIFF
--- a/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
+++ b/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
@@ -19,7 +19,7 @@ const CVETableExpandedCell = ({ description, rules, cve }) => {
             <Stack hasGutter>
                 {rules && rules.map((rule, i) => (
                     rule && (
-                        <div key={i}>
+                        <div key={i} className="rule">
                             <Label className='icon-with-label pf-u-mb-sm'>
                                 <Tooltip content={ruleIconTooltip}>
                                     <CSAwLabel className="pf-u-mr-sm"/>

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -8476,6 +8476,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                               className="pf-l-stack pf-m-gutter"
                                                             >
                                                               <div
+                                                                className="rule"
                                                                 key="0"
                                                               >
                                                                 <Label


### PR DESCRIPTION
Tests are failing because they can't find rules in expanded CVE