### PR TITLE
chore: Downgrade config in order to work with prod.foo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3258,66 +3258,45 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.2.6.tgz",
-      "integrity": "sha512-JpLDbyWcc0zZP3UWrvJe4q4jIK+N/crINSlQJe/q0xXWVNZRinT88EC89KKSH+VfgPjhZ83VOvnYOgyXcnYZ6g==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.1.9.tgz",
+      "integrity": "sha512-cVdf4o6A4flo/IE4YiguXDmm/bTz+ET5QvSVn2ToVTIOGyl1XEi82AmsW+IBQBfloJj7tU5NIecQXSsKjepl4A==",
       "dev": true,
       "requires": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "1.3.1",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.0.0",
         "assert": "^2.0.0",
         "babel-loader": "^8.2.2",
         "browserify-zlib": "^0.2.0",
-        "buffer": "^6.0.3",
+        "buffer": "^6.0.2",
         "clean-webpack-plugin": "^3.0.0",
-        "css-loader": "^5.2.6",
+        "css-loader": "^5.0.1",
         "file-loader": "^6.2.0",
         "git-revision-webpack-plugin": "^3.0.6",
-        "glob": "^7.0.0",
         "html-replace-webpack-plugin": "^2.6.0",
-        "html-webpack-plugin": "^5.3.1",
-        "js-yaml": "^4.0.0",
+        "html-webpack-plugin": "^5.1.0",
         "jws": "^4.0.0",
         "mini-css-extract-plugin": "^1.6.0",
+        "nodesi": "^1.16.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
-        "sass": "^1.34.1",
+        "sass": "^1.32.13",
         "sass-loader": "^11.1.1",
         "source-map-loader": "^3.0.0",
         "stream-browserify": "^3.0.0",
         "ts-loader": "^8.0.11",
         "url": "^0.11.0",
-        "util": "^0.12.4",
-        "webpack": "^5.38.1",
-        "webpack-cli": "^4.7.2",
-        "webpack-dev-server": "^3.11.2",
+        "util": "^0.12.3",
+        "webpack": "^5.6.0",
+        "webpack-cli": "^4.2.0",
+        "webpack-dev-server": "^3.11.0",
         "write-file-webpack-plugin": "^4.5.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.3.1.tgz",
-      "integrity": "sha512-eeIBS6tk1Cjfd3T8evSjZui0EWmqb7hbVOZy940rEvEsKBZ9i1l2gOqUYi75CWCW6ni+SNh93xK/l1PgRghM7Q==",
-      "dev": true,
-      "requires": {
-        "nodesi": "^1.17.0"
-      }
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.3.4.tgz",
+      "integrity": "sha512-2B4wG9Xfm8TM0Y6N3i8o7wr+viJvQ6Mk7DDl6unTu2wB1eh3jp5GHhLlDEkiHxn0xvCWQ3Mx/b2c23gd3pAQxA==",
+      "dev": true
     },
     "@redhat-cloud-services/frontend-components-inventory-insights": {
       "version": "3.2.1",
@@ -4147,9 +4126,9 @@
       "dev": true
     },
     "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==",
       "dev": true,
       "requires": {
         "@types/minimatch": "*",
@@ -4175,9 +4154,9 @@
       }
     },
     "@types/html-minifier-terser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
-      "integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
+      "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -4231,9 +4210,9 @@
       }
     },
     "@types/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "dev": true
     },
     "@types/minimist": {
@@ -5796,16 +5775,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "blob": {
       "version": "0.0.4",
@@ -9067,13 +9036,6 @@
           "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -14799,13 +14761,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
     },
     "nanoid": {
       "version": "3.1.23",
@@ -20968,9 +20923,9 @@
       }
     },
     "sass": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.1.tgz",
-      "integrity": "sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.2.tgz",
+      "integrity": "sha512-jhO5KAR+AMxCEwIH3v+4zbB2WB0z67V1X0jbapfVwQQdjHZUGUyukpnoM6+iCMfsIUC016w9OPKQ5jrNOS9uXw==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -24618,11 +24573,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@babel/preset-flow": "^7.12.1",
     "@babel/preset-react": "^7.12.13",
     "@formatjs/cli": "^4.2.21",
-    "@redhat-cloud-services/frontend-components-config": "^4.2.6",
+    "@redhat-cloud-services/frontend-components-config": "^4.1.9",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-image": "^2.0.6",
     "@rollup/plugin-json": "^4.0.3",


### PR DESCRIPTION
pre-prod is being down almost a day now but with the new configuration (console.redhat.com) we cannot run prod.foo locally.  Thus I had to downgrade the configuration package.  In order to run prod.foo locally you need to run

1. `npm run start`
2.   `SPANDX_CONFIG=/home/HOME...`

** `npm run start:proxy` is not working