### PR TITLE
VULN-1453 fix(systems maximum update): Use deep comparison for params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7774,8 +7774,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -7815,6 +7814,11 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -13397,6 +13401,11 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "destroy": {
       "version": "1.0.4",
@@ -33710,6 +33719,46 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-deep-compare-effect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
+      "integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": "^17.0.0",
+        "dequal": "^2.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@types/react": {
+          "version": "17.0.3",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+          "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "csstype": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
     },
     "util": {
       "version": "0.12.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "^16.13.0",
     "sanitize-html": "^2.1.2",
     "seamless-immutable": "^7.1.4",
-    "style-loader": "^2.0.0"
+    "style-loader": "^2.0.0",
+    "use-deep-compare-effect": "^1.6.1"
   },
   "sassIncludes": {
     "patternfly": "node_modules/patternfly/dist/sass",

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter.js
@@ -7,7 +7,11 @@ import React from 'react';
 const SearchFilter = (urlParam, label, placeholder, search, apply) => {
     const [searchValue, setSearchValue] = React.useState();
     const [handleSearch] = React.useState(() =>
-        debounce(newValue =>  {if (newValue !== undefined) { apply({ [urlParam]: newValue, page: 1 }); }}, 400)
+        debounce(newValue =>  {
+            if (newValue !== undefined) {
+                apply({ [urlParam]: newValue, page: 1 });
+            }},
+        400)
     );
 
     React.useEffect(() => setSearchValue(search), [search]);

--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
@@ -75,11 +75,14 @@ describe('CVE details:', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('Should dispatch fetchCveDetails actions', () => {
-        mountWithIntl(<Provider store={store}>
-            <Router><CveDetailsPage {...props} /></Router>
-        </Provider>);
-        expect(store.getActions()[3].type).toEqual('FETCH_CVE_DETAILS'); 
+    it('Should dispatch actions to fetch data', () => {
+        mountWithIntl(
+            <Provider store={store}>
+                <Router><CveDetailsPage {...props} /></Router>
+            </Provider>
+        );
+        expect(store.getActions().some(({ type }) => type === 'FETCH_CVE_DETAILS' )).toBeTruthy();
+        expect(store.getActions().some(({ type }) => type === 'FETCH_AFFECTED_SYSTEMS_BY_CVE' )).toBeTruthy();
     });
 
     describe('test modals: ', () => {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -3,7 +3,7 @@ import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { withRouter } from 'react-router-dom';
 import { useUrlParams, updateRef, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import React, { useEffect, useState, useMemo } from 'react';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
@@ -35,6 +35,7 @@ import {
 } from '../../../Helpers/constants';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 const SystemsExposedTable = (props) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);
@@ -43,6 +44,7 @@ const SystemsExposedTable = (props) => {
     const inventory = React.createRef();
     const dispatch = useDispatch();
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_EXPOSED_ALLOWED_PARAMS);
+    const [isFirstMount, setFirstMount] = useState(true);
 
     const affectedSystems = useSelector(
         ({ CVEDetailsPageStore }) => CVEDetailsPageStore.affectedSystemsByCVE
@@ -53,7 +55,8 @@ const SystemsExposedTable = (props) => {
     );
 
     const parameters = useSelector(
-        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.parameters
+        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.parameters,
+        shallowEqual
     );
 
     const metadata = useSelector(
@@ -94,14 +97,17 @@ const SystemsExposedTable = (props) => {
     });
 
     useEffect(() => {
-        if (!inventory.current) {
-            apply(urlParameters);
-        }
-        else {
-            dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));
+        apply(urlParameters);
+        setFirstMount(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useDeepCompareEffect(() => {
+        if (!isFirstMount) {
             setUrlParams({ ...parameters });
+            dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));
         }
-    }, [parameters]);
+    }, [parameters, isFirstMount]);
 
     useEffect(() => {
         if (selectedHosts) {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
@@ -121,7 +121,7 @@ describe('SystemsExposedPage', () => {
         wrapper.update(); 
         act( () => wrapper.find('InventoryTable').props().onRefresh(testObj)); 
         const dispatchedActions = store.getActions();
-        expect(dispatchedActions[1]).toEqual({
+        expect(dispatchedActions[2]).toEqual({
             type: 'CHANGE_EXPOSED_SYSTEMS_PARAMETERS',
             payload: { page: 2, page_size: 2 }
         });
@@ -132,7 +132,7 @@ describe('SystemsExposedPage', () => {
         act(() => wrapper.find('InventoryTable').props().bulkSelect.items[1].onClick());
         act(() => wrapper.find('InventoryTable').props().bulkSelect.onSelect());
         const dispatchedActions = store.getActions();
-        expect(dispatchedActions[1]).toEqual({
+        expect(dispatchedActions[2]).toEqual({
                 type: 'SELECT_MULTIPLE_ENTITIES',
                 payload: [ 'c3f36a42-5289-4940-8dcf-d1b7c8f90db2' ]
         });        

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -2,7 +2,7 @@ import React, { useEffect, Fragment, useState, useMemo } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import SystemsTableToolbar from './SystemsTableToolbar';
 import { SYSTEMS_HEADER, SYSTEMS_ALLOWED_PARAMS, SYSTEMS_SORTING_HEADER } from '../../../Helpers/constants';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
@@ -22,6 +22,7 @@ import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inven
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { TableVariant } from '@patternfly/react-table';
 import { useNotification } from '../../../Helpers/Hooks';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 const createRows = ({ data }) => {
     const items = data?.map(item => {
@@ -38,6 +39,7 @@ const createRows = ({ data }) => {
 const SystemsPage = ({ intl }) => {
     const [selectedHosts, setSelectedHosts] = useState(undefined);
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_ALLOWED_PARAMS);
+    const [isFirstMount, setFirstMount] = useState(true);
     const addNotification = useNotification({ variant: 'success' });
 
     const inventory = React.createRef();
@@ -46,7 +48,8 @@ const SystemsPage = ({ intl }) => {
     const systems = useSelector(({ SystemsPageStore }) => SystemsPageStore.payload);
 
     const parameters = useSelector(
-        ({ SystemsPageStore }) => SystemsPageStore.params
+        ({ SystemsPageStore }) => SystemsPageStore.params,
+        shallowEqual
     );
 
     const metadata = useSelector(
@@ -90,15 +93,17 @@ const SystemsPage = ({ intl }) => {
     };
 
     useEffect(() => {
-        if (!inventory.current) {
-            apply(urlParameters);
-        }
-        else {
-            dispatch(fetchSystems(parameters));
-            setUrlParams({ ...parameters });
-        }
+        apply(urlParameters);
+        setFirstMount(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [parameters]);
+    }, []);
+
+    useDeepCompareEffect(() => {
+        if (!isFirstMount) {
+            setUrlParams({ ...parameters });
+            dispatch(fetchSystems(parameters));
+        }
+    }, [parameters, isFirstMount]);
 
     const handleSelect = (isChecked, payload) => {
         if (!payload) { payload = []; }

--- a/src/Store/Reducers/SystemsPageStore.js
+++ b/src/Store/Reducers/SystemsPageStore.js
@@ -11,7 +11,6 @@ export const initialState = {
         total_items: 0
     },
     params: {
-        filter: undefined,
         excluded: 'true,false',
         page: 1,
         page_size: 20,


### PR DESCRIPTION
I'm not 100% happy with the solution but for now it should be okay and it will unblock the other tickets.

## before 
dispatching several times the action to change the params was causing the  error `Maximum update depth exceeded`. On every single action it tried to update the view (in short time) even though the parameters were the same. 
![Screenshot from 2021-03-18 19-13-50](https://user-images.githubusercontent.com/3369346/111677417-7dbf8800-881f-11eb-8e60-528126617b80.png)

For that reason, I used a deep object comparison for the parameters which checks the keys and the values and fires the effect(request) only if the parameters **really** change


## after
`CHANGE_EXPOSED_SYSTEMS_PARAMETERS` is dispatched only once on first load. 
![Screenshot from 2021-03-18 19-20-58](https://user-images.githubusercontent.com/3369346/111677860-f1619500-881f-11eb-9832-e66784fdd4f4.png)

