### PR TITLE
VULN-1564 fix(exec report): Fix CVEs by CVSS score chart legend

### DIFF
--- a/src/Components/SmartComponents/Reports/BuildExecReport.js
+++ b/src/Components/SmartComponents/Reports/BuildExecReport.js
@@ -35,7 +35,7 @@ const BuildExecReport = ({ data, intl }) => {
         ];
     });
 
-    const CVSSData = Object.values(cvesBySeverity).map(({ count, percentage }) =>
+    const CVSSData = Object.values(cvesBySeverity).reverse().map(({ count, percentage }) =>
         [intl.formatMessage(messages.executiveReportOfTotal,
             {
                 count,

--- a/src/Components/SmartComponents/Reports/__snapshots__/BuildExecReport.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/BuildExecReport.test.js.snap
@@ -26,13 +26,13 @@ Object {
   ],
   "CVSSData": Array [
     Array [
-      "44 (7% of total)",
+      "105 (18% of total)",
     ],
     Array [
       "446 (75% of total)",
     ],
     Array [
-      "105 (18% of total)",
+      "44 (7% of total)",
     ],
   ],
   "CVSSHeader": Array [


### PR DESCRIPTION
Fixes [VULN-1564](https://issues.redhat.com/browse/VULN-1564).

Problem was that first column of legend table was higher CVSS score to lower and the second one was in reverse order.

## Before:
![before](https://user-images.githubusercontent.com/8426204/114873615-bdb46380-9dfb-11eb-9c08-0007191a66d7.png)

## After:
![after](https://user-images.githubusercontent.com/8426204/114873619-bee59080-9dfb-11eb-8764-7e2fda866a27.png)
