### PR TITLE
fix: Fix tag icon size and spacing

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -64,7 +64,7 @@
 // override FEC applying large font to first column of inventory table
 .ins-composed-col {
     * {
-        font-size: var(	--pf-global--FontSize--md) !important;
+        font-size: var(--pf-c-table--m-compact--FontSize) !important;
     }
 }
 
@@ -73,5 +73,21 @@
 
     .pf-c-toolbar__content {
         padding: 0
+    }
+}
+
+.ins-c-inventory__list-tags {
+    display: block !important; 
+    
+    .ins-c-tag-count {
+        padding-top: 2px;
+        padding-bottom: 0;
+        padding-left: 2px;
+    
+        svg {
+            padding-top: 2px;
+            height: 1.2rem;
+            width: 1.2rem;
+        }
     }
 }


### PR DESCRIPTION
## Before:
![before](https://user-images.githubusercontent.com/8426204/115046608-f1fd5200-9ed7-11eb-91cd-d0c4fa17085f.png)

## After:
![after](https://user-images.githubusercontent.com/8426204/115046615-f45fac00-9ed7-11eb-89fc-6e638dbce6fb.png)
