### PR TITLE
VULN-1682 chore: Stylesheets cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-
 import React, {
     useEffect,
     useState,

--- a/src/App.scss
+++ b/src/App.scss
@@ -22,11 +22,6 @@
     }
 }
 
-.csaw-icon {
-    vertical-align: -0.125em;
-    margin-right: var(--pf-global--spacer--xs);
-}
-
 // temp solution to fix radio being cut off in mac
 .business-risk-radio > input {
     margin-left: 1px;
@@ -96,3 +91,39 @@
     margin: 0 0 auto auto !important;
 }
 
+.dropdown-toggle {
+    min-width: 150px;
+}
+
+.popover-content {
+    display: inline-block;
+    cursor: pointer;
+}
+
+.cve-synopsis {
+    display: block;
+}
+
+.cvss-input {
+    width: 5em;
+}
+
+#severity-shield {
+    font-weight: 700;
+}
+
+#cvss-vector-content {
+    font-size: var(--pf-global--FontSize--sm);
+}
+
+.pointer {
+    cursor: pointer;
+}
+
+.breadcrumb-skeleton {
+    width: 100px;
+}
+
+.cvss-input-label {
+    font-size: var(--pf-global--FontSize--sm);
+}

--- a/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
+++ b/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
@@ -42,7 +42,6 @@ const AdvisoryColumn = ({ cve, advisoriesList }) => {
                             <OutlinedQuestionCircleIcon
                                 className="pf-u-ml-xs"
                                 color="var(--pf-global--Color--200)"
-                                style={{ verticalAlign: '-0.125em' }}
                             />
                         </Tooltip>
                     </Fragment>

--- a/src/Components/PresentationalComponents/BasePfComponents/BaseDropdown.js
+++ b/src/Components/PresentationalComponents/BasePfComponents/BaseDropdown.js
@@ -18,7 +18,7 @@ const BaseDropdown = ({ dropdownItems, disabled,  ...props }) => {
                     onToggle={() => setIsOpen(!isOpen)}
                     toggleIndicator={CaretDownIcon}
                     isDisabled={disabled}
-                    style={{ minWidth: '150px' }}
+                    className="dropdown-toggle"
                 >
                     {intl.formatMessage(messages.actions)}
                 </DropdownToggle>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.scss
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.scss
@@ -52,7 +52,6 @@
 
 .powerOffIcon {
     color: var(--pf-global--danger-color--100);
-    vertical-align: '-0.125em'
 }
 
 .outlinedQuestionCircleIcon {

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -681,12 +681,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         }
                                                         trigger={
                                                           <Label
-                                                            style={
-                                                              Object {
-                                                                "backgroundColor": "#FFF5EC",
-                                                                "color": "#773D00",
-                                                              }
-                                                            }
+                                                            className="impact-label-moderate"
                                                           >
                                                             Moderate
                                                           </Label>
@@ -697,21 +692,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                           onFoundRef={[Function]}
                                                         >
                                                           <Label
-                                                            style={
-                                                              Object {
-                                                                "backgroundColor": "#FFF5EC",
-                                                                "color": "#773D00",
-                                                              }
-                                                            }
+                                                            className="impact-label-moderate"
                                                           >
                                                             <span
-                                                              className="pf-c-label"
-                                                              style={
-                                                                Object {
-                                                                  "backgroundColor": "#FFF5EC",
-                                                                  "color": "#773D00",
-                                                                }
-                                                              }
+                                                              className="pf-c-label impact-label-moderate"
                                                             >
                                                               <span
                                                                 className="pf-c-label__content"
@@ -1694,12 +1678,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                         }
                                                         trigger={
                                                           <Label
-                                                            style={
-                                                              Object {
-                                                                "backgroundColor": "#FFF5EC",
-                                                                "color": "#773D00",
-                                                              }
-                                                            }
+                                                            className="impact-label-moderate"
                                                           >
                                                             Moderate
                                                           </Label>
@@ -1710,21 +1689,10 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                                           onFoundRef={[Function]}
                                                         >
                                                           <Label
-                                                            style={
-                                                              Object {
-                                                                "backgroundColor": "#FFF5EC",
-                                                                "color": "#773D00",
-                                                              }
-                                                            }
+                                                            className="impact-label-moderate"
                                                           >
                                                             <span
-                                                              className="pf-c-label"
-                                                              style={
-                                                                Object {
-                                                                  "backgroundColor": "#FFF5EC",
-                                                                  "color": "#773D00",
-                                                                }
-                                                              }
+                                                              className="pf-c-label impact-label-moderate"
                                                             >
                                                               <span
                                                                 className="pf-c-label__content"

--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/SnippetWithHeaderAndPopover.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/SnippetWithHeaderAndPopover.js
@@ -9,7 +9,7 @@ const SnippetWithHeaderAndPopover = props => {
     return (
         <Popover id="popover" bodyContent={content} headerContent={''} aria-label="Business risk popover" position="right"
             appendTo={document.querySelector('.vulnerability')}>
-            <Stack style={{ display: 'inline-block', cursor: 'pointer' }}>
+            <Stack className="popover-content">
                 <StackItem>
                     <Label isLarge>{title}</Label>
                 </StackItem>

--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/SnippetWithHeaderAndPopover.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/SnippetWithHeaderAndPopover.test.js.snap
@@ -85,12 +85,7 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label and Tool
       }
       trigger={
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <StackItem>
             <Label
@@ -112,21 +107,10 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label and Tool
         onFoundRef={[Function]}
       >
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <div
-            className="pf-l-stack"
-            style={
-              Object {
-                "cursor": "pointer",
-                "display": "inline-block",
-              }
-            }
+            className="pf-l-stack popover-content"
           >
             <StackItem>
               <div
@@ -140,7 +124,7 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label and Tool
                     style={
                       Object {
                         "display": "block",
-                        "fontSize": 16,
+                        "fontSize": "medium",
                       }
                     }
                   >
@@ -250,12 +234,7 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label only 1`]
       }
       trigger={
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <StackItem>
             <Label
@@ -277,21 +256,10 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label only 1`]
         onFoundRef={[Function]}
       >
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <div
-            className="pf-l-stack"
-            style={
-              Object {
-                "cursor": "pointer",
-                "display": "inline-block",
-              }
-            }
+            className="pf-l-stack popover-content"
           >
             <StackItem>
               <div
@@ -305,7 +273,7 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label only 1`]
                     style={
                       Object {
                         "display": "block",
-                        "fontSize": 16,
+                        "fontSize": "medium",
                       }
                     }
                   >
@@ -412,12 +380,7 @@ exports[`SnippetWithHeaderAndPopover Should render without params 1`] = `
       }
       trigger={
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <StackItem>
             <Label
@@ -435,21 +398,10 @@ exports[`SnippetWithHeaderAndPopover Should render without params 1`] = `
         onFoundRef={[Function]}
       >
         <Stack
-          style={
-            Object {
-              "cursor": "pointer",
-              "display": "inline-block",
-            }
-          }
+          className="popover-content"
         >
           <div
-            className="pf-l-stack"
-            style={
-              Object {
-                "cursor": "pointer",
-                "display": "inline-block",
-              }
-            }
+            className="pf-l-stack popover-content"
           >
             <StackItem>
               <div
@@ -463,7 +415,7 @@ exports[`SnippetWithHeaderAndPopover Should render without params 1`] = `
                     style={
                       Object {
                         "display": "block",
-                        "fontSize": 16,
+                        "fontSize": "medium",
                       }
                     }
                   />

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
@@ -112,7 +112,7 @@ const CVEDetailsPageSidebar = ({ cveAttributes, intl }) => {
                 <Label className="pf-u-mb-xs" isLarge>
                     {intl.formatMessage(messages.impact)}
                 </Label>
-                <span style={{ fontWeight: 700, color: cveDetails.color }}>
+                <span id="severity-shield" style={{ color: cveDetails.color }}>
                     <Shield impact={cveDetails.title} hasLabel/>
                 </span>
             </StackItem>

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
@@ -241,12 +241,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           }
                           trigger={
                             <Stack
-                              style={
-                                Object {
-                                  "cursor": "pointer",
-                                  "display": "inline-block",
-                                }
-                              }
+                              className="popover-content"
                             >
                               <StackItem>
                                 <Label
@@ -268,21 +263,10 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                             onFoundRef={[Function]}
                           >
                             <Stack
-                              style={
-                                Object {
-                                  "cursor": "pointer",
-                                  "display": "inline-block",
-                                }
-                              }
+                              className="popover-content"
                             >
                               <div
-                                className="pf-l-stack"
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                    "display": "inline-block",
-                                  }
-                                }
+                                className="pf-l-stack popover-content"
                               >
                                 <StackItem>
                                   <div
@@ -296,7 +280,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                                         style={
                                           Object {
                                             "display": "block",
-                                            "fontSize": 16,
+                                            "fontSize": "medium",
                                           }
                                         }
                                       >
@@ -636,12 +620,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           }
                           trigger={
                             <Stack
-                              style={
-                                Object {
-                                  "cursor": "pointer",
-                                  "display": "inline-block",
-                                }
-                              }
+                              className="popover-content"
                             >
                               <StackItem>
                                 <Label
@@ -671,21 +650,10 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                             onFoundRef={[Function]}
                           >
                             <Stack
-                              style={
-                                Object {
-                                  "cursor": "pointer",
-                                  "display": "inline-block",
-                                }
-                              }
+                              className="popover-content"
                             >
                               <div
-                                className="pf-l-stack"
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                    "display": "inline-block",
-                                  }
-                                }
+                                className="pf-l-stack popover-content"
                               >
                                 <StackItem>
                                   <div
@@ -699,7 +667,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                                         style={
                                           Object {
                                             "display": "block",
-                                            "fontSize": 16,
+                                            "fontSize": "medium",
                                           }
                                         }
                                       >
@@ -769,7 +737,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                 style={
                   Object {
                     "display": "block",
-                    "fontSize": 16,
+                    "fontSize": "medium",
                   }
                 }
               >
@@ -777,10 +745,10 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
               </span>
             </Label>
             <span
+              id="severity-shield"
               style={
                 Object {
                   "color": "var(--pf-global--palette--orange-400)",
-                  "fontWeight": 700,
                 }
               }
             >

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
@@ -476,12 +476,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -501,21 +496,10 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -529,7 +513,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -705,12 +689,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -734,21 +713,10 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -762,7 +730,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -807,7 +775,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                 style={
                                   Object {
                                     "display": "block",
-                                    "fontSize": 16,
+                                    "fontSize": "medium",
                                   }
                                 }
                               >
@@ -815,10 +783,10 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                               </span>
                             </Label>
                             <span
+                              id="severity-shield"
                               style={
                                 Object {
                                   "color": "black",
-                                  "fontWeight": 700,
                                 }
                               }
                             >
@@ -1405,12 +1373,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -1430,21 +1393,10 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -1458,7 +1410,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -1634,12 +1586,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -1663,21 +1610,10 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -1691,7 +1627,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -1736,7 +1672,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                 style={
                                   Object {
                                     "display": "block",
-                                    "fontSize": 16,
+                                    "fontSize": "medium",
                                   }
                                 }
                               >
@@ -1744,10 +1680,10 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                               </span>
                             </Label>
                             <span
+                              id="severity-shield"
                               style={
                                 Object {
                                   "color": "black",
-                                  "fontWeight": 700,
                                 }
                               }
                             >
@@ -2355,12 +2291,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -2380,21 +2311,10 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -2408,7 +2328,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -2584,12 +2504,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -2613,21 +2528,10 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -2641,7 +2545,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -2686,7 +2590,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                 style={
                                   Object {
                                     "display": "block",
-                                    "fontSize": 16,
+                                    "fontSize": "medium",
                                   }
                                 }
                               >
@@ -2694,10 +2598,10 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                               </span>
                             </Label>
                             <span
+                              id="severity-shield"
                               style={
                                 Object {
                                   "color": "black",
-                                  "fontWeight": 700,
                                 }
                               }
                             >
@@ -3270,12 +3174,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -3295,21 +3194,10 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -3323,7 +3211,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -3499,12 +3387,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           }
                                           trigger={
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <StackItem>
                                                 <Label
@@ -3528,21 +3411,10 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                             onFoundRef={[Function]}
                                           >
                                             <Stack
-                                              style={
-                                                Object {
-                                                  "cursor": "pointer",
-                                                  "display": "inline-block",
-                                                }
-                                              }
+                                              className="popover-content"
                                             >
                                               <div
-                                                className="pf-l-stack"
-                                                style={
-                                                  Object {
-                                                    "cursor": "pointer",
-                                                    "display": "inline-block",
-                                                  }
-                                                }
+                                                className="pf-l-stack popover-content"
                                               >
                                                 <StackItem>
                                                   <div
@@ -3556,7 +3428,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                         style={
                                                           Object {
                                                             "display": "block",
-                                                            "fontSize": 16,
+                                                            "fontSize": "medium",
                                                           }
                                                         }
                                                       >
@@ -3601,7 +3473,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                 style={
                                   Object {
                                     "display": "block",
-                                    "fontSize": 16,
+                                    "fontSize": "medium",
                                   }
                                 }
                               >
@@ -3609,10 +3481,10 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                               </span>
                             </Label>
                             <span
+                              id="severity-shield"
                               style={
                                 Object {
                                   "color": "black",
-                                  "fontWeight": 700,
                                 }
                               }
                             >

--- a/src/Components/PresentationalComponents/CvssVector/CvssVector.js
+++ b/src/Components/PresentationalComponents/CvssVector/CvssVector.js
@@ -65,12 +65,11 @@ const CvssVector = props => {
                             }
                         >
                             <React.Fragment>
-                                <Label isLarge style={{ cursor: 'pointer' }} className="pf-u-mb-xs">
+                                <Label isLarge className="pf-u-mb-xs pointer">
                                     {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
                                     <OutlinedQuestionCircleIcon
                                         color={'var(--pf-global--secondary-color--100)'}
                                         className="pf-u-ml-xs"
-                                        style={{ verticalAlign: '-0.125em' }}
                                     />
                                 </Label>
                             </React.Fragment>
@@ -79,7 +78,7 @@ const CvssVector = props => {
 
                     <WithLoader loading={context.isLoading}>
                         <span className="pf-u-mr-md">{props.score}</span>
-                        <span style={{ fontSize: 'small' }}>
+                        <span id="cvss-vector-content">
                             {intl.formatMessage(messages.vector) + ': '}
                             {cvssVector?.substring(cvssVector.indexOf('/') + 1) || notAvailable}
                         </span>

--- a/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
@@ -35,28 +35,28 @@ const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }
 
     const filterCvssContent = (<Split className="pf-u-m-md">
         <SplitItem>
-            <span style={{ fontSize: 14 }}>{intl.formatMessage(messages.customReportCvssMinLabel)}</span><br />
+            <span className="cvss-input-label">{intl.formatMessage(messages.customReportCvssMinLabel)}</span><br />
             <TextInput
                 type="number"
                 onChange={(value) => handleCvssInputChange(value, 'from')}
                 validated={validateCvssInput('from')}
                 id="cvss-min"
+                className="cvss-input"
                 value={filterData.cvss_filter.from}
-                style={{ width: '5em' }}
             />
         </SplitItem>
         <SplitItem>
             <br /><span className="pf-u-m-sm">-</span>
         </SplitItem>
         <SplitItem>
-            <span style={{ fontSize: 14 }}>{intl.formatMessage(messages.customReportCvssMaxLabel)}</span><br />
+            <span className="cvss-input-label">{intl.formatMessage(messages.customReportCvssMaxLabel)}</span><br />
             <TextInput
                 type="number"
                 onChange={(value) => handleCvssInputChange(value, 'to')}
                 validated={validateCvssInput('to')}
                 id="cvss-max"
+                className="cvss-input"
                 value={filterData.cvss_filter.to}
-                style={{ width: '5em' }}
             />
         </SplitItem>
     </Split>);

--- a/src/Components/PresentationalComponents/Header/Breadcrumb.js
+++ b/src/Components/PresentationalComponents/Header/Breadcrumb.js
@@ -21,7 +21,7 @@ const Breadcrumb = ({ breadcrumbs }) => {
                                 item.isActive ? item.title : <Link to={item.to}>{item.title}</Link>
                             )
                             : (
-                                <Skeleton style={{ width: '100px' }}/>
+                                <Skeleton class="breadcrumb-skeleton"/>
                             )
                     }
                 </BreadcrumbItem>

--- a/src/Components/PresentationalComponents/Snippets/Label.js
+++ b/src/Components/PresentationalComponents/Snippets/Label.js
@@ -3,7 +3,7 @@ import React from 'react';
 import './Label.scss';
 
 const Label = ({ children, className = '', style, isLarge = false, isInline = false }) => {
-    const styleProp = { ...(isLarge && { fontSize: 16 }),  ...(isInline || { display: 'block' }), ...style };
+    const styleProp = { ...(isLarge && { fontSize: 'medium' }),  ...(isInline || { display: 'block' }), ...style };
 
     return (
         <span className={`vuln-label ${className}`} style={styleProp}>

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -103,12 +103,7 @@ exports[`CVEs Should render without props 1`] = `
                                   Object {
                                     "title": <span>
                                       <Link
-                                        className="pf-u-mr-sm"
-                                        style={
-                                          Object {
-                                            "display": "block",
-                                          }
-                                        }
+                                        className="pf-u-mr-sm cve-synopsis"
                                         to="/cves/CVE-2020-0543"
                                       >
                                         CVE-2020-0543
@@ -3248,12 +3243,7 @@ exports[`CVEs Should render without props 1`] = `
                                 Object {
                                   "title": <span>
                                     <Link
-                                      className="pf-u-mr-sm"
-                                      style={
-                                        Object {
-                                          "display": "block",
-                                        }
-                                      }
+                                      className="pf-u-mr-sm cve-synopsis"
                                       to="/cves/CVE-2020-0543"
                                     >
                                       CVE-2020-0543
@@ -3524,12 +3514,7 @@ exports[`CVEs Should render without props 1`] = `
                               Object {
                                 "title": <span>
                                   <Link
-                                    className="pf-u-mr-sm"
-                                    style={
-                                      Object {
-                                        "display": "block",
-                                      }
-                                    }
+                                    className="pf-u-mr-sm cve-synopsis"
                                     to="/cves/CVE-2020-0543"
                                   >
                                     CVE-2020-0543
@@ -6560,12 +6545,7 @@ exports[`CVEs Should render without props 1`] = `
                                           Object {
                                             "title": <span>
                                               <Link
-                                                className="pf-u-mr-sm"
-                                                style={
-                                                  Object {
-                                                    "display": "block",
-                                                  }
-                                                }
+                                                className="pf-u-mr-sm cve-synopsis"
                                                 to="/cves/CVE-2020-0543"
                                               >
                                                 CVE-2020-0543
@@ -6662,12 +6642,7 @@ exports[`CVEs Should render without props 1`] = `
                                             Object {
                                               "title": <span>
                                                 <Link
-                                                  className="pf-u-mr-sm"
-                                                  style={
-                                                    Object {
-                                                      "display": "block",
-                                                    }
-                                                  }
+                                                  className="pf-u-mr-sm cve-synopsis"
                                                   to="/cves/CVE-2020-0543"
                                                 >
                                                   CVE-2020-0543
@@ -6727,12 +6702,7 @@ exports[`CVEs Should render without props 1`] = `
                                             },
                                             "title": <span>
                                               <Link
-                                                className="pf-u-mr-sm"
-                                                style={
-                                                  Object {
-                                                    "display": "block",
-                                                  }
-                                                }
+                                                className="pf-u-mr-sm cve-synopsis"
                                                 to="/cves/CVE-2020-0543"
                                               >
                                                 CVE-2020-0543
@@ -6865,12 +6835,7 @@ exports[`CVEs Should render without props 1`] = `
                                             Object {
                                               "title": <span>
                                                 <Link
-                                                  className="pf-u-mr-sm"
-                                                  style={
-                                                    Object {
-                                                      "display": "block",
-                                                    }
-                                                  }
+                                                  className="pf-u-mr-sm cve-synopsis"
                                                   to="/cves/CVE-2020-0543"
                                                 >
                                                   CVE-2020-0543
@@ -6930,12 +6895,7 @@ exports[`CVEs Should render without props 1`] = `
                                             },
                                             "title": <span>
                                               <Link
-                                                className="pf-u-mr-sm"
-                                                style={
-                                                  Object {
-                                                    "display": "block",
-                                                  }
-                                                }
+                                                className="pf-u-mr-sm cve-synopsis"
                                                 to="/cves/CVE-2020-0543"
                                               >
                                                 CVE-2020-0543
@@ -7574,12 +7534,7 @@ exports[`CVEs Should render without props 1`] = `
                                               Object {
                                                 "title": <span>
                                                   <Link
-                                                    className="pf-u-mr-sm"
-                                                    style={
-                                                      Object {
-                                                        "display": "block",
-                                                      }
-                                                    }
+                                                    className="pf-u-mr-sm cve-synopsis"
                                                     to="/cves/CVE-2020-0543"
                                                   >
                                                     CVE-2020-0543
@@ -7639,12 +7594,7 @@ exports[`CVEs Should render without props 1`] = `
                                               },
                                               "title": <span>
                                                 <Link
-                                                  className="pf-u-mr-sm"
-                                                  style={
-                                                    Object {
-                                                      "display": "block",
-                                                    }
-                                                  }
+                                                  className="pf-u-mr-sm cve-synopsis"
                                                   to="/cves/CVE-2020-0543"
                                                 >
                                                   CVE-2020-0543
@@ -7801,12 +7751,7 @@ exports[`CVEs Should render without props 1`] = `
                                               Object {
                                                 "title": <span>
                                                   <Link
-                                                    className="pf-u-mr-sm"
-                                                    style={
-                                                      Object {
-                                                        "display": "block",
-                                                      }
-                                                    }
+                                                    className="pf-u-mr-sm cve-synopsis"
                                                     to="/cves/CVE-2020-0543"
                                                   >
                                                     CVE-2020-0543
@@ -7866,12 +7811,7 @@ exports[`CVEs Should render without props 1`] = `
                                               },
                                               "title": <span>
                                                 <Link
-                                                  className="pf-u-mr-sm"
-                                                  style={
-                                                    Object {
-                                                      "display": "block",
-                                                    }
-                                                  }
+                                                  className="pf-u-mr-sm cve-synopsis"
                                                   to="/cves/CVE-2020-0543"
                                                 >
                                                   CVE-2020-0543
@@ -8006,12 +7946,7 @@ exports[`CVEs Should render without props 1`] = `
                                                 Object {
                                                   "title": <span>
                                                     <Link
-                                                      className="pf-u-mr-sm"
-                                                      style={
-                                                        Object {
-                                                          "display": "block",
-                                                        }
-                                                      }
+                                                      className="pf-u-mr-sm cve-synopsis"
                                                       to="/cves/CVE-2020-0543"
                                                     >
                                                       CVE-2020-0543
@@ -8071,12 +8006,7 @@ exports[`CVEs Should render without props 1`] = `
                                                 },
                                                 "title": <span>
                                                   <Link
