### PR TITLE
Refactor SystemsPage to use getEntities

### DIFF
--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -1,15 +1,14 @@
 import React, { useEffect, Fragment, useState, useMemo } from 'react';
-import propTypes from 'prop-types';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import SystemsTableToolbar from './SystemsTableToolbar';
-import { SYSTEMS_HEADER, SYSTEMS_ALLOWED_PARAMS, SYSTEMS_SORTING_HEADER } from '../../../Helpers/constants';
+import { SYSTEMS_HEADER, SYSTEMS_ALLOWED_PARAMS, SYSTEMS_ADVISORY_COLUMN } from '../../../Helpers/constants';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { systemTableRowActions } from '../../../Helpers/CVEHelper';
 import Header from '../../PresentationalComponents/Header/Header';
-import { fetchSystems, optOutSystemsAction } from '../../../Store/Actions/Actions';
+import { optOutSystemsAction } from '../../../Store/Actions/Actions';
 import { inventoryEntitiesReducer } from '../../../Store/Reducers/InventoryEntitiesReducer';
 import {
     changeSystemsParams,
@@ -17,26 +16,33 @@ import {
     clearSystemStore,
     clearInventoryStore
 } from '../../../Store/Actions/Actions';
-import { useUrlParams, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
+import { useUrlParams } from '../../../Helpers/MiscHelper';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
-import { TableVariant } from '@patternfly/react-table';
+import { nowrap, TableVariant } from '@patternfly/react-table';
 import { useNotification } from '../../../Helpers/Hooks';
 import useDeepCompareEffect from 'use-deep-compare-effect';
+import * as APIHelper from '../../../Helpers/APIHelper';
 
-const createRows = ({ data }) => {
-    const items = data?.map(item => {
-        const { cve_count: cveCount, ...rest } = item.attributes;
-        return {
-            cve_count: cveCount,
-            id: item.attributes.inventory_id,
-            ...rest
-        };
-    });
-    return items || [];
+const createColumns = (defaultColumns, hasPatchAccess) => {
+    let [nameColumn, restColumns] = SYSTEMS_HEADER;
+    let lastSeenColumn = defaultColumns.filter(({ key }) => key === 'updated');
+    let tagsColumn = defaultColumns.filter(({ key }) => key === 'tags');
+
+    tagsColumn = { ...tagsColumn[0], props: { width: 20, isStatic: true } };
+    lastSeenColumn = { ...lastSeenColumn[0], cellTransforms: [nowrap], props: { width: 20 } };
+
+    let mergedColumns = [nameColumn, tagsColumn, restColumns, lastSeenColumn];
+
+    if (hasPatchAccess) {
+        mergedColumns.splice(2, 0, SYSTEMS_ADVISORY_COLUMN);
+    }
+
+    return mergedColumns;
 };
 
-const SystemsPage = ({ intl }) => {
+const SystemsPage = () => {
+    const intl = useIntl();
     const [selectedHosts, setSelectedHosts] = useState(undefined);
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_ALLOWED_PARAMS);
     const [isFirstMount, setFirstMount] = useState(true);
@@ -45,24 +51,19 @@ const SystemsPage = ({ intl }) => {
     const inventory = React.createRef();
     const dispatch = useDispatch();
 
-    const systems = useSelector(({ SystemsPageStore }) => SystemsPageStore.payload);
+    const systems = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
+    const totalItems = useSelector(({ entities }) => entities?.total);
 
     const parameters = useSelector(
         ({ SystemsPageStore }) => SystemsPageStore.params,
         shallowEqual
     );
 
-    const metadata = useSelector(
-        ({ SystemsPageStore }) => SystemsPageStore.metadata
-    );
-
     const { hasError, errorCode } = useSelector(
         ({ SystemsPageStore }) => SystemsPageStore.error
     );
 
-    const isLoading =  useSelector(({ SystemsPageStore }) => SystemsPageStore.isLoading);
-
-    const items = useMemo(() => createRows(systems), [systems]);
+    const hasPatchAccess = useSelector(({ entities }) => entities?.rows?.some(({ patchAccess }) => patchAccess));
 
     useEffect(() => {
         return () => {
@@ -81,17 +82,6 @@ const SystemsPage = ({ intl }) => {
         dispatch(changeSystemsParams(config));
     };
 
-    //DRY: SystemsExposed page has also the same function
-    const inventoryRefresh = ({ page, per_page: pageSize }) => {
-        if (metadata.page !== page || metadata.limit !== pageSize) {
-            apply({ page, page_size: pageSize });
-        }
-
-        if (metadata && metadata.total_items <= pageSize && inventory.current) {
-            inventory.current.onRefreshData({ page, page_size: pageSize });
-        }
-    };
-
     useEffect(() => {
         apply(urlParameters);
         setFirstMount(false);
@@ -101,7 +91,6 @@ const SystemsPage = ({ intl }) => {
     useDeepCompareEffect(() => {
         if (!isFirstMount) {
             setUrlParams({ ...parameters });
-            dispatch(fetchSystems(parameters));
         }
     }, [parameters, isFirstMount]);
 
@@ -114,7 +103,7 @@ const SystemsPage = ({ intl }) => {
     const doOptOut = (systemId = null, optOut) => {
         if (selectedHosts && (selectedHosts.length > 0) || systemId) {
             dispatch(optOutSystemsAction(systemId || selectedHosts, optOut)).then(() => {
-                dispatch(fetchSystems({ ...parameters, page: 1 }));
+                inventory.current.onRefreshData(({ page: 1 }));
 
                 let count = systemId ? 1 : selectedHosts.length || 0;
 
@@ -132,20 +121,7 @@ const SystemsPage = ({ intl }) => {
         }
     };
 
-    const sortBy = () =>
-        createSortBy(
-            SYSTEMS_SORTING_HEADER,
-            metadata.sort
-        );
-
-    const onSort = (event, index, direction) =>
-        handleSortColumn(
-            index,
-            direction,
-            SYSTEMS_SORTING_HEADER,
-            urlParameters.sort,
-            apply
-        );
+    let columnCounter = useMemo(() => columnCounter ? columnCounter++ : 0, [hasPatchAccess]);
 
     return (
         <Fragment>
@@ -159,7 +135,15 @@ const SystemsPage = ({ intl }) => {
                             onLoad={({ mergeWithEntities, mergeWithDetail }) => {
                                 ReducerRegistry.register({
                                     ...mergeWithEntities(
-                                        inventoryEntitiesReducer(SYSTEMS_HEADER)
+                                        inventoryEntitiesReducer(SYSTEMS_HEADER),
+                                        {
+                                            page: Number(parameters.page || 1),
+                                            perPage: Number(parameters.page_size || 20),
+                                            ...(parameters.sort && { sortBy: {
+                                                key: parameters.sort.replace(/^-/, ''),
+                                                direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
+                                            } })
+                                        }
                                     ),
                                     ...mergeWithDetail()
                                 });
@@ -167,25 +151,63 @@ const SystemsPage = ({ intl }) => {
                             tableProps={{
                                 isStickyHeader: true,
                                 canSelectAll: false,
-                                onSort: (items.length > 0) && onSort,
-                                sortBy: (items.length > 0) && sortBy(),
                                 actionResolver: (rowData) => systemTableRowActions(rowData,  doOptOut),
                                 variant: TableVariant.compact
                             }}
-                            showTags
+                            showTagModal
                             isFullView
                             ref={inventory}
-                            items={items}
-                            page={metadata && metadata.page || 1 }
-                            perPage={metadata && metadata.page_size || 20}
-                            total={metadata && metadata.total_items || 0}
-                            onRefresh={inventoryRefresh}
-                            isLoaded = {!isLoading}
-                            hasCheckbox={systems.length !== 0}
+                            autoRefresh
+                            customFilters={{
+                                vulnerabilityParams: {
+                                    excluded: parameters.excluded,
+                                    filter: parameters.filter
+                                }
+                            }}
+                            hasCheckbox={systems?.length !== 0}
+                            columnCounter={columnCounter}
+                            columns={(defaultColumns) => createColumns(defaultColumns, hasPatchAccess)}
+                            getEntities={async (
+                                _items,
+                                { vulnerabilityParams, orderBy, orderDirection, ...config },
+                                _hasItems,
+                                defaultGetEntities
+                            ) => {
+                                const sort = `${orderDirection === 'ASC' ? '' : '-'}${orderBy}`;
+
+                                apply({
+                                    page: config.page,
+                                    page_size: config.per_page,
+                                    sort
+                                });
+
+                                const items = await APIHelper.getSystems({
+                                    ...vulnerabilityParams,
+                                    page: config.page,
+                                    page_size: config.per_page,
+                                    sort
+                                });
+                                const results = await defaultGetEntities(
+                                    items.data.map(({ id }) => id),
+                                    { ...config, hasItems: true, fields: {} }
+                                );
+
+                                const findInsightsId = (id) => results.results.find((item) => item.id === id)?.insights_id;
+
+                                return Promise.resolve({
+                                    results: items.data.map(item => ({
+                                        ...item,
+                                        ...item.attributes,
+                                        insights_id: findInsightsId(item.id)
+                                    })),
+                                    total: items.meta.total_items
+                                });
+                            }}
+                            hideFilters={{ all: true }}
                         >
-                            {systems.data && (<SystemsTableToolbar
+                            <SystemsTableToolbar
                                 parameters = {parameters}
-                                systems = {systems}
+                                systems = {{ data: systems, meta: { total_items: totalItems } }}
                                 selectedHosts = {selectedHosts || []}
                                 methods = {{
                                     doOptOut,
@@ -194,7 +216,7 @@ const SystemsPage = ({ intl }) => {
                                     setSelectedHosts
                                 }}
                                 actions
-                            />)}
+                            />
                         </InventoryTable>
                         )}
                 </Fragment>
@@ -203,8 +225,4 @@ const SystemsPage = ({ intl }) => {
     );
 };
 
-SystemsPage.propTypes  = {
-    intl: propTypes.any
-};
-
-export default injectIntl(SystemsPage);
+export default SystemsPage;

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -465,7 +465,6 @@ export const SYSTEMS_HEADER = [
         key: 'display_name',
         title: intl.formatMessage(messages.systemsColumnHeaderName),
         composed: ['facts.os_release', 'display_name'],
-        transforms: [sortable],
         cellTransforms: [nowrap],
         renderFunc: (item, _id, { opt_out: optOut }) => <SystemNameColumn item={item} optOut={optOut} />
 
@@ -473,7 +472,7 @@ export const SYSTEMS_HEADER = [
     {
         key: 'cve_count',
         title: intl.formatMessage(messages.systemsColumnHeaderCveCount),
-        transforms: [sortable, cellWidth(25)],
+        transforms: [cellWidth(25)],
         renderFunc: (value) => (value !== null ? String(value) : intl.formatMessage(messages.systemsTableExcluded))
     }
 ];


### PR DESCRIPTION
This refactors SystemsPage to use the getEntities function and other new inventory features.

Please test it carefully, as there are many use-cases of the table and there are not so many tests.

This PR has to be merged only in ENVs where the InventoryTable is a version of (and higher): https://github.com/RedHatInsights/frontend-components/pull/1126 https://github.com/RedHatInsights/insights-chrome/pull/1425