### PR TITLE
chore: Cleanup GroupedCVELabels

### DIFF
--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -17,8 +17,6 @@ import BusinessRiskModal from '../Modals/BusinessRiskModal';
 import CveStatusModal from '../Modals/CveStatusModal';
 import SystemsExposedTable from '../SystemsExposedTable/SystemsExposedTable';
 import Header from '../../PresentationalComponents/Header/Header';
-import CSAwLabel from '../../PresentationalComponents/Snippets/CSAwLabel';
-import KnownExploitLabel from '../../PresentationalComponents/Snippets/KnownExploitLabel';
 import GroupedCVELabels from '../../PresentationalComponents/Snippets/GroupedCVELabels';
 
 export const CVEPageContext = React.createContext({ isLoading: true });
@@ -108,7 +106,7 @@ const CVEDetailsPage = (props) => {
                         labels={[
                             <GroupedCVELabels
                                 key="labels"
-                                hasExploit={details.payload.data?.attributes.known_exploit}
+                                hasExploit={!!details.payload.data?.attributes.known_exploit}
                                 hasRule={details.payload.data?.attributes.rules.length > 0}
                             />
                         ]}

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -275,7 +275,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={null}
+                                            hasRule={false}
                                           />
                                         </span>,
                                       },
@@ -3539,7 +3539,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                   CVE-2020-0543
                                 </a>
                                 <GroupedCVELabels
-                                  hasRule={null}
+                                  hasRule={false}
                                 />
                               </span>,
                             },
@@ -3838,7 +3838,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                 CVE-2020-0543
                               </a>
                               <GroupedCVELabels
-                                hasRule={null}
+                                hasRule={false}
                               />
                             </span>,
                           },
@@ -6841,7 +6841,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={null}
+                                            hasRule={false}
                                           />
                                         </span>,
                                       },
@@ -6999,7 +6999,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               CVE-2020-0543
                                             </a>
                                             <GroupedCVELabels
-                                              hasRule={null}
+                                              hasRule={false}
                                             />
                                           </span>,
                                         },
@@ -7097,7 +7097,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={null}
+                                            hasRule={false}
                                           />
                                         </span>,
                                       },
@@ -7279,7 +7279,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               CVE-2020-0543
                                             </a>
                                             <GroupedCVELabels
-                                              hasRule={null}
+                                              hasRule={false}
                                             />
                                           </span>,
                                         },
@@ -7377,7 +7377,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={null}
+                                            hasRule={false}
                                           />
                                         </span>,
                                       },
@@ -8061,7 +8061,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 CVE-2020-0543
                                               </a>
                                               <GroupedCVELabels
-                                                hasRule={null}
+                                                hasRule={false}
                                               />
                                             </span>,
                                           },
@@ -8159,7 +8159,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               CVE-2020-0543
                                             </a>
                                             <GroupedCVELabels
-                                              hasRule={null}
+                                              hasRule={false}
                                             />
                                           </span>,
                                         },
@@ -8365,7 +8365,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 CVE-2020-0543
                                               </a>
                                               <GroupedCVELabels
-                                                hasRule={null}
+                                                hasRule={false}
                                               />
                                             </span>,
                                           },
@@ -8463,7 +8463,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               CVE-2020-0543
                                             </a>
                                             <GroupedCVELabels
-                                              hasRule={null}
+                                              hasRule={false}
                                             />
                                           </span>,
                                         },
@@ -8647,7 +8647,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                   CVE-2020-0543
                                                 </a>
                                                 <GroupedCVELabels
-                                                  hasRule={null}
+                                                  hasRule={false}
                                                 />
                                               </span>,
                                             },
@@ -8745,7 +8745,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 CVE-2020-0543
                                               </a>
                                               <GroupedCVELabels
-                                                hasRule={null}
+                                                hasRule={false}
                                               />
                                             </span>,
                                           },
@@ -9449,7 +9449,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         CVE-2020-0543
                                                       </a>
                                                       <GroupedCVELabels
-                                                        hasRule={null}
+                                                        hasRule={false}
                                                       />
                                                     </span>,
                                                   },
@@ -9547,7 +9547,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                       CVE-2020-0543
                                                     </a>
                                                     <GroupedCVELabels
-                                                      hasRule={null}
+                                                      hasRule={false}
                                                     />
                                                   </span>,
                                                 },
@@ -9692,7 +9692,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                           CVE-2020-0543
                                                         </a>
                                                         <GroupedCVELabels
-                                                          hasRule={null}
+                                                          hasRule={false}
                                                         />
                                                       </span>,
                                                     },
@@ -9790,7 +9790,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         CVE-2020-0543
                                                       </a>
                                                       <GroupedCVELabels
-                                                        hasRule={null}
+                                                        hasRule={false}
                                                       />
                                                     </span>,
                                                   },
@@ -10098,7 +10098,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                 CVE-2020-0543
                                                               </a>
                                                               <GroupedCVELabels
-                                                                hasRule={null}
+                                                                hasRule={false}
                                                               >
                                                                 <LabelGroup
                                                                   aria-label="Label group category"
@@ -10921,7 +10921,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                           CVE-2020-0543
                                                                         </a>
                                                                         <GroupedCVELabels
-                                                                          hasRule={null}
+                                                                          hasRule={false}
                                                                         />
                                                                       </span>,
                                                                     },
@@ -11019,7 +11019,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                         CVE-2020-0543
                                                                       </a>
                                                                       <GroupedCVELabels
-                                                                        hasRule={null}
+                                                                        hasRule={false}
                                                                       />
                                                                     </span>,
                                                                   },

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -91,13 +91,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       CVE-2020-0543
                     </a>
                     <GroupedCVELabels
-                      hasRule={
-                        Object {
-                          "description": "testDescription",
-                          "id": "testId",
-                          "summary": "testSummary",
-                        }
-                      }
+                      hasRule={true}
                     />
                   </span>,
                 },
@@ -401,13 +395,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                     CVE-2020-0543
                   </a>
                   <GroupedCVELabels
-                    hasRule={
-                      Object {
-                        "description": "testDescription",
-                        "id": "testId",
-                        "summary": "testSummary",
-                      }
-                    }
+                    hasRule={true}
                   />
                 </span>,
               },
@@ -3182,13 +3170,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 CVE-2020-0543
                               </a>
                               <GroupedCVELabels
-                                hasRule={
-                                  Object {
-                                    "description": "testDescription",
-                                    "id": "testId",
-                                    "summary": "testSummary",
-                                  }
-                                }
+                                hasRule={true}
                               />
                             </span>,
                           },
@@ -3342,13 +3324,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   CVE-2020-0543
                                 </a>
                                 <GroupedCVELabels
-                                  hasRule={
-                                    Object {
-                                      "description": "testDescription",
-                                      "id": "testId",
-                                      "summary": "testSummary",
-                                    }
-                                  }
+                                  hasRule={true}
                                 />
                               </span>,
                             },
@@ -3440,13 +3416,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 CVE-2020-0543
                               </a>
                               <GroupedCVELabels
-                                hasRule={
-                                  Object {
-                                    "description": "testDescription",
-                                    "id": "testId",
-                                    "summary": "testSummary",
-                                  }
-                                }
+                                hasRule={true}
                               />
                             </span>,
                           },
@@ -3634,13 +3604,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   CVE-2020-0543
                                 </a>
                                 <GroupedCVELabels
-                                  hasRule={
-                                    Object {
-                                      "description": "testDescription",
-                                      "id": "testId",
-                                      "summary": "testSummary",
-                                    }
-                                  }
+                                  hasRule={true}
                                 />
                               </span>,
                             },
@@ -3732,13 +3696,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 CVE-2020-0543
                               </a>
                               <GroupedCVELabels
-                                hasRule={
-                                  Object {
-                                    "description": "testDescription",
-                                    "id": "testId",
-                                    "summary": "testSummary",
-                                  }
-                                }
+                                hasRule={true}
                               />
                             </span>,
                           },