-                                                    className="pf-u-mr-sm"
-                                                    style={
-                                                      Object {
-                                                        "display": "block",
-                                                      }
-                                                    }
+                                                    className="pf-u-mr-sm cve-synopsis"
                                                     to="/cves/CVE-2020-0543"
                                                   >
                                                     CVE-2020-0543
@@ -8735,12 +8665,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       Object {
                                                         "title": <span>
                                                           <Link
-                                                            className="pf-u-mr-sm"
-                                                            style={
-                                                              Object {
-                                                                "display": "block",
-                                                              }
-                                                            }
+                                                            className="pf-u-mr-sm cve-synopsis"
                                                             to="/cves/CVE-2020-0543"
                                                           >
                                                             CVE-2020-0543
@@ -8800,12 +8725,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       },
                                                       "title": <span>
                                                         <Link
-                                                          className="pf-u-mr-sm"
-                                                          style={
-                                                            Object {
-                                                              "display": "block",
-                                                            }
-                                                          }
+                                                          className="pf-u-mr-sm cve-synopsis"
                                                           to="/cves/CVE-2020-0543"
                                                         >
                                                           CVE-2020-0543
@@ -8911,12 +8831,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         Object {
                                                           "title": <span>
                                                             <Link
-                                                              className="pf-u-mr-sm"
-                                                              style={
-                                                                Object {
-                                                                  "display": "block",
-                                                                }
-                                                              }
+                                                              className="pf-u-mr-sm cve-synopsis"
                                                               to="/cves/CVE-2020-0543"
                                                             >
                                                               CVE-2020-0543
@@ -8976,12 +8891,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         },
                                                         "title": <span>
                                                           <Link
-                                                            className="pf-u-mr-sm"
-                                                            style={
-                                                              Object {
-                                                                "display": "block",
-                                                              }
-                                                            }
+                                                            className="pf-u-mr-sm cve-synopsis"
                                                             to="/cves/CVE-2020-0543"
                                                           >
                                                             CVE-2020-0543
@@ -9267,33 +9177,18 @@ exports[`CVEs Should render without props 1`] = `
                                                                   key="CVE-2019-6454"
                                                                 >
                                                                   <Link
-                                                                    className="pf-u-mr-sm"
-                                                                    style={
-                                                                      Object {
-                                                                        "display": "block",
-                                                                      }
-                                                                    }
+                                                                    className="pf-u-mr-sm cve-synopsis"
                                                                     to="/cves/CVE-2020-0543"
                                                                   >
                                                                     <LinkAnchor
-                                                                      className="pf-u-mr-sm"
+                                                                      className="pf-u-mr-sm cve-synopsis"
                                                                       href="/cves/CVE-2020-0543"
                                                                       navigate={[Function]}
-                                                                      style={
-                                                                        Object {
-                                                                          "display": "block",
-                                                                        }
-                                                                      }
                                                                     >
                                                                       <a
-                                                                        className="pf-u-mr-sm"
+                                                                        className="pf-u-mr-sm cve-synopsis"
                                                                         href="/cves/CVE-2020-0543"
                                                                         onClick={[Function]}
-                                                                        style={
-                                                                          Object {
-                                                                            "display": "block",
-                                                                          }
-                                                                        }
                                                                       >
                                                                         CVE-2020-0543
                                                                       </a>
@@ -9792,12 +9687,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                         Object {
                                                                           "title": <span>
                                                                             <ForwardRef(Link)
-                                                                              className="pf-u-mr-sm"
-                                                                              style={
-                                                                                Object {
-                                                                                  "display": "block",
-                                                                                }
-                                                                              }
+                                                                              className="pf-u-mr-sm cve-synopsis"
                                                                               to="/cves/CVE-2020-0543"
                                                                             >
                                                                               CVE-2020-0543
@@ -9857,12 +9747,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                         },
                                                                         "title": <span>
                                                                           <ForwardRef(Link)
-                                                                            className="pf-u-mr-sm"
-                                                                            style={
-                                                                              Object {
-                                                                                "display": "block",
-                                                                              }
-                                                                            }
+                                                                            className="pf-u-mr-sm cve-synopsis"
                                                                             to="/cves/CVE-2020-0543"
                                                                           >
                                                                             CVE-2020-0543

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -111,12 +111,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     Object {
                       "title": <span>
                         <Link
-                          className="pf-u-mr-sm"
-                          style={
-                            Object {
-                              "display": "block",
-                            }
-                          }
+                          className="pf-u-mr-sm cve-synopsis"
                           to="/cves/CVE-2020-0543"
                         >
                           CVE-2020-0543
@@ -390,12 +385,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                   Object {
                     "title": <span>
                       <Link
-                        className="pf-u-mr-sm"
-                        style={
-                          Object {
-                            "display": "block",
-                          }
-                        }
+                        className="pf-u-mr-sm cve-synopsis"
                         to="/cves/CVE-2020-0543"
                       >
                         CVE-2020-0543
@@ -3425,12 +3415,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               Object {
                                 "title": <span>
                                   <Link
-                                    className="pf-u-mr-sm"
-                                    style={
-                                      Object {
-                                        "display": "block",
-                                      }
-                                    }
+                                    className="pf-u-mr-sm cve-synopsis"
                                     to="/cves/CVE-2020-0543"
                                   >
                                     CVE-2020-0543
@@ -3526,12 +3511,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 Object {
                                   "title": <span>
                                     <Link
-                                      className="pf-u-mr-sm"
-                                      style={
-                                        Object {
-                                          "display": "block",
-                                        }
-                                      }
+                                      className="pf-u-mr-sm cve-synopsis"
                                       to="/cves/CVE-2020-0543"
                                     >
                                       CVE-2020-0543
@@ -3590,12 +3570,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 },
                                 "title": <span>
                                   <Link
-                                    className="pf-u-mr-sm"
-                                    style={
-                                      Object {
-                                        "display": "block",
-                                      }
-                                    }
+                                    className="pf-u-mr-sm cve-synopsis"
                                     to="/cves/CVE-2020-0543"
                                   >
                                     CVE-2020-0543
@@ -3727,12 +3702,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 Object {
                                   "title": <span>
                                     <Link
-                                      className="pf-u-mr-sm"
-                                      style={
-                                        Object {
-                                          "display": "block",
-                                        }
-                                      }
+                                      className="pf-u-mr-sm cve-synopsis"
                                       to="/cves/CVE-2020-0543"
                                     >
                                       CVE-2020-0543
@@ -3791,12 +3761,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 },
                                 "title": <span>
                                   <Link
-                                    className="pf-u-mr-sm"
-                                    style={
-                                      Object {
-                                        "display": "block",
-                                      }
-                                    }
+                                    className="pf-u-mr-sm cve-synopsis"
                                     to="/cves/CVE-2020-0543"
                                   >
                                     CVE-2020-0543
@@ -4434,12 +4399,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   Object {
                                     "title": <span>
                                       <Link
-                                        className="pf-u-mr-sm"
-                                        style={
-                                          Object {
-                                            "display": "block",
-                                          }
-                                        }
+                                        className="pf-u-mr-sm cve-synopsis"
                                         to="/cves/CVE-2020-0543"
                                       >
                                         CVE-2020-0543
@@ -4498,12 +4458,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   },
                                   "title": <span>
                                     <Link
-                                      className="pf-u-mr-sm"
-                                      style={
-                                        Object {
-                                          "display": "block",
-                                        }
-                                      }
+                                      className="pf-u-mr-sm cve-synopsis"
                                       to="/cves/CVE-2020-0543"
                                     >
                                       CVE-2020-0543
@@ -4659,12 +4614,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   Object {
                                     "title": <span>
                                       <Link
-                                        className="pf-u-mr-sm"
-                                        style={
-                                          Object {
-                                            "display": "block",
-                                          }
-                                        }
+                                        className="pf-u-mr-sm cve-synopsis"
                                         to="/cves/CVE-2020-0543"
                                       >
                                         CVE-2020-0543
@@ -4723,12 +4673,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   },
                                   "title": <span>
                                     <Link
-                                      className="pf-u-mr-sm"
-                                      style={
-                                        Object {
-                                          "display": "block",
-                                        }
-                                      }
+                                      className="pf-u-mr-sm cve-synopsis"
                                       to="/cves/CVE-2020-0543"
                                     >
                                       CVE-2020-0543
@@ -4862,12 +4807,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                     Object {
                                       "title": <span>
                                         <Link
-                                          className="pf-u-mr-sm"
-                                          style={
-                                            Object {
-                                              "display": "block",
-                                            }
-                                          }
+                                          className="pf-u-mr-sm cve-synopsis"
                                           to="/cves/CVE-2020-0543"
                                         >
                                           CVE-2020-0543
@@ -4926,12 +4866,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                     },
                                     "title": <span>
                                       <Link
-                                        className="pf-u-mr-sm"
-                                        style={
-                                          Object {
-                                            "display": "block",
-                                          }
-                                        }
+                                        className="pf-u-mr-sm cve-synopsis"
                                         to="/cves/CVE-2020-0543"
                                       >
                                         CVE-2020-0543
@@ -5589,12 +5524,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           Object {
                                             "title": <span>
                                               <Link
-                                                className="pf-u-mr-sm"
-                                                style={
-                                                  Object {
-                                                    "display": "block",
-                                                  }
-                                                }
+                                                className="pf-u-mr-sm cve-synopsis"
                                                 to="/cves/CVE-2020-0543"
                                               >
                                                 CVE-2020-0543
@@ -5653,12 +5583,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           },
                                           "title": <span>
                                             <Link
-                                              className="pf-u-mr-sm"
-                                              style={
-                                                Object {
-                                                  "display": "block",
-                                                }
-                                              }
+                                              className="pf-u-mr-sm cve-synopsis"
                                               to="/cves/CVE-2020-0543"
                                             >
                                               CVE-2020-0543
@@ -5763,12 +5688,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             Object {
                                               "title": <span>
                                                 <Link
-                                                  className="pf-u-mr-sm"
-                                                  style={
-                                                    Object {
-                                                      "display": "block",
-                                                    }
-                                                  }
+                                                  className="pf-u-mr-sm cve-synopsis"
                                                   to="/cves/CVE-2020-0543"
                                                 >
                                                   CVE-2020-0543
@@ -5827,12 +5747,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             },
                                             "title": <span>
                                               <Link
-                                                className="pf-u-mr-sm"
-                                                style={
-                                                  Object {
-                                                    "display": "block",
-                                                  }
-                                                }
+                                                className="pf-u-mr-sm cve-synopsis"
                                                 to="/cves/CVE-2020-0543"
                                               >
                                                 CVE-2020-0543
@@ -6117,33 +6032,18 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                       key="CVE-2019-6454"
                                                     >
                                                       <Link
-                                                        className="pf-u-mr-sm"
-                                                        style={
-                                                          Object {
-                                                            "display": "block",
-                                                          }
-                                                        }
+                                                        className="pf-u-mr-sm cve-synopsis"
                                                         to="/cves/CVE-2020-0543"
                                                       >
                                                         <LinkAnchor
-                                                          className="pf-u-mr-sm"
+                                                          className="pf-u-mr-sm cve-synopsis"
                                                           href="/cves/CVE-2020-0543"
                                                           navigate={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "display": "block",
-                                                            }
-                                                          }
                                                         >
                                                           <a
-                                                            className="pf-u-mr-sm"
+                                                            className="pf-u-mr-sm cve-synopsis"
                                                             href="/cves/CVE-2020-0543"
                                                             onClick={[Function]}
-                                                            style={
-                                                              Object {
-                                                                "display": "block",
-                                                              }
-                                                            }
                                                           >
                                                             CVE-2020-0543
                                                           </a>
@@ -6641,12 +6541,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                             Object {
                                                               "title": <span>
                                                                 <ForwardRef(Link)
-                                                                  className="pf-u-mr-sm"
-                                                                  style={
-                                                                    Object {
-                                                                      "display": "block",
-                                                                    }
-                                                                  }
+                                                                  className="pf-u-mr-sm cve-synopsis"
                                                                   to="/cves/CVE-2020-0543"
                                                                 >
                                                                   CVE-2020-0543
@@ -6705,12 +6600,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                             },
                                                             "title": <span>
                                                               <ForwardRef(Link)
-                                                                className="pf-u-mr-sm"
-                                                                style={
-                                                                  Object {
-                                                                    "display": "block",
-                                                                  }
-                                                                }
+                                                                className="pf-u-mr-sm cve-synopsis"
                                                                 to="/cves/CVE-2020-0543"
                                                               >
                                                                 CVE-2020-0543

--- a/src/Components/SmartComponents/InsightsSystemRule/InsightsSystemRule.js
+++ b/src/Components/SmartComponents/InsightsSystemRule/InsightsSystemRule.js
@@ -14,7 +14,7 @@ export const InsightsSystemRule = ({ rule, cve }) => {
             { !rule ? <InsightsNoSystemRule cve={cve}/> :
                 <Fragment>
                     <TextContent>
-                        <Text component={TextVariants.h3} style={{ paddingLeft: 'var(--pf-global--spacer--lg)' }}>
+                        <Text component={TextVariants.h3} className="pf-u-pl-lg">
                             <Label isInline>
                                 <CSAwLabel className="pf-u-mr-sm"/>
                             </Label>

--- a/src/Components/SmartComponents/InsightsSystemRule/__snapshots__/InsightsSystemRule.test.js.snap
+++ b/src/Components/SmartComponents/InsightsSystemRule/__snapshots__/InsightsSystemRule.test.js.snap
@@ -117,21 +117,12 @@ It means:
       className="pf-c-content"
     >
       <Text
+        className="pf-u-pl-lg"
         component="h3"
-        style={
-          Object {
-            "paddingLeft": "var(--pf-global--spacer--lg)",
-          }
-        }
       >
         <h3
-          className=""
+          className="pf-u-pl-lg"
           data-pf-content={true}
-          style={
-            Object {
-              "paddingLeft": "var(--pf-global--spacer--lg)",
-            }
-          }
         >
           <Label
             isInline={true}

--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -78,7 +78,6 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                             <OutlinedQuestionCircleIcon
                                 className="pf-u-ml-xs"
                                 color="var(--pf-global--Color--200)"
-                                style={{ verticalAlign: '-0.125em' }}
                             />
                         </React.Fragment>
                     </Tooltip>

--- a/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
+++ b/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
@@ -1463,23 +1463,15 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                               >
                                                 <SplitItem>
                                                   <span
-                                                    style={
-                                                      Object {
-                                                        "fontSize": 14,
-                                                      }
-                                                    }
+                                                    className="cvss-input-label"
                                                   >
                                                     Min CVSS
                                                   </span>
                                                   <br />
                                                   <TextInput
+                                                    className="cvss-input"
                                                     id="cvss-min"
                                                     onChange={[Function]}
-                                                    style={
-                                                      Object {
-                                                        "width": "5em",
-                                                      }
-                                                    }
                                                     type="number"
                                                     validated="default"
                                                     value={0}
@@ -1495,23 +1487,15 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                                 </SplitItem>
                                                 <SplitItem>
                                                   <span
-                                                    style={
-                                                      Object {
-                                                        "fontSize": 14,
-                                                      }
-                                                    }
+                                                    className="cvss-input-label"
                                                   >
                                                     Max CVSS
                                                   </span>
                                                   <br />
                                                   <TextInput
+                                                    className="cvss-input"
                                                     id="cvss-max"
                                                     onChange={[Function]}
-                                                    style={
-                                                      Object {
-                                                        "width": "5em",
-                                                      }
-                                                    }
                                                     type="number"
                                                     validated="default"
                                                     value={10}

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -6903,11 +6903,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                             color="var(--pf-global--Color--200)"
                                                             noVerticalAlign={false}
                                                             size="sm"
-                                                            style={
-                                                              Object {
-                                                                "verticalAlign": "-0.125em",
-                                                              }
-                                                            }
                                                           />
                                                         }
                                                         zIndex={9999}
@@ -6920,11 +6915,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                             color="var(--pf-global--Color--200)"
                                                             noVerticalAlign={false}
                                                             size="sm"
-                                                            style={
-                                                              Object {
-                                                                "verticalAlign": "-0.125em",
-                                                              }
-                                                            }
                                                           >
                                                             <svg
                                                               aria-hidden={true}

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -37,8 +37,7 @@ export function createCveListByAccount(cveList) {
                                 <span key={row.id}>
                                     <Link
                                         to={'/cves/' + row.attributes.synopsis}
-                                        className="pf-u-mr-sm"
-                                        style={{ display: 'block' }}
+                                        className="pf-u-mr-sm cve-synopsis"
                                     >
                                         {row.attributes.synopsis}
                                     </Link>

--- a/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
+++ b/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
@@ -10,12 +10,7 @@ Object {
         Object {
           "title": <span>
             <Link
-              className="pf-u-mr-sm"
-              style={
-                Object {
-                  "display": "block",
-                }
-              }
+              className="pf-u-mr-sm cve-synopsis"
               to="/cves/CVE-2019-6454"
             >
               CVE-2019-6454
@@ -94,12 +89,7 @@ Object {
         Object {
           "title": <span>
             <Link
-              className="pf-u-mr-sm"
-              style={
-                Object {
-                  "display": "block",
-                }
-              }
+              className="pf-u-mr-sm cve-synopsis"
               to="/cves/CVE-2019-6116"
             >
               CVE-2019-6116
@@ -178,12 +168,7 @@ Object {
         Object {
           "title": <span>
             <Link
-              className="pf-u-mr-sm"
-              style={
-                Object {
-                  "display": "block",
-                }
-              }
+              className="pf-u-mr-sm cve-synopsis"
               to="/cves/CVE-2019-3815"
             >
               CVE-2019-3815

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -10,6 +10,7 @@ import messages from '../Messages';
 import { intl } from '../Utilities/IntlProvider';
 import { intlFormatWithBold } from '../Components/SmartComponents/Reports/ReportsHelper';
 import { Label as Pflabel } from '@patternfly/react-core';
+import './severityLabels.scss';
 
 export const DEFAULT_PAGE_SIZE = 20;
 export const RH_KB_URL = 'https://access.redhat.com/node';
@@ -346,34 +347,22 @@ export const RISK_OF_CHANGE_TOOLTIP = {
 
 export const RISK_OF_CHANGE_LABEL = {
     1: (
-        <Pflabel style={{
-            backgroundColor: 'var(--pf-global--palette--blue-50)',
-            color: 'var(--pf-global--palette--blue-600)'
-        }}>
+        <Pflabel className="impact-label-very-low">
             {intl.formatMessage(messages.impactListVeryLow)}
         </Pflabel>
     ),
     2: (
-        <Pflabel style={{
-            backgroundColor: '#fdf7e7',
-            color: 'var(--pf-global--palette--gold-700)'
-        }}>
+        <Pflabel className="impact-label-low">
             {intl.formatMessage(messages.impactListLow)}
         </Pflabel>
     ),
     3: (
-        <Pflabel style={{
-            backgroundColor: '#FFF5EC',
-            color: '#773D00'
-        }}>
+        <Pflabel className="impact-label-moderate">
             {intl.formatMessage(messages.impactListModerate)}
         </Pflabel>
     ),
     4: (
-        <Pflabel style={{
-            backgroundColor: '#FAEAE8',
-            color: 'var(--pf-global--palette--red-300)'
-        }}>
+        <Pflabel className="impact-label-high">
             {intl.formatMessage(messages.impactListHigh)}
         </Pflabel>
     )

--- a/src/Helpers/severityLabels.scss
+++ b/src/Helpers/severityLabels.scss
@@ -1,0 +1,31 @@
+.impact-label-very-low {
+    background-color: var(--pf-global--palette--blue-50);
+
+    span {
+        color: var(--pf-global--palette--blue-600);
+    }
+}
+
+.impact-label-low {
+    background-color: #fdf7e7;
+    
+    span {   
+        color: var(--pf-global--palette--gold-700);
+    }
+}
+
+.impact-label-moderate {
+    background-color: #FFF5EC;
+
+    span {
+        color: #773D00;
+    }
+}
+
+.impact-label-high {
+    background-color: #FAEAE8;
+
+    span {
+        color: var(--pf-global--palette--red-300) !important;
+    }
+}


### PR DESCRIPTION
Resolves [VULN-1682](https://issues.redhat.com/browse/VULN-1682).

- remove inline styles where it made sense
- removed implicit `valign: -0.125em` on icons

Aside from cleanup this also might also help QA by providing class names and ids for more elements.