### PR TITLE
fix: update vulnerable package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6518,13 +6518,13 @@
       }
     },
     "@redhat-cloud-services/frontend-components-remediations": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-2.3.9.tgz",
-      "integrity": "sha512-uTPU67DEw62wN32RE7nUBGTZST/8aRE137AMTwZ5v/xooOt0ekEW6PlQPXdiIZjFyK8O2gbLlFsRaB26YWrczg==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-remediations/-/frontend-components-remediations-2.3.10.tgz",
+      "integrity": "sha512-5aIGoh0uDLohw9qhaJ38OvMIPzseFUkcvzWDejVULnHB7wy1fTMAxuJPJ0pfenuwstriMnObel1eg59VAhO05w==",
       "requires": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
-        "urijs": "^1.19.1"
+        "urijs": "^1.19.4"
       }
     },
     "@redhat-cloud-services/frontend-components-translations": {
@@ -34396,9 +34396,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
-      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg=="
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@redhat-cloud-services/frontend-components-inventory-insights": "^3.0.2",
     "@redhat-cloud-services/frontend-components-notifications": "^3.0.3",
     "@redhat-cloud-services/frontend-components-pdf-generator": "^2.3.8",
-    "@redhat-cloud-services/frontend-components-remediations": "^2.3.9",
+    "@redhat-cloud-services/frontend-components-remediations": "^2.3.10",
     "@redhat-cloud-services/frontend-components-translations": "^3.0.0",
     "@redhat-cloud-services/frontend-components-utilities": "^3.0.3",
     "@redhat-cloud-services/vulnerabilities-client": "^1.0.93",


### PR DESCRIPTION
frontend-components-remediations were previously pulling a package vulnerable to CVE-2020-26291, newer version of f-c-r is no longer doing that