### PR TITLE
fix: Minor modal and popover tweaks

### DIFF
--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/SnippetWithHeaderAndPopover.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/SnippetWithHeaderAndPopover.js
@@ -7,7 +7,7 @@ const SnippetWithHeaderAndPopover = props => {
     const { title, value, content } = props;
 
     return (
-        <Popover id="popover" bodyContent={content} headerContent={''} aria-label="Business risk popover" position="right"
+        <Popover id="popover" bodyContent={content} headerContent={''} position="bottom"
             appendTo={document.querySelector('.vulnerability')}>
             <Stack className="popover-content">
                 <StackItem>

--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/SnippetWithHeaderAndPopover.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/SnippetWithHeaderAndPopover.test.js.snap
@@ -8,10 +8,9 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label and Tool
 >
   <Popover
     appendTo={null}
-    aria-label="Business risk popover"
     headerContent=""
     id="popover"
-    position="right"
+    position="bottom"
   >
     <Popper
       appendTo={null}
@@ -33,12 +32,12 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label and Tool
       onDocumentKeyDown={[Function]}
       onTriggerClick={[Function]}
       onTriggerEnter={[Function]}
-      placement="right"
+      placement="bottom"
       popper={
         <FocusTrap
           active={false}
           aria-describedby="popover-popover-body"
-          aria-label="Business risk popover"
+          aria-label=""
           aria-modal="true"
           className="pf-c-popover"
           focusTrapOptions={
@@ -157,10 +156,9 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label only 1`]
 >
   <Popover
     appendTo={null}
-    aria-label="Business risk popover"
     headerContent=""
     id="popover"
-    position="right"
+    position="bottom"
   >
     <Popper
       appendTo={null}
@@ -182,12 +180,12 @@ exports[`SnippetWithHeaderAndPopover Should render with title and label only 1`]
       onDocumentKeyDown={[Function]}
       onTriggerClick={[Function]}
       onTriggerEnter={[Function]}
-      placement="right"
+      placement="bottom"
       popper={
         <FocusTrap
           active={false}
           aria-describedby="popover-popover-body"
-          aria-label="Business risk popover"
+          aria-label=""
           aria-modal="true"
           className="pf-c-popover"
           focusTrapOptions={
@@ -303,10 +301,9 @@ exports[`SnippetWithHeaderAndPopover Should render without params 1`] = `
 <SnippetWithHeaderAndPopover>
   <Popover
     appendTo={null}
-    aria-label="Business risk popover"
     headerContent=""
     id="popover"
-    position="right"
+    position="bottom"
   >
     <Popper
       appendTo={null}
@@ -328,12 +325,12 @@ exports[`SnippetWithHeaderAndPopover Should render without params 1`] = `
       onDocumentKeyDown={[Function]}
       onTriggerClick={[Function]}
       onTriggerEnter={[Function]}
-      placement="right"
+      placement="bottom"
       popper={
         <FocusTrap
           active={false}
           aria-describedby="popover-popover-body"
-          aria-label="Business risk popover"
+          aria-label=""
           aria-modal="true"
           className="pf-c-popover"
           focusTrapOptions={

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
@@ -134,7 +134,6 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                     >
                       <Popover
                         appendTo={null}
-                        aria-label="Business risk popover"
                         bodyContent={
                           <Stack
                             className="pf-u-p-xs"
@@ -153,7 +152,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                         }
                         headerContent=""
                         id="popover"
-                        position="right"
+                        position="bottom"
                       >
                         <Popper
                           appendTo={null}
@@ -175,12 +174,12 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           onDocumentKeyDown={[Function]}
                           onTriggerClick={[Function]}
                           onTriggerEnter={[Function]}
-                          placement="right"
+                          placement="bottom"
                           popper={
                             <FocusTrap
                               active={false}
                               aria-describedby="popover-popover-body"
-                              aria-label="Business risk popover"
+                              aria-label=""
                               aria-modal="true"
                               className="pf-c-popover"
                               focusTrapOptions={
@@ -401,7 +400,6 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                     >
                       <Popover
                         appendTo={null}
-                        aria-label="Business risk popover"
                         bodyContent={
                           <Stack
                             className="pf-u-p-xs"
@@ -476,7 +474,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                         }
                         headerContent=""
                         id="popover"
-                        position="right"
+                        position="bottom"
                       >
                         <Popper
                           appendTo={null}
@@ -498,12 +496,12 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           onDocumentKeyDown={[Function]}
                           onTriggerClick={[Function]}
                           onTriggerEnter={[Function]}
-                          placement="right"
+                          placement="bottom"
                           popper={
                             <FocusTrap
                               active={false}
                               aria-describedby="popover-popover-body"
-                              aria-label="Business risk popover"
+                              aria-label=""
                               aria-modal="true"
                               className="pf-c-popover"
                               focusTrapOptions={

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
@@ -369,7 +369,6 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -388,7 +387,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -410,12 +409,12 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -574,7 +573,6 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -597,7 +595,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -619,12 +617,12 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -1269,7 +1267,6 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -1288,7 +1285,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -1310,12 +1307,12 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -1474,7 +1471,6 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -1497,7 +1493,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -1519,12 +1515,12 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -2190,7 +2186,6 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -2209,7 +2204,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -2231,12 +2226,12 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -2395,7 +2390,6 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -2418,7 +2412,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -2440,12 +2434,12 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -3076,7 +3070,6 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -3095,7 +3088,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -3117,12 +3110,12 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={
@@ -3281,7 +3274,6 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                     >
                                       <Popover
                                         appendTo={null}
-                                        aria-label="Business risk popover"
                                         bodyContent={
                                           <Stack
                                             className="pf-u-p-xs"
@@ -3304,7 +3296,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                         }
                                         headerContent=""
                                         id="popover"
-                                        position="right"
+                                        position="bottom"
                                       >
                                         <Popper
                                           appendTo={null}
@@ -3326,12 +3318,12 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           onDocumentKeyDown={[Function]}
                                           onTriggerClick={[Function]}
                                           onTriggerEnter={[Function]}
-                                          placement="right"
+                                          placement="bottom"
                                           popper={
                                             <FocusTrap
                                               active={false}
                                               aria-describedby="popover-popover-body"
-                                              aria-label="Business risk popover"
+                                              aria-label=""
                                               aria-modal="true"
                                               className="pf-c-popover"
                                               focusTrapOptions={

--- a/src/Components/SmartComponents/Modals/BaseModal.js
+++ b/src/Components/SmartComponents/Modals/BaseModal.js
@@ -37,6 +37,7 @@ export function useJustificationInput(initialValue) {
                 value={justification}
                 resizeOrientation="vertical"
                 aria-label={'justification note'}
+                style={{ minHeight: '2.25rem' }}
                 {...props}
             />
         </FormGroup>

--- a/src/Components/SmartComponents/Modals/BusinessRiskModal.js
+++ b/src/Components/SmartComponents/Modals/BusinessRiskModal.js
@@ -86,6 +86,7 @@ export const BusinessRiskModal = ({ cves, updateRef, intl }) => {
                                 value={label}
                                 resizeOrientation="vertical"
                                 aria-label={'justification'}
+                                style={{ minHeight: '2.25rem' }}
                             />
                         </FormGroup>
                     </Form>


### PR DESCRIPTION
1. Delete `aria-label="Business risk popover"` from popover because it is used for both status and BR, it still has `id="popover"` so it is still targetable by QA.
2. Make both popovers go bottom, one of them would go right (obstruction the other one); now they both go bottom, so they don't obstruct themselves and the direction is consistent.

## Old:
![popoverOld](https://user-images.githubusercontent.com/8426204/123635107-8f9bc880-d81b-11eb-9398-d264b8cb2ef4.png)

## New:
![popoverNew](https://user-images.githubusercontent.com/8426204/123635293-cd98ec80-d81b-11eb-8b82-64d12f573488.png)

3. Add minimum height to modal's textareas (they are vertically resizable), so at least one line can fit

## Old:
![textareaold](https://user-images.githubusercontent.com/8426204/123634586-e94fc300-d81a-11eb-8ba8-14e743dc56ab.png)

## New:
![textareanew](https://user-images.githubusercontent.com/8426204/123634588-ea80f000-d81a-11eb-8c52-9aa5056ce07b.png)