@@ -4380,13 +4338,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     CVE-2020-0543
                                   </a>
                                   <GroupedCVELabels
-                                    hasRule={
-                                      Object {
-                                        "description": "testDescription",
-                                        "id": "testId",
-                                        "summary": "testSummary",
-                                      }
-                                    }
+                                    hasRule={true}
                                   />
                                 </span>,
                               },
@@ -4478,13 +4430,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   CVE-2020-0543
                                 </a>
                                 <GroupedCVELabels
-                                  hasRule={
-                                    Object {
-                                      "description": "testDescription",
-                                      "id": "testId",
-                                      "summary": "testSummary",
-                                    }
-                                  }
+                                  hasRule={true}
                                 />
                               </span>,
                             },
@@ -4696,13 +4642,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     CVE-2020-0543
                                   </a>
                                   <GroupedCVELabels
-                                    hasRule={
-                                      Object {
-                                        "description": "testDescription",
-                                        "id": "testId",
-                                        "summary": "testSummary",
-                                      }
-                                    }
+                                    hasRule={true}
                                   />
                                 </span>,
                               },
@@ -4794,13 +4734,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   CVE-2020-0543
                                 </a>
                                 <GroupedCVELabels
-                                  hasRule={
-                                    Object {
-                                      "description": "testDescription",
-                                      "id": "testId",
-                                      "summary": "testSummary",
-                                    }
-                                  }
+                                  hasRule={true}
                                 />
                               </span>,
                             },
@@ -4990,13 +4924,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       CVE-2020-0543
                                     </a>
                                     <GroupedCVELabels
-                                      hasRule={
-                                        Object {
-                                          "description": "testDescription",
-                                          "id": "testId",
-                                          "summary": "testSummary",
-                                        }
-                                      }
+                                      hasRule={true}
                                     />
                                   </span>,
                                 },
@@ -5088,13 +5016,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     CVE-2020-0543
                                   </a>
                                   <GroupedCVELabels
-                                    hasRule={
-                                      Object {
-                                        "description": "testDescription",
-                                        "id": "testId",
-                                        "summary": "testSummary",
-                                      }
-                                    }
+                                    hasRule={true}
                                   />
                                 </span>,
                               },
@@ -5756,13 +5678,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={
-                                              Object {
-                                                "description": "testDescription",
-                                                "id": "testId",
-                                                "summary": "testSummary",
-                                              }
-                                            }
+                                            hasRule={true}
                                           />
                                         </span>,
                                       },
@@ -5854,13 +5770,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                           CVE-2020-0543
                                         </a>
                                         <GroupedCVELabels
-                                          hasRule={
-                                            Object {
-                                              "description": "testDescription",
-                                              "id": "testId",
-                                              "summary": "testSummary",
-                                            }
-                                          }
+                                          hasRule={true}
                                         />
                                       </span>,
                                     },
@@ -6003,13 +5913,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                               CVE-2020-0543
                                             </a>
                                             <GroupedCVELabels
-                                              hasRule={
-                                                Object {
-                                                  "description": "testDescription",
-                                                  "id": "testId",
-                                                  "summary": "testSummary",
-                                                }
-                                              }
+                                              hasRule={true}
                                             />
                                           </span>,
                                         },
@@ -6101,13 +6005,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                             CVE-2020-0543
                                           </a>
                                           <GroupedCVELabels
-                                            hasRule={
-                                              Object {
-                                                "description": "testDescription",
-                                                "id": "testId",
-                                                "summary": "testSummary",
-                                              }
-                                            }
+                                            hasRule={true}
                                           />
                                         </span>,
                                       },
@@ -6419,13 +6317,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                     CVE-2020-0543
                                                   </a>
                                                   <GroupedCVELabels
-                                                    hasRule={
-                                                      Object {
-                                                        "description": "testDescription",
-                                                        "id": "testId",
-                                                        "summary": "testSummary",
-                                                      }
-                                                    }
+                                                    hasRule={true}
                                                   >
                                                     <LabelGroup
                                                       aria-label="Label group category"

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -71,13 +71,7 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                         CVE-2020-0543
                       </a>
                       <GroupedCVELabels
-                        hasRule={
-                          Object {
-                            "description": "testDescription",
-                            "id": "testId",
-                            "summary": "testSummary",
-                          }
-                        }
+                        hasRule={true}
                       />
                     </span>,
                   },

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -154,7 +154,7 @@ export function createCveListBySystem(systemId, cveList) {
                                         }
                                         <GroupedCVELabels
                                             hasExploit={row.attributes.known_exploit}
-                                            hasRule={row.attributes.rule}
+                                            hasRule={!!row.attributes.rule}
                                         />
                                     </span>
                                 )

--- a/src/Helpers/VulnerabilityHelper.test.js
+++ b/src/Helpers/VulnerabilityHelper.test.js
@@ -40,7 +40,8 @@ describe('VulnerabilitiesHelper', () => {
                             cvss3_score: '7.000',
                             business_risk_id: '3',
                             status_id: 2,
-                            cve_status_id: 2
+                            cve_status_id: 2,
+                            known_exploit: false
                         }
                     },
                     {
@@ -56,7 +57,8 @@ describe('VulnerabilitiesHelper', () => {
                             cvss3_score: '7.300',
                             business_risk_id: '1',
                             status_id: 1,
-                            cve_status_id: 2
+                            cve_status_id: 2,
+                            known_exploit: false
                         }
                     },
                     {
@@ -72,13 +74,14 @@ describe('VulnerabilitiesHelper', () => {
                             cvss3_score: '3.300',
                             business_risk_id: '2',
                             status_id: 2,
-                            cve_status_id: 2
+                            cve_status_id: 2,
+                            known_exploit: false
                         }
                     }
                 ]
             }
         };
-        expect(JSON.stringify(createCveListByAccount(cveList))).toMatchSnapshot();
+        expect(createCveListByAccount(cveList)).toMatchSnapshot();
     });
 
     it('test function createCveListByAccount() render CSaw icon', () => {
@@ -103,7 +106,8 @@ describe('VulnerabilitiesHelper', () => {
                             business_risk_id: '3',
                             status_id: 2,
                             cve_status_id: 2,
-                            rules: ['testRule']
+                            rules: ['testRule'],
+                            known_exploit: false
                         }
                     }
                 ]
@@ -135,7 +139,8 @@ describe('VulnerabilitiesHelper', () => {
                             business_risk_id: '3',
                             status_id: 2,
                             cve_status_id: 2,
-                            systems_status_divergent: 2
+                            systems_status_divergent: 2,
+                            known_exploit: false
                         }
                     }
                 ]
@@ -184,13 +189,14 @@ describe('VulnerabilitiesHelper', () => {
                             status: "Scheduled for Patch",
                             status_id: 3,
                             status_text: "pair status different",
-                            synopsis: "CVE-2020-12662"
+                            synopsis: "CVE-2020-12662",
+                            known_exploit: false
                         }
                     }
                 ]
             }
         };
-        expect(JSON.stringify(createCveListBySystem(null, cveList))).toMatchSnapshot();
+        expect(createCveListBySystem(null, cveList)).toMatchSnapshot();
     });
 
     it('test function createCveListBySystem() render CSaw icon', () => {
@@ -216,12 +222,12 @@ describe('VulnerabilitiesHelper', () => {
                             impact: "Moderate",
                             public_date: "2020-06-09T17:00:00+00:00",
                             reporter: 1,
-                            rule: null,
                             status: "On-Hold",
                             status_id: 2,
                             status_text: "testhello",
                             synopsis: "CVE-2020-0543",
-                            rule: 'testRule'
+                            rule: 'testRule',
+                            known_exploit: false
                         }
                     }
                 ]
@@ -261,7 +267,8 @@ describe('VulnerabilitiesHelper', () => {
                             status_id: 2,
                             status_text: "testhello",
                             synopsis: "CVE-2020-0543",
-                            rule: 'testRule'
+                            rule: 'testRule',
+                            known_exploit: false
                         }
                     }
                 ]
