### PR TITLE
fix(CVE page): Handle errors gracefully

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -182,6 +182,8 @@
   "moreThanYear": "More than 1 year ago",
   "no": "No",
   "noAction": "No action - risk accepted",
+  "notAuthorizedDescription": "Contact your organization administrator(s) for more information.",
+  "notAuthorizedTitle": "You do not have permissions to view or manage Vulnerability",
   "notAvailable": "Not available",
   "notDefined": "Not defined",
   "notReviewed": "Not reviewed",

--- a/src/Components/PresentationalComponents/EmptyStates/EmptyStates.js
+++ b/src/Components/PresentationalComponents/EmptyStates/EmptyStates.js
@@ -153,32 +153,3 @@ export const EmptyVulnerabilityData = (
         </EmptyState>
     </Bullseye>
 );
-
-// Generic error
-export const GenericError = (
-    <Bullseye>
-        <EmptyState variant={EmptyStateVariant.large}>
-            <EmptyStateIcon icon={ExclamationCircleIcon} color={'var(--pf-global--danger-color--100)'} />
-            <Title headingLevel="h5" size="lg">
-                <FormattedMessage {...messages.somethingWrong} />
-            </Title>
-            <EmptyStateBody>
-                <FormattedMessage {...messages.tryRefreshing} />
-                <br/><br/>
-                <FormattedMessage {...messages.ifProblemPersists}
-                    values = {{
-                        statusPageLink:
-                                <a href="https://status.redhat.com" target="__blank" rel="noopener noreferrer">
-                                    <FormattedMessage {...messages.statusPage} />
-                                </a>
-                    }}
-                />
-                <br/><br/>
-                <Button variant="primary" onClick={ () => history.back() }>
-                    <FormattedMessage {...messages.returnToPreviousPage} />
-                </Button>
-
-            </EmptyStateBody>
-        </EmptyState>
-    </Bullseye>
-);

--- a/src/Components/PresentationalComponents/EmptyStates/EmptyStates.js
+++ b/src/Components/PresentationalComponents/EmptyStates/EmptyStates.js
@@ -175,7 +175,7 @@ export const GenericError = (
                 />
                 <br/><br/>
                 <Button variant="primary" onClick={ () => history.back() }>
-                    <FormattedMessage {...messages.returnPreviousPage} />
+                    <FormattedMessage {...messages.returnToPreviousPage} />
                 </Button>
 
             </EmptyStateBody>

--- a/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
+++ b/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
@@ -8,16 +8,16 @@ import {
 
 const ErrorHandler = ({ code }) => {
     switch (code) {
-        case 500:
-            return <Unavailable />;
-        case 503:
-            return <Unavailable />;
         case 404:
             return <InvalidObject />;
-        case 400:
-            return <ErrorState />;
+
+        case 500:
+        case 502:
+        case 503:
+            return <Unavailable />;
+
         default:
-            return <ErrorState/>;
+            return <ErrorState />;
     }
 };
 

--- a/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
+++ b/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
@@ -3,11 +3,24 @@ import propTypes from 'prop-types';
 import {
     InvalidObject,
     Unavailable,
-    ErrorState
+    ErrorState,
+    NotAuthorized
 } from '@redhat-cloud-services/frontend-components';
+import { LockIcon } from '@patternfly/react-icons';
+import { intl } from '../../../Utilities/IntlProvider';
+import messages from '../../../Messages';
 
 const ErrorHandler = ({ code }) => {
     switch (code) {
+        case 403:
+            return <NotAuthorized
+                icon={LockIcon}
+                title={intl.formatMessage(messages.notAuthorizedTitle)}
+                description={intl.formatMessage(messages.notAuthorizedDescription)}
+                prevPageButtonText={intl.formatMessage(messages.returnToPreviousPage)}
+                toLandingPageText={intl.formatMessage(messages.returnToLandingPage)}
+            />;
+
         case 404:
             return <InvalidObject />;
 

--- a/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
+++ b/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
@@ -28,7 +28,7 @@ const NoAccessPage = ({ intl }) => {
                         {
                             document.referrer ?
                                 <Button variant="primary" onClick={ () => history.back() }>
-                                    {intl.formatMessage(messages.returnPreviousPage)}
+                                    {intl.formatMessage(messages.returnToPreviousPage)}
                                 </Button> :
                                 <Button variant="primary" component="a" href=".">
                                     {intl.formatMessage(messages.returnToLandingPage)}

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -2,7 +2,6 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { VULNERABILITIES_HEADER, CVES_ALLOWED_PARAMS } from '../../../Helpers/constants';
-import { GenericError } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { createCveListByAccount } from '../../../Helpers/VulnerabilityHelper';
 import { constructFilterParameters, updateRef, useUrlParams } from '../../../Helpers/MiscHelper';
 import BusinessRiskModal from '../Modals/BusinessRiskModal';
@@ -20,6 +19,7 @@ import {
 import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 
 export const CVETableContext = React.createContext({});
 
@@ -70,12 +70,12 @@ export const CVEs = () => {
     useEffect(() => {
         return () => {
             dispatch(clearCVEsStore());
+            dispatch(clearNotifications());
         };
-    }, []);
+    }, [dispatch]);
 
     const processError = () => {
-        dispatch(clearNotifications());
-        return GenericError;
+        return <ErrorHandler code={parseInt(cves.errors.status)} />;
     };
 
     const handleCveSelect = (isSelected, cveNames) => {

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -74,10 +74,6 @@ export const CVEs = () => {
         };
     }, [dispatch]);
 
-    const processError = () => {
-        return <ErrorHandler code={parseInt(cves.errors.status)} />;
-    };
-
     const handleCveSelect = (isSelected, cveNames) => {
         dispatch(selectCve(cveNames || []));
     };
@@ -137,7 +133,7 @@ export const CVEs = () => {
             </CVETableContext.Provider>
         );
     } else {
-        return processError();
+        return <ErrorHandler code={parseInt(cves.errors.status)}/>;
     }
 
 };

--- a/src/Components/SmartComponents/CVEs/CVEs.test.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.test.js
@@ -103,7 +103,7 @@ describe('CVEs', () => {
         expect(dispatchedActions.filter(item => item.type === 'CLEAR_CVEs_STORE')).toHaveLength(1);
     });
 
-    it('Should generate GenericError', () => {
+    it('Should generate error', () => {
         const customMiddleWareErrors = store => next => action => {
             useSelector.mockImplementation(callback => {
                 return callback({ 

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -67,7 +67,7 @@ export const SystemCVEs = ({ entity, intl, allowedCveActions, showHeaderLabel, s
             return EmptyVulnerabilityData;
         }
         else {
-            return <ErrorHandler code={status}/>;
+            return <ErrorHandler code={statusCode}/>;
         }
     };
 

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -17,7 +17,7 @@ import { SYSTEM_DETAILS_HEADER, CVES_ALLOWED_PARAMS } from '../../../Helpers/con
 import { constructFilterParameters, useUrlParams, updateRef } from '../../../Helpers/MiscHelper';
 import { createCveListBySystem } from '../../../Helpers/VulnerabilityHelper';
 import { Stack, StackItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { EmptyVulnerabilityData, GenericError } from '../../PresentationalComponents/EmptyStates/EmptyStates';
+import { EmptyVulnerabilityData } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import DownloadReport from '../../../Helpers/DownloadReport';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import SystemCveTableToolbar from './SystemCveTableToolbar';
@@ -25,6 +25,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 
 export const CVETableContext = createContext({});
 
@@ -66,8 +67,7 @@ export const SystemCVEs = ({ entity, intl, allowedCveActions, showHeaderLabel, s
             return EmptyVulnerabilityData;
         }
         else {
-            dispatch(clearNotifications());
-            return GenericError;
+            return <ErrorHandler code={status}/>;
         }
     };
 
@@ -97,6 +97,7 @@ export const SystemCVEs = ({ entity, intl, allowedCveActions, showHeaderLabel, s
     useEffect(() => {
         return () => {
             dispatch(clearSystemCvesStore());
+            dispatch(clearNotifications());
         };
     }, []);
 

--- a/src/Components/SmartComponents/SystemCves/SystemCves.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.test.js
@@ -128,7 +128,7 @@ describe('SystemCves', () => {
             );
         };
 
-        it('Should generate GenericError', () => {
+        it('Should generate error', () => {
             const customMiddleWareErrors = store => next => action => {
                 useSelector.mockImplementation(callback => {
                     return callback({ 

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -152,9 +152,9 @@ const SystemsPage = ({ intl }) => {
             <Header title={intl.formatMessage(messages.systemsHeader)} showBreadcrumb={false} />
             <Main>
                 <Fragment>
-                    { hasError && <ErrorHandler code={errorCode} />}
-                    { !hasError && (
-                        <InventoryTable
+                    { hasError
+                        ? <ErrorHandler code={errorCode} />
+                        : (<InventoryTable
                             onLoad={({ mergeWithEntities, mergeWithDetail }) => {
                                 ReducerRegistry.register({
                                     ...mergeWithEntities(
@@ -194,7 +194,7 @@ const SystemsPage = ({ intl }) => {
                                 actions
                             />)}
                         </InventoryTable>
-                    )}
+                        )}
                 </Fragment>
             </Main>
         </Fragment>

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -225,7 +225,7 @@ export function createCveListBySystem(systemId, cveList) {
                 ]);
 
         if (!meta?.patch_access) {
-            rows = rows.map(row => {
+            rows = rows?.map(row => {
                 return {
                     ...row,
                     cells: row.cells.filter(cell => cell?.title?.key !== 'advisory')

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1235,7 +1235,7 @@ export default defineMessages({
         description: 'No access page body',
         defaultMessage: 'Contact your organization administrator(s) for more information'
     },
-    returnPreviousPage: {
+    returnToPreviousPage: {
         id: 'returnPreviousPage',
         description: 'Return to previous page label for general usage',
         defaultMessage: 'Return to previous page'
@@ -1481,5 +1481,16 @@ export default defineMessages({
         id: 'pageTitleSuffix',
         description: 'Suffix to all page titles, preceded by page name',
         defaultMessage: 'Vulnerability | Red Hat Insights'
+    },
+
+    notAuthorizedTitle: {
+        id: 'notAuthorizedTitle',
+        description: 'Title for component which shows up when user doesn\'t have permission to view content',
+        defaultMessage: 'You do not have permissions to view or manage Vulnerability'
+    },
+    notAuthorizedDescription: {
+        id: 'notAuthorizedDescription',
+        description: 'Description for component which shows up when user doesn\'t have permission to view content',
+        defaultMessage: 'Contact your organization administrator(s) for more information.'
     }
 });


### PR DESCRIPTION
Fixes [VULN-1388](https://issues.redhat.com/browse/VULN-1388).

CVE page and system CVE page used to crash because of clearing notification on error response, which caused maximum update depth error. I moved the clear notifications function to unmounting, added 502 status code to switch and rearanged them descending in the switch.

Added 403 (unauthorized) error handler.

Error handling should be correct on all pages except CVE detail page, see [VULN-1365](https://issues.redhat.com/browse/VULN-1365).