### PR TITLE
chore: Update FEC import path to v3

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -16,7 +16,7 @@ import { Stack,
 } from '@patternfly/react-core';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { InsightsLabel } from '@redhat-cloud-services/frontend-components';
+import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import {
     CheckCircleIcon,
     OutlinedQuestionCircleIcon,

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleSummary.js
@@ -4,7 +4,7 @@ import marked from 'marked';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import sanitizeHtml from 'sanitize-html';
-import { Truncate } from '@redhat-cloud-services/frontend-components';
+import { Truncate } from '@redhat-cloud-services/frontend-components/Truncate';
 import { StackItem, TextContent } from '@patternfly/react-core';
 import { TRUNCATE_TEXT_THRESHOLD } from '../../../Helpers/constants';
 import messages from '../../../Messages';

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
@@ -10,7 +10,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { STATUS_OPTIONS } from '../../../Helpers/constants';
 import { injectIntl } from 'react-intl';
-import { Shield } from '@redhat-cloud-services/frontend-components';
+import { Shield } from '@redhat-cloud-services/frontend-components/Shield';
 import Label from '../Snippets/Label';
 
 const CVEDetailsPageSidebar = ({ cveAttributes, intl }) => {

--- a/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
+++ b/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import {
-    InvalidObject,
-    Unavailable,
-    ErrorState,
-    NotAuthorized
-} from '@redhat-cloud-services/frontend-components';
+import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
+import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { LockIcon } from '@patternfly/react-icons';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/AffectingFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/AffectingFilter.js
@@ -1,4 +1,4 @@
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
 import { AFFECTING_FILTER_OPTIONS } from '../../../../Helpers/constants';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/BusinessRiskFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/BusinessRiskFilter.js
@@ -1,5 +1,5 @@
 
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { BUSINESS_RISK_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter.js
@@ -1,4 +1,4 @@
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
 import CheckboxCustomFilter from '../CustomFilters/CvssCustomFilter';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/ExcludedFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/ExcludedFilter.js
@@ -1,4 +1,4 @@
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
 import { EXCLUDED_FILTER_OPTIONS } from '../../../../Helpers/constants';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/ImpactFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/ImpactFilter.js
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { IMPACT_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/PublishDateFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/PublishDateFilter.js
@@ -1,5 +1,5 @@
 
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { PUBLIC_DATE_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
@@ -1,4 +1,4 @@
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { intl } from '../../../../Utilities/IntlProvider';
 
 import debounce from 'lodash/debounce';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
@@ -1,5 +1,5 @@
 
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { RULE_PRESENCE_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/StatusFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/StatusFilter.js
@@ -1,5 +1,5 @@
 
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { STATUS_OPTIONS } from '../../../../Helpers/constants';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';

--- a/src/Components/PresentationalComponents/Header/Breadcrumb.js
+++ b/src/Components/PresentationalComponents/Header/Breadcrumb.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Breadcrumb as PfBreadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import { Skeleton } from '@redhat-cloud-services/frontend-components';
+import { Skeleton } from '@redhat-cloud-services/frontend-components/Skeleton';
 
 import { PATHS } from '../../../Helpers/constants';
 

--- a/src/Components/PresentationalComponents/Header/Header.js
+++ b/src/Components/PresentationalComponents/Header/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import Breadcrumb from './Breadcrumb';
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';

--- a/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
+++ b/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import { LockIcon } from '@patternfly/react-icons';
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import messages from '../../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';

--- a/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
+++ b/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import { CloudServerIcon } from '@patternfly/react-icons';
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 
 import messages from '../../../Messages';

--- a/src/Components/PresentationalComponents/WithLoader/WithLoader.js
+++ b/src/Components/PresentationalComponents/WithLoader/WithLoader.js
@@ -1,4 +1,5 @@
-import { Skeleton, SkeletonSize, Spinner } from '@redhat-cloud-services/frontend-components';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import propTypes from 'prop-types';
 import React from 'react';
 import ContentLoader, { BulletList, List } from 'react-content-loader';

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -1,4 +1,5 @@
-import { InvalidObject, Main } from '@redhat-cloud-services/frontend-components';
+import { InvalidObject } from '@redhat-cloud-services/frontend-components/InvalidObject';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import propTypes from 'prop-types';
 import React, { useMemo, useState, useEffect } from 'react';
 import { createCveDetailsPage } from '../../../Helpers/CVEHelper';

--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -1,7 +1,8 @@
 import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { SkeletonTable, TableToolbar } from '@redhat-cloud-services/frontend-components';
+import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
 import { cveTableRowActions } from '../../../Helpers/CVEHelper';
 import { createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
 import PaginationWrapper from '../../PresentationalComponents/PaginationWrapper/PaginationWrapper';

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -5,7 +5,7 @@ import messages from '../../../Messages';
 import { CVETableContext } from './CVEs';
 import { fetchCvesIds } from '../../../Store/Actions/Actions';
 import selectAllCheckbox from '../../../Helpers/selectAllCheckboxHelper';
-import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import affectingFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/AffectingFilter';
 import publishDateFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/PublishDateFilter';
 import cvssBaseScoreFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter';

--- a/src/Components/SmartComponents/LandingPage/LandingPage.js
+++ b/src/Components/SmartComponents/LandingPage/LandingPage.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import Header from '../../PresentationalComponents/Header/Header';
 import CVEs from '../CVEs/CVEs';
 

--- a/src/Components/SmartComponents/Reports/Executive/FirstPage.js
+++ b/src/Components/SmartComponents/Reports/Executive/FirstPage.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Section, Panel, PanelItem } from '@redhat-cloud-services/frontend-components-pdf-generator';
-import { DateFormat as dateFormat } from '@redhat-cloud-services/frontend-components';
+import { DateFormat as dateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { Text } from '@react-pdf/renderer';
 
 import CounterItem from '../Common/CounterItem';

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -1,6 +1,6 @@
 import React,  { useState, useEffect } from 'react';
 import { Grid, GridItem, Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { FileAltIcon } from '@patternfly/react-icons';
 import DownloadExecutive from './DownloadExecutive';
 import ReportConfigModal from '../Modals/ReportConfigModal';

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -1,7 +1,8 @@
 import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { SkeletonTable, TableToolbar } from '@redhat-cloud-services/frontend-components';
+import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
 
 import { systemCveTableRowActions } from '../../../Helpers/CVEHelper';
 import { createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -5,7 +5,7 @@ import messages from '../../../Messages';
 import { CVETableContext } from './SystemCves';
 import Remediation from '../Remediation/Remediation';
 import selectAllCheckbox from '../../../Helpers/selectAllCheckboxHelper';
-import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import publishDateFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/PublishDateFilter';
 import cvssBaseScoreFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter';
 import impactFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/ImpactFilter';

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -1,4 +1,4 @@
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import propTypes from 'prop-types';
 import React from 'react';
@@ -12,7 +12,7 @@ import { injectIntl } from 'react-intl';
 import { PATHS } from '../../../Helpers/constants';
 import messages from '../../../Messages';
 
-import { AppInfo, DetailWrapper, InventoryDetailHead } from '@redhat-cloud-services/frontend-components/components/esm/Inventory';
+import { AppInfo, DetailWrapper, InventoryDetailHead } from '@redhat-cloud-services/frontend-components/Inventory';
 
 class InventoryDetail extends React.Component {
     static propTypes = {

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.test.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.test.js
@@ -4,7 +4,7 @@ import { mountWithIntl } from '../../../Helpers/MiscHelper';
 import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { Provider } from "react-redux";
-import { InventoryDetailHead } from '@redhat-cloud-services/frontend-components/components/esm/Inventory';
+import { InventoryDetailHead } from '@redhat-cloud-services/frontend-components/Inventory';
 import { act } from 'react-dom/test-utils';
 
 const customMiddleWare = store => next => action => {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -33,7 +33,7 @@ import {
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
     SYSTEMS_EXPOSED_SORTING_HEADER
 } from '../../../Helpers/constants';
-import { InventoryTable } from '@redhat-cloud-services/frontend-components/components/esm/Inventory';
+import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 
 const SystemsExposedTable = (props) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import SystemsTableToolbar from './SystemsTableToolbar';
 import { SYSTEMS_HEADER, SYSTEMS_ALLOWED_PARAMS, SYSTEMS_SORTING_HEADER } from '../../../Helpers/constants';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
-import { Main } from '@redhat-cloud-services/frontend-components';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { systemTableRowActions } from '../../../Helpers/CVEHelper';
 import Header from '../../PresentationalComponents/Header/Header';
 import { fetchSystems, optOutSystemsAction } from '../../../Store/Actions/Actions';
@@ -19,7 +19,7 @@ import {
     clearInventoryStore
 } from '../../../Store/Actions/Actions';
 import { useUrlParams, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
-import { InventoryTable } from '@redhat-cloud-services/frontend-components/components/esm/Inventory';
+import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 
 const createRows = ({ data }) => {

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -7,7 +7,7 @@ import { dataShape } from '../../../Helpers/MiscHelper';
 import { fetchSystems, fetchSystemsIds } from '../../../Store/Actions/Actions';
 import { middlewareListener } from '../../../Utilities/ReducerRegistry';
 import selectAllCheckbox from '../../../Helpers/selectAllCheckboxHelper';
-import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import searchFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import { exportConfig, buildActiveFilters, removeFilters } from '../../../Helpers/TableToolbarHelper';
 import DownloadReport from '../../../Helpers/DownloadReport';

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -1,6 +1,6 @@
 import { Tooltip, Flex, FlexItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { Shield } from '@redhat-cloud-services/frontend-components';
+import { Shield } from '@redhat-cloud-services/frontend-components/Shield';
 import parseCvssScore from '@redhat-cloud-services/frontend-components-utilities/parseCvssScore';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { flatMap } from 'lodash';


### PR DESCRIPTION
In FEC version 3.1 old import path won't work. 