### PR TITLE
chore: Fix lint warnings

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,7 +23,7 @@ globals:
   shallow: true
   React: true
 rules:
-  no-console: 1
+  no-console: 2
   no-async-promise-executor: 0
   no-misleading-character-class: 0
   no-prototype-builtins: 0
@@ -108,7 +108,7 @@ rules:
     - error
     - functions: false
   no-undef: 2
-  no-unused-vars: 1
+  no-unused-vars: 2
   no-var: 2
   no-with: 2
   object-shorthand: 2

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,6 @@ import React, {
     useMemo,
     Fragment
 } from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/RouterParams';
 import NotificationPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';

--- a/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
+++ b/src/Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { intl } from '../../../Utilities/IntlProvider';
-import { Text, TextContent, TextVariants, Tooltip, Stack, StackItem } from '@patternfly/react-core';
+import { Text, TextContent, TextVariants, Stack, StackItem } from '@patternfly/react-core';
 import Label from '../Snippets/Label';
 import CSAwLabel from '../Snippets/CSAwLabel';
 import CSAwRuleSummary from '../CSAwRuleBox/CSAwRuleSummary';

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -1,4 +1,4 @@
-import { Tooltip, Flex, FlexItem } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Shield } from '@redhat-cloud-services/frontend-components/Shield';
 import parseCvssScore from '@redhat-cloud-services/frontend-components-utilities/parseCvssScore';
@@ -13,7 +13,6 @@ import messages from '../Messages';
 import CVETableExpandedCell from '../Components/PresentationalComponents/CVETableExpandedCell/CVETableExpandedCell';
 import AdvisoryColumn from '../Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn';
 import GroupedCVELabels from '../Components/PresentationalComponents/Snippets/GroupedCVELabels';
-import CSAwLabel from '../Components/PresentationalComponents/Snippets/CSAwLabel';
 
 export function createCveListByAccount(cveList) {
     let isLoading = cveList && cveList.isLoading;


### PR DESCRIPTION
Finally it compiles when you wither use console or an unused variable so I brought back the eslint rules for those 2. 
We missed in few places the unused variable so I fixed them  