### PR TITLE
VULN-1661 fix: Consistent expand all

### DIFF
--- a/src/Store/Reducers/CVEsStore.js
+++ b/src/Store/Reducers/CVEsStore.js
@@ -82,9 +82,7 @@ export const CVEsStore = (state = initialState, action) => {
             expandedRows.includes(cveName) && expandedRows.splice(expandedRows.indexOf(cveName), 1)
             || expandedRows.push(cveName);
 
-            const isAllExpanded = (expandedRows.length === newState.cveList.payload.data.length);
-
-            return { ...newState, expandedRows, isAllExpanded };
+            return { ...newState, expandedRows };
         }
 
         case ActionTypes.CLEAR_CVES_STORE:


### PR DESCRIPTION
Fixes [VULN-1661](https://issues.redhat.com/browse/VULN-1661).

According to [patternfly example](https://www.patternfly.org/v4/components/table/react-demos/expandcollapse-all/):
1. expand all then collapse one should yield to `v`
2. expand all then collapse one by one every row should yield to `>`
3. expand one by one every row should yield to `v`

---
1. was ok in systems exposed page, but was not present in CVE page, which is fixed in this PR
2. and 3. is in PF example, but this cannot be solved simply when using pagination, because we can only track expandedness of CVE if it's on the current page; CVEs on other pages are not loaded