### PR TITLE
feat(system detail): use federated modules to share system detail

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,11 @@ const { config: webpackConfig, plugins } = config({
 plugins.push(
     require('@redhat-cloud-services/frontend-components-config/federated-modules')({
         root: resolve(__dirname, '../'),
-        useFileHash: false
+        useFileHash: false,
+        exposes: {
+            './RootApp': resolve(__dirname, '../src/AppEntry'),
+            './SystemDetail': resolve(__dirname, '../src/index.js')
+        }
     })
 );
 

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -8,7 +8,11 @@ const { config: webpackConfig, plugins } = config({
 
 plugins.push(
     require('@redhat-cloud-services/frontend-components-config/federated-modules')({
-        root: resolve(__dirname, '../')
+        root: resolve(__dirname, '../'),
+        exposes: {
+            './RootApp': resolve(__dirname, '../src/AppEntry'),
+            './SystemDetail': resolve(__dirname, '../src/index.js')
+        }
     })
 );
 

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -21,7 +21,6 @@ import { EmptyVulnerabilityData } from '../../PresentationalComponents/EmptyStat
 import DownloadReport from '../../../Helpers/DownloadReport';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import SystemCveTableToolbar from './SystemCveTableToolbar';
-import { BrowserRouter as Router } from 'react-router-dom';
 import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -194,18 +193,13 @@ export const ConnectedSystemCves = withRouter(
     injectIntl(SystemCVEs)
 );
 
-const TranslateSystemCves = ({ customItnlProvider, customRouter, ...props }) => {
-    const RouterWrapper = customRouter ? Router : Fragment;
+const TranslateSystemCves = ({ customItnlProvider, ...props }) => {
     const Wrapper = customItnlProvider ? IntlProvider : Fragment;
     return <Wrapper {...customItnlProvider && {
         locale: navigator.language.slice(0, 2),
         messages
     } } >
-        <RouterWrapper
-            {...customRouter && { basename: `${window.location.pathname}` } }
-        >
-            <ConnectedSystemCves { ...props } />
-        </RouterWrapper>
+        <ConnectedSystemCves { ...props } />
     </Wrapper>;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,34 @@
-import React from 'react';
+import React, { useEffect, Fragment, useState } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import SystemCVEs from './Components/SmartComponents/SystemCves/SystemCves';
+import { SystemCvesStore } from './Store/Reducers/SystemCvesStore';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const WrappedSystemCves = (props) => {
+const WrappedSystemCves = ({ getRegistry, ...props }) => {
+    const [Wrapper, setWrapper] = useState();
+    useEffect(() => {
+        if (getRegistry) {
+            getRegistry()?.register?.({ SystemCvesStore });
+        }
+
+        setWrapper(() => getRegistry ? Provider : Fragment);
+    }, []);
     return <Router>
-        <SystemCVEs {...props} allowedCveActions={['REMEDIATE']} />
+        {
+            Wrapper ? <Wrapper {...getRegistry && { store: getRegistry()?.getStore() }}>
+                <SystemCVEs {...props} allowedCveActions={['REMEDIATE']} />
+            </Wrapper> : <Bullseye>
+                <Spinner size="xl" />
+            </Bullseye>
+        }
     </Router>;
 };
 
-export { SystemCvesStore } from './Store/Reducers/SystemCvesStore';
+WrappedSystemCves.propTypes = {
+    getRegistry: PropTypes.func
+};
+
+export { SystemCvesStore };
 export default WrappedSystemCves;


### PR DESCRIPTION
### Use federated modules to share system detail

Since we can now use federated modules in every environment let's share the system detail with it. This way we don't have to maintain the version of it in all environments, it's the same for all users on one environment. If a bug is found the fix is deployed just in this application and propagated to inventory via federetad modules.

### Usage
```JSX
import React, { useContext } from 'react';
import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
import { RegistryContext } from '../../store';
import { useRouteMatch } from 'react-router-dom';

const AdvisorTab = () => {
    const { params } = useRouteMatch('/:inventoryId');
    return <AsyncComponent
        appName="vulnerability"
        module="./SystemDetail"
        getRegistry={useContext(RegistryContext).getRegistry}
        customItnlProvider
        entity={ { id: params.inventoryId } }
    />;
};
```