### PR TITLE
VULN-1508 fix(Report modal): Fix multiple minor bugs

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -25,15 +25,15 @@
 }
 
 .report-text-input {
-        width: 80%;
+    width: 80%;
 }
 
 .custom-report-filter-wrapper {
-    width: calc(50rem - 2 * 24px); // width of modal minus padding from both sides
-}
+    max-width: calc(50rem - 2 * 24px); // width of modal minus padding from both sides
 
-.custom-report-filter-select {
-    max-width: 100%;
+    .pf-c-select {
+        max-width: inherit;
+    }
 }
 
 .toolip-link--embeded {

--- a/src/Components/PresentationalComponents/Filters/CustomFilters/CheckboxCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/CheckboxCustomFilter.js
@@ -35,7 +35,6 @@ const CheckboxCustomFilter = ({ filterData, setFilterData, selectProps, options,
             placeholderText={getPlaceholderText()}
             key={filterId}
             width="auto"
-            className="custom-report-filter-select"
             onSelect={(event, optionName) => { handleOnCheckboxChange(filterId, optionName); }}
             selections={filterData[filterId].map(
                 id => options.find(item => item.value === id).label)}

--- a/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
@@ -5,6 +5,10 @@ import messages from '../../../../Messages';
 import { intl } from '../../../../Utilities/IntlProvider';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
+export const isCvssRangeValid = (min, max) => {
+    return min >= 0 && max <= 10 && min <= max && !isNaN(min) && !isNaN(max);
+};
+
 const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }) => {
     const [isOpen, setOpen] = useState(false);
 
@@ -22,7 +26,7 @@ const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }
         const minValue = filterData.cvss_filter.from;
         const maxValue = filterData.cvss_filter.to;
 
-        if (currentValue < 0 || currentValue > 10 || minValue > maxValue) {
+        if (currentValue < 0 || currentValue > 10 || minValue > maxValue || isNaN(currentValue)) {
             return 'error';
         }
 
@@ -68,7 +72,7 @@ const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }
         return (
             <Text>
                 {`${filterName}: ${parseFloat(min).toFixed(1)} - ${parseFloat(max).toFixed(1)}`}
-                {(min < 0 || max > 10 || min > max) &&
+                { isCvssRangeValid(min, max) ||
                     <ExclamationCircleIcon color={'var(--pf-global--danger-color--100)'} className="pf-u-ml-xs" />}
             </Text>
         );

--- a/src/Components/PresentationalComponents/Filters/CustomFilters/RadioCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/RadioCustomFilter.js
@@ -33,6 +33,7 @@ const RadioCustomFilter = ({ filterData, setFilterData, selectProps, options, fi
                         label={item.label}
                         value={item.label}
                         isChecked={filterData[filterId] === item.value}
+                        id={`custom-filter-${filterId}-${item.value}`}
                     />
                 </SelectOption>
             )}

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -15,6 +15,7 @@ import { CVE_REPORT_FILTERS, PDF_REPORT_USER_NOTE_MAX_LENGTH } from '../../../He
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';
 import styles from '../Reports/Common/styles';
+import { isCvssRangeValid } from '../../PresentationalComponents/Filters/CustomFilters/CvssCustomFilter';
 
 const ReportConfigModal = ({
     isOpen: isModalOpen,
@@ -52,6 +53,7 @@ const ReportConfigModal = ({
 
     return (
         <Modal
+            appendTo={document.querySelector('.vulnerability')}
             width="50rem"
             title={intl.formatMessage(messages.configModalTitle)}
             ouiaId={'custom-report-modal'}
@@ -63,9 +65,7 @@ const ReportConfigModal = ({
                     variant="primary"
                     onClick={handleDownloadButton}
                     isDisabled={
-                        filterData.cvss_filter.from < 0 ||
-                        filterData.cvss_filter.to > 10 ||
-                        filterData.cvss_filter.from > filterData.cvss_filter.to ||
+                        !isCvssRangeValid(filterData.cvss_filter.from, filterData.cvss_filter.to) ||
                         userNotes.length > PDF_REPORT_USER_NOTE_MAX_LENGTH
                     }
                 >

--- a/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
+++ b/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
@@ -82,7 +82,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
               </Button>,
             ]
           }
-          appendTo={[Function]}
+          appendTo={null}
           aria-describedby=""
           aria-label=""
           aria-labelledby=""

--- a/src/Components/SmartComponents/Reports/CustomReportFilter.js
+++ b/src/Components/SmartComponents/Reports/CustomReportFilter.js
@@ -77,7 +77,6 @@ const CustomReportFilter = ({ filterName, filterData, setFilterData, selectProps
             direction="bottom"
             key={filterName}
             width="auto"
-            className="custom-report-filter-select"
             onSelect={(event, optionName) => { handleOnCheckboxChange(filterName, optionName); }}
             selections={filterData[filterName].map(
                 id => CVE_REPORT_FILTERS[filterName].items.find(item => item.value === id).label)}

--- a/src/Components/SmartComponents/Reports/ReportsHelper.js
+++ b/src/Components/SmartComponents/Reports/ReportsHelper.js
@@ -11,6 +11,7 @@ export const buildFilters = filterData => {
         // if the filters value is default don't include it
         if (DEFAULT_FILTER_DATA[key] === value
             || value.length === 0
+            || (value.length > 0 && value.length === CVE_REPORT_FILTERS[key].items?.length)
             || (key === 'cvss_filter' && value.from === 0 && value.to === 10)) {
             return;
         }

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -318,7 +318,7 @@ exports[`Reports page component Should match snapshots 1`] = `
                 </Button>,
               ]
             }
-            appendTo={[Function]}
+            appendTo={null}
             aria-describedby=""
             aria-label=""
             aria-labelledby=""


### PR DESCRIPTION
Fixes [VULN-1508](https://issues.redhat.com/browse/VULN-1508).

- CVSS filter shouldn't be validated when user leaves "from" or "to" field empty (leads to NaN error)
- styles not applying to config modal because it was mounted outside #root elements
    - If the selected options are too long select box overflows awkwardly
- Selecting all items in checkbox filter should not add segment to first PDF page intro string
- Radio missing id console error