### PR TITLE
chore(config): Fix local development configurations

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,7 +4,7 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     debug: true,
-    https: true
+    deployment: process.env.BETA ? 'beta/apps' : 'apps'
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -3,7 +3,8 @@ const { resolve } = require('path');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
-    rootFolder: resolve(__dirname, '../')
+    rootFolder: resolve(__dirname, '../'),
+    deployment: process.env.BETA ? 'beta/apps' : 'apps'
 });
 
 plugins.push(

--- a/profiles/local-frontend.js
+++ b/profiles/local-frontend.js
@@ -4,9 +4,9 @@ const APP_ID = 'vulnerability';
 const FRONTEND_PORT = 8002;
 const routes = {};
 
-routes[`/beta/${SECTION}/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/${SECTION}/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/beta/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-routes[`/apps/${APP_ID}`] = { host: `https://localhost:${FRONTEND_PORT}` };
+routes[`/beta/${SECTION}/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/${SECTION}/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/beta/apps/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+routes[`/apps/${APP_ID}`] = { host: `http://localhost:${FRONTEND_PORT}` };
 
 module.exports = { routes };


### PR DESCRIPTION
@leSamo, @tkasparek 
FYI if you want to run `/beta/insights/vulnerability` you should run the 

- `npm run start:beta` --> `ci.foo...../beta/..`
- `npm run prod:beta` --> `prod.foo..../beta/..`

The command without `:beta` running against stable chrome, inventory, platform ..etc, like
- `npm run start` --> `ci.foo...../insights/..`