@@ -301,7 +308,8 @@ describe('VulnerabilitiesHelper', () => {
                             status_id: 2,
                             status_text: "testhello",
                             synopsis: "CVE-2020-0543",
-                            rule: 'testRule'
+                            rule: 'testRule',
+                            known_exploit: false
                         }
                     }
                 ]

--- a/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
+++ b/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
@@ -1,5 +1,396 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VulnerabilitiesHelper test function createCveListByAccount() with cveList param 1`] = `"{\\"data\\":[{\\"id\\":\\"CVE-2019-6454\\",\\"business_risk_id\\":\\"3\\",\\"status_id\\":2,\\"exposed_systems_count\\":2,\\"cells\\":[{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":[{\\"type\\":{\\"propTypes\\":{}},\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"to\\":\\"/cves/CVE-2019-6454\\",\\"className\\":\\"pf-u-mr-sm\\",\\"style\\":{\\"display\\":\\"block\\"},\\"children\\":\\"CVE-2019-6454\\"},\\"_owner\\":null,\\"_store\\":{}},{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"hasRule\\":false},\\"_owner\\":null,\\"_store\\":{}}]},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"18 Feb 2019\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"impact\\":\\"Important\\",\\"hasLabel\\":true,\\"hasTooltip\\":true,\\"size\\":\\"sm\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"7.0\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"type\\":\\"a\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"href\\":\\"http://localhost/insights/vulnerability/cves/CVE-2019-6454\\",\\"children\\":\\"2\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"High\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6454\\",\\"ref\\":null,\\"props\\":{\\"children\\":[\\"\\",\\" \\",\\"On-hold\\"]},\\"_owner\\":null,\\"_store\\":{}}}],\\"isOpen\\":false,\\"selected\\":false},{\\"cells\\":[{\\"title\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"description\\":\\"** RESERVED ** This candidate\\",\\"cve\\":\\"CVE-2019-6454\\"},\\"_owner\\":null,\\"_store\\":{}}}],\\"parent\\":0},{\\"id\\":\\"CVE-2019-6116\\",\\"business_risk_id\\":\\"1\\",\\"status_id\\":1,\\"exposed_systems_count\\":2,\\"cells\\":[{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":[{\\"type\\":{\\"propTypes\\":{}},\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"to\\":\\"/cves/CVE-2019-6116\\",\\"className\\":\\"pf-u-mr-sm\\",\\"style\\":{\\"display\\":\\"block\\"},\\"children\\":\\"CVE-2019-6116\\"},\\"_owner\\":null,\\"_store\\":{}},{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"hasRule\\":false},\\"_owner\\":null,\\"_store\\":{}}]},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"23 Jan 2019\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"impact\\":\\"Important\\",\\"hasLabel\\":true,\\"hasTooltip\\":true,\\"size\\":\\"sm\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"7.3\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"type\\":\\"a\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"href\\":\\"http://localhost/insights/vulnerability/cves/CVE-2019-6116\\",\\"children\\":\\"2\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"Low\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":[\\"\\",\\" \\",\\"In review\\"]},\\"_owner\\":null,\\"_store\\":{}}}],\\"isOpen\\":false,\\"selected\\":false},{\\"cells\\":[{\\"title\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"description\\":\\"It was found that ghostscript\\",\\"cve\\":\\"CVE-2019-6116\\"},\\"_owner\\":null,\\"_store\\":{}}}],\\"parent\\":2},{\\"id\\":\\"CVE-2019-3815\\",\\"business_risk_id\\":\\"2\\",\\"status_id\\":2,\\"exposed_systems_count\\":2,\\"cells\\":[{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":[{\\"type\\":{\\"propTypes\\":{}},\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"to\\":\\"/cves/CVE-2019-3815\\",\\"className\\":\\"pf-u-mr-sm\\",\\"style\\":{\\"display\\":\\"block\\"},\\"children\\":\\"CVE-2019-3815\\"},\\"_owner\\":null,\\"_store\\":{}},{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"hasRule\\":false},\\"_owner\\":null,\\"_store\\":{}}]},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"14 Jan 2019\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"impact\\":\\"Low\\",\\"hasLabel\\":true,\\"hasTooltip\\":true,\\"size\\":\\"sm\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"3.3\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"type\\":\\"a\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"href\\":\\"http://localhost/insights/vulnerability/cves/CVE-2019-3815\\",\\"children\\":\\"2\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"Medium\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-3815\\",\\"ref\\":null,\\"props\\":{\\"children\\":[\\"\\",\\" \\",\\"On-hold\\"]},\\"_owner\\":null,\\"_store\\":{}}}],\\"isOpen\\":false,\\"selected\\":false},{\\"cells\\":[{\\"title\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"description\\":\\"A memory leak was discovered\\",\\"cve\\":\\"CVE-2019-3815\\"},\\"_owner\\":null,\\"_store\\":{}}}],\\"parent\\":4}],\\"meta\\":{\\"page\\":1,\\"page_size\\":20,\\"total_items\\":248,\\"pages\\":10,\\"sort\\":\\"-public_date\\",\\"filter\\":\\"\\",\\"affecting\\":\\"true,false\\",\\"cvss_from\\":\\"\\",\\"cvss_to\\":\\"\\",\\"public_from\\":\\"\\",\\"public_to\\":\\"\\",\\"cvesCount\\":3},\\"isLoading\\":false}"`;
+exports[`VulnerabilitiesHelper test function createCveListByAccount() with cveList param 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "business_risk_id": "3",
+      "business_risk_justification": undefined,
+      "cells": Array [
+        Object {
+          "title": <span>
+            <Link
+              className="pf-u-mr-sm"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
+              to="/cves/CVE-2019-6454"
+            >
+              CVE-2019-6454
+            </Link>
+            <GroupedCVELabels
+              hasExploit={false}
+              hasRule={false}
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            18 Feb 2019
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <Shield
+              hasLabel={true}
+              hasTooltip={true}
+              impact="Important"
+              size="sm"
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            7.0
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <a
+              href="http://localhost/insights/vulnerability/cves/CVE-2019-6454"
+            >
+              2
+            </a>
+          </span>,
+        },
+        Object {
+          "title": <span>
+            High
+          </span>,
+        },
+        Object {
+          "title": <span>
+            
+             
+            On-hold
+          </span>,
+        },
+      ],
+      "exposed_systems_count": 2,
+      "id": "CVE-2019-6454",
+      "isOpen": false,
+      "rules": undefined,
+      "selected": false,
+      "status_id": 2,
+      "status_justification": undefined,
+    },
+    Object {
+      "cells": Array [
+        Object {
+          "title": <CVETableExpandedCell
+            cve="CVE-2019-6454"
+            description="** RESERVED ** This candidate"
+          />,
+        },
+      ],
+      "parent": 0,
+    },
+    Object {
+      "business_risk_id": "1",
+      "business_risk_justification": undefined,
+      "cells": Array [
+        Object {
+          "title": <span>
+            <Link
+              className="pf-u-mr-sm"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
+              to="/cves/CVE-2019-6116"
+            >
+              CVE-2019-6116
+            </Link>
+            <GroupedCVELabels
+              hasExploit={false}
+              hasRule={false}
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            23 Jan 2019
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <Shield
+              hasLabel={true}
+              hasTooltip={true}
+              impact="Important"
+              size="sm"
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            7.3
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <a
+              href="http://localhost/insights/vulnerability/cves/CVE-2019-6116"
+            >
+              2
+            </a>
+          </span>,
+        },
+        Object {
+          "title": <span>
+            Low
+          </span>,
+        },
+        Object {
+          "title": <span>
+            
+             
+            In review
+          </span>,
+        },
+      ],
+      "exposed_systems_count": 2,
+      "id": "CVE-2019-6116",
+      "isOpen": false,
+      "rules": undefined,
+      "selected": false,
+      "status_id": 1,
+      "status_justification": undefined,
+    },
+    Object {
+      "cells": Array [
+        Object {
+          "title": <CVETableExpandedCell
+            cve="CVE-2019-6116"
+            description="It was found that ghostscript"
+          />,
+        },
+      ],
+      "parent": 2,
+    },
+    Object {
+      "business_risk_id": "2",
+      "business_risk_justification": undefined,
+      "cells": Array [
+        Object {
+          "title": <span>
+            <Link
+              className="pf-u-mr-sm"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
+              to="/cves/CVE-2019-3815"
+            >
+              CVE-2019-3815
+            </Link>
+            <GroupedCVELabels
+              hasExploit={false}
+              hasRule={false}
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            14 Jan 2019
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <Shield
+              hasLabel={true}
+              hasTooltip={true}
+              impact="Low"
+              size="sm"
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            3.3
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <a
+              href="http://localhost/insights/vulnerability/cves/CVE-2019-3815"
+            >
+              2
+            </a>
+          </span>,
+        },
+        Object {
+          "title": <span>
+            Medium
+          </span>,
+        },
+        Object {
+          "title": <span>
+            
+             
+            On-hold
+          </span>,
+        },
+      ],
+      "exposed_systems_count": 2,
+      "id": "CVE-2019-3815",
+      "isOpen": false,
+      "rules": undefined,
+      "selected": false,
+      "status_id": 2,
+      "status_justification": undefined,
+    },
+    Object {
+      "cells": Array [
+        Object {
+          "title": <CVETableExpandedCell
+            cve="CVE-2019-3815"
+            description="A memory leak was discovered"
+          />,
+        },
+      ],
+      "parent": 4,
+    },
+  ],
+  "errors": undefined,
+  "isLoading": false,
+  "meta": Object {
+    "affecting": "true,false",
+    "cvesCount": 3,
+    "cvss_from": "",
+    "cvss_to": "",
+    "filter": "",
+    "page": 1,
+    "page_size": 20,
+    "pages": 10,
+    "public_from": "",
+    "public_to": "",
+    "sort": "-public_date",
+    "total_items": 248,
+  },
+}
+`;
 
-exports[`VulnerabilitiesHelper test function createCveListBySystem() with cveList param 1`] = `"{\\"data\\":[{\\"id\\":\\"CVE-2019-6116\\",\\"business_risk_id\\":0,\\"business_risk_justification\\":null,\\"status_id\\":3,\\"rules\\":null,\\"cve_status_id\\":0,\\"status_justification\\":\\"pair status different\\",\\"cve_status_justification\\":null,\\"cells\\":[{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":[{\\"type\\":\\"a\\",\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"href\\":\\"http://localhost/insights/vulnerability/cves/CVE-2020-12662\\",\\"className\\":\\"pf-u-mr-sm\\",\\"style\\":{\\"display\\":\\"block\\"},\\"children\\":\\"CVE-2020-12662\\"},\\"_owner\\":null,\\"_store\\":{}},{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"hasRule\\":null},\\"_owner\\":null,\\"_store\\":{}}]},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"19 May 2020\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"impact\\":\\"Important\\",\\"tooltipPosition\\":\\"right\\",\\"hasLabel\\":true,\\"hasTooltip\\":true,\\"size\\":\\"sm\\"},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"7.5\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":\\"Not defined\\"},\\"_owner\\":null,\\"_store\\":{}}},{\\"title\\":{\\"type\\":\\"span\\",\\"key\\":\\"CVE-2019-6116\\",\\"ref\\":null,\\"props\\":{\\"children\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"row\\":{\\"type\\":\\"cve\\",\\"id\\":\\"CVE-2019-6116\\",\\"attributes\\":{\\"business_risk\\":\\"Not Defined\\",\\"business_risk_id\\":0,\\"business_risk_text\\":null,\\"cve_status_id\\":0,\\"cve_status_text\\":null,\\"cvss2_score\\":null,\\"cvss3_score\\":\\"7.500\\",\\"description\\":\\"A network amplification\\",\\"impact\\":\\"Important\\",\\"public_date\\":\\"2020-05-19T00:00:00+00:00\\",\\"reporter\\":1,\\"rule\\":null,\\"status\\":\\"Scheduled for Patch\\",\\"status_id\\":3,\\"status_text\\":\\"pair status different\\",\\"synopsis\\":\\"CVE-2020-12662\\"}},\\"type\\":1},\\"_owner\\":null,\\"_store\\":{}}},\\"_owner\\":null,\\"_store\\":{}}}],\\"isOpen\\":false,\\"selected\\":false},{\\"cells\\":[{\\"title\\":{\\"key\\":null,\\"ref\\":null,\\"props\\":{\\"description\\":\\"A network amplification\\",\\"rules\\":[null],\\"cve\\":\\"CVE-2020-12662\\"},\\"_owner\\":null,\\"_store\\":{}}}],\\"parent\\":0}],\\"meta\\":{\\"test\\":\\"test\\",\\"cvesCount\\":1},\\"isLoading\\":false}"`;
+exports[`VulnerabilitiesHelper test function createCveListBySystem() with cveList param 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "business_risk_id": 0,
+      "business_risk_justification": null,
+      "cells": Array [
+        Object {
+          "title": <span>
+            <a
+              className="pf-u-mr-sm"
+              href="http://localhost/insights/vulnerability/cves/CVE-2020-12662"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
+            >
+              CVE-2020-12662
+            </a>
+            <GroupedCVELabels
+              hasExploit={false}
+              hasRule={false}
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            19 May 2020
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <Shield
+              hasLabel={true}
+              hasTooltip={true}
+              impact="Important"
+              size="sm"
+              tooltipPosition="right"
+            />
+          </span>,
+        },
+        Object {
+          "title": <span>
+            7.5
+          </span>,
+        },
+        Object {
+          "title": <span>
+            Not defined
+          </span>,
+        },
+        Object {
+          "title": <span>
+            <SnippetWithPopover
+              row={
+                Object {
+                  "attributes": Object {
+                    "business_risk": "Not Defined",
+                    "business_risk_id": 0,
+                    "business_risk_text": null,
+                    "cve_status_id": 0,
+                    "cve_status_text": null,
+                    "cvss2_score": null,
+                    "cvss3_score": "7.500",
+                    "description": "A network amplification",
+                    "impact": "Important",
+                    "known_exploit": false,
+                    "public_date": "2020-05-19T00:00:00+00:00",
+                    "reporter": 1,
+                    "rule": null,
+                    "status": "Scheduled for Patch",
+                    "status_id": 3,
+                    "status_text": "pair status different",
+                    "synopsis": "CVE-2020-12662",
+                  },
+                  "id": "CVE-2019-6116",
+                  "type": "cve",
+                }
+              }
+              type={1}
+            />
+          </span>,
+        },
+      ],
+      "cve_status_id": 0,
+      "cve_status_justification": null,
+      "id": "CVE-2019-6116",
+      "isOpen": false,
+      "rules": null,
+      "selected": false,
+      "status_id": 3,
+      "status_justification": "pair status different",
+    },
+    Object {
+      "cells": Array [
+        Object {
+          "title": <CVETableExpandedCell
+            cve="CVE-2020-12662"
+            description="A network amplification"
+            rules={
+              Array [
+                null,
+              ]
+            }
+          />,
+        },
+      ],
+      "parent": 0,
+    },
+  ],
+  "errors": undefined,
+  "isLoading": false,
+  "meta": Object {
+    "cvesCount": 1,
+    "test": "test",
+  },
+}
+`;


### PR DESCRIPTION
- fix `VulnerabilityHelper` snapshot being on one line and hard to read
- fix proptypes errors with `hasExploit` and `hasRule` in `GroupedCVELabels` which expects booleans, if you don't like the `!!truthyValue` to boolean conversion, let my know