### PR TITLE
Disable default columns on inventory table

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -205,6 +205,7 @@ const SystemsExposedTable = (props) => {
                 </StackItem>
                 <StackItem>
                     <InventoryTable
+                        disableDefaultColumns
                         onLoad={({ mergeWithEntities, mergeWithDetail }) => {
 
                             ReducerRegistry.register({

--- a/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
@@ -308,6 +308,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                           systems={Array []}
                         />
                       }
+                      disableDefaultColumns={true}
                       expandable="true"
                       exportConfig={
                         Object {
@@ -522,6 +523,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                             systems={Array []}
                           />
                         }
+                        disableDefaultColumns={true}
                         expandable="true"
                         exportConfig={
                           Object {
@@ -756,6 +758,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                     systems={Array []}
                                   />
                                 }
+                                disableDefaultColumns={true}
                                 expandable="true"
                                 exportConfig={
                                   Object {
@@ -979,6 +982,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                 systems={Array []}
                               />
                             }
+                            disableDefaultColumns={true}
                             expandable="true"
                             exportConfig={
                               Object {
@@ -1234,6 +1238,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                       systems={Array []}
                                     />
                                   }
+                                  disableDefaultColumns={true}
                                   expandable="true"
                                   exportConfig={
                                     Object {
@@ -1457,6 +1462,7 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                   systems={Array []}
                                 />
                               }
+                              disableDefaultColumns={true}
                               expandable="true"
                               exportConfig={
                                 Object {

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -155,6 +155,7 @@ const SystemsPage = ({ intl }) => {
                     { hasError
                         ? <ErrorHandler code={errorCode} />
                         : (<InventoryTable
+                            disableDefaultColumns
                             onLoad={({ mergeWithEntities, mergeWithDetail }) => {
                                 ReducerRegistry.register({
                                     ...mergeWithEntities(


### PR DESCRIPTION
This will ensure that a newer version of insights inventory table would not break columns.