### PR TITLE
Fix sticky header layout.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3,7 +3,7 @@
 @import "~@redhat-cloud-services/frontend-components/index.css";
 @import "~@redhat-cloud-services/frontend-components-utilities/files/Utilities/_all";
 
-.vulnerability {
+.vuln-root {
     overflow: inherit !important;
 }
 

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ReducerRegistry from './Utilities/ReducerRegistry';
@@ -8,16 +8,28 @@ import { getBaseName } from '@redhat-cloud-services/frontend-components-utilitie
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import messages from '../locales/en.json';
 
-const Vulnerabilities = () => (
-    <div className="vuln-root">
-        <IntlProvider locale = {navigator.language.slice(0, 2)}  messages={messages}>
-            <Provider store={ReducerRegistry.getStore()}>
-                <Router basename={getBaseName(window.location.pathname)}>
-                    <App />
-                </Router>
-            </Provider>
-        </IntlProvider>
-    </div>
-);
+const Vulnerabilities = () => {
+    useEffect(() => {
+        /**
+         * Temporary overflow fix for chrome 1. There is no risk breaking styles for other apps, no SPA
+         * Can be deleted once chtome 2 is deployed everywhere. Overflow is fixed by "vuln-root" class in chrome 2
+         */
+        const elem = document.querySelector('main#root');
+        if (!window.insights.chrome.isChrome2 && elem) {
+            elem.style.overflow = 'inherit';
+        }
+    }, []);
+    return (
+        <div className="vuln-root">
+            <IntlProvider locale = {navigator.language.slice(0, 2)}  messages={messages}>
+                <Provider store={ReducerRegistry.getStore()}>
+                    <Router basename={getBaseName(window.location.pathname)}>
+                        <App />
+                    </Router>
+                </Provider>
+            </IntlProvider>
+        </div>
+    );
+};
 
 export default Vulnerabilities;

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -9,13 +9,15 @@ import { IntlProvider } from '@redhat-cloud-services/frontend-components-transla
 import messages from '../locales/en.json';
 
 const Vulnerabilities = () => (
-    <IntlProvider locale = {navigator.language.slice(0, 2)}  messages={messages}>
-        <Provider store={ReducerRegistry.getStore()}>
-            <Router basename={getBaseName(window.location.pathname)}>
-                <App />
-            </Router>
-        </Provider>
-    </IntlProvider>
+    <div className="vuln-root">
+        <IntlProvider locale = {navigator.language.slice(0, 2)}  messages={messages}>
+            <Provider store={ReducerRegistry.getStore()}>
+                <Router basename={getBaseName(window.location.pathname)}>
+                    <App />
+                </Router>
+            </Provider>
+        </IntlProvider>
+    </div>
 );
 
 export default Vulnerabilities;


### PR DESCRIPTION
@leSamo This simple layout change has worked for me locally. Can you double-check it covers all use cases with no regressions?

Chrome 2 uses the CSS class to fix the problem. Chrome 1 however (non-beta envs until summit) needs adding the style to the root element. We can allow that in old chrome because there is no client-side routing between apps so the style is discarded when navigatin. The effect will be obsolete after the summit.

I've check bot ci beta and stable envs and the sticky header is in both.

![sticky](https://user-images.githubusercontent.com/22619452/112480214-14d39500-8d76-11eb-97d5-a18c09ae9311.gif)
