### PR TITLE
chore: Use cloud.redhat.com paths

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,6 +10,7 @@ const insightsProxy = {
 const webpackProxy = {
     deployment: process.env.BETA ? 'beta/apps' : 'apps',
     useProxy: true,
+    useCloud: true,
     appUrl: process.env.BETA ? ['/beta/insights/vulnerability'] : ['/insights/vulnerability']
 };
 


### PR DESCRIPTION
Until the platform will switch to `console.redhat.com` with the flag `useCloud` we can still use the old paths from `cloud.redhat.com` 