### PR TITLE
fix: Fix CVSS filter misalignment in report modal

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -124,10 +124,6 @@
     width: 100px;
 }
 
-.cvss-input-label {
-    font-size: var(--pf-global--FontSize--sm);
-}
-
 .ins-inventory-list {
     .pf-c-table__action {
         min-width: 60px;

--- a/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/CvssCustomFilter.js
@@ -35,7 +35,9 @@ const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }
 
     const filterCvssContent = (<Split className="pf-u-m-md">
         <SplitItem>
-            <span className="cvss-input-label">{intl.formatMessage(messages.customReportCvssMinLabel)}</span><br />
+            <span style={{ fontSize: 'var(--pf-global--FontSize--sm)' }}>
+                {intl.formatMessage(messages.customReportCvssMinLabel)}
+            </span><br />
             <TextInput
                 type="number"
                 onChange={(value) => handleCvssInputChange(value, 'from')}
@@ -49,7 +51,9 @@ const CvssCustomFilter = ({ filterData, setFilterData, selectProps, filterName }
             <br /><span className="pf-u-m-sm">-</span>
         </SplitItem>
         <SplitItem>
-            <span className="cvss-input-label">{intl.formatMessage(messages.customReportCvssMaxLabel)}</span><br />
+            <span style={{ fontSize: 'var(--pf-global--FontSize--sm)' }}>
+                {intl.formatMessage(messages.customReportCvssMaxLabel)}
+            </span><br />
             <TextInput
                 type="number"
                 onChange={(value) => handleCvssInputChange(value, 'to')}

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/CvssBaseScoreFilter.js
@@ -1,7 +1,7 @@
 import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
-import CheckboxCustomFilter from '../CustomFilters/CvssCustomFilter';
+import CvssCustomFilter from '../CustomFilters/CvssCustomFilter';
 import React from 'react';
 import debounce from 'lodash/debounce';
 
@@ -29,7 +29,7 @@ const CvssBaseScoreFilter = (apply, currentFilter = {}) => {
         type: conditionalFilterType.custom,
         urlParam: 'cvss_filter',
         filterValues: {
-            children: (<CheckboxCustomFilter
+            children: (<CvssCustomFilter
                 key={'cvss_filter'}
                 filterId={'cvss_filter'}
                 filterData={{ cvss_filter: searchValue }}

--- a/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
+++ b/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
@@ -1465,7 +1465,11 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                               >
                                                 <SplitItem>
                                                   <span
-                                                    className="cvss-input-label"
+                                                    style={
+                                                      Object {
+                                                        "fontSize": "var(--pf-global--FontSize--sm)",
+                                                      }
+                                                    }
                                                   >
                                                     Min CVSS
                                                   </span>
@@ -1489,7 +1493,11 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                                 </SplitItem>
                                                 <SplitItem>
                                                   <span
-                                                    className="cvss-input-label"
+                                                    style={
+                                                      Object {
+                                                        "fontSize": "var(--pf-global--FontSize--sm)",
+                                                      }
+                                                    }
                                                   >
                                                     Max CVSS
                                                   </span>


### PR DESCRIPTION
Had to move the external style to inline, because modal is mounted outside vuln app viewport and since chrome 2 update you cannot style outside of app viewport.

## Old
![cvssOld](https://user-images.githubusercontent.com/8426204/123626799-83ab0900-d811-11eb-9d2f-2ac8af6ba775.png)

## New
![cvssNew](https://user-images.githubusercontent.com/8426204/123626802-84dc3600-d811-11eb-8707-e87181c73c65.png)
