### PR TITLE
VULN-1487 fix(navigation): Highlight correct nav button upon navigating back

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,11 +41,18 @@ const App = ({ history, location }) => {
             setAccess(userPermissions.some(access => permissionList.includes(access.permission)));
         })();
 
-        const unregister =  insights?.chrome?.on('APP_NAVIGATION', event => {
+        const unregister = insights?.chrome?.on('APP_NAVIGATION', event => {
             if (event.domEvent) {
                 history.push(`/${event.navId}`);
                 appNavClick[event.navId] !== undefined ? appNavClick[event.navId](true) : appNavClick.cves;
             }
+        });
+
+        history.listen((location) => {
+            const { pathname } = location;
+
+            const navId = pathname.split('/').filter(element => element.length > 0)[0];
+            appNavClick[navId] !== undefined ? appNavClick[navId](true) : appNavClick.cves;
         });
 
         return () => unregister();


### PR DESCRIPTION
Fixes [VULN-1487](https://issues.redhat.com/browse/VULN-1487).

I fixed this but was a bit confused why the previous button stayed gray until I clicked somewhere else, but this is actually correct because that button is the last clicked upon so it had focus.
![shadow](https://user-images.githubusercontent.com/8426204/107508945-05233700-6ba2-11eb-8092-5c3719e2088a.png)
