### PR TITLE
VULN-1793 fix(CVEsstore): Store previously loaded rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1364,13 +1364,13 @@
       }
     },
     "@formatjs/cli": {
-      "version": "4.2.27",
-      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-4.2.27.tgz",
-      "integrity": "sha512-P+y3nIBa+IMfv8dKPdZ38xhF/l9AghsU8kKi2onUJLpvjjDdjTEUTleaPpVghZKhe6BqNbso+anludxlZUdKoA==",
+      "version": "4.2.29",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-4.2.29.tgz",
+      "integrity": "sha512-uU3joDk6qcNkbk6kink8HBREkGHgqyKV6cGOK+NUq4z/3AIDr9l7eJCIm87tTsNjLJ6iKP3p80W8lk0IoElbcQ==",
       "dev": true,
       "requires": {
-        "@formatjs/icu-messageformat-parser": "2.0.7",
-        "@formatjs/ts-transformer": "3.4.5",
+        "@formatjs/icu-messageformat-parser": "2.0.8",
+        "@formatjs/ts-transformer": "3.4.6",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.150",
         "@types/node": "14",
@@ -1378,7 +1378,7 @@
         "@vue/compiler-sfc": "^3.0.5",
         "chalk": "^4.0.0",
         "commander": "8",
-        "fast-glob": "^3.2.4",
+        "fast-glob": "^3.2.7",
         "fs-extra": "^9.0.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.15",
@@ -1439,10 +1439,11 @@
       }
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.4.tgz",
-      "integrity": "sha512-ePJXI7tWC9PBxQxS7jtbkCLGVmpC8MH8n9Yjmg8dsh9wXK9svu7nAbq76Oiu5Zb+5GVkLkeTVerlSvHCbNImlA==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.5.tgz",
+      "integrity": "sha512-cGpEBzrf9bL2lTMEuRZ3gjLrEUEucxAXDIdX4tNqNdNZO81ZN558BfjiFfyPgrhILEuJU/+sgLwWxddSn6usHw==",
       "requires": {
+        "@formatjs/intl-localematcher": "0.2.18",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1459,12 +1460,12 @@
       "integrity": "sha512-mIqBr5uigIlx13eZTOPSEh2buDiy3BCdMYUtewICREQjbb4xarDiVWoXSnrERM7NanZ+0TAHNXSqDe6HpEFQUg=="
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.7.tgz",
-      "integrity": "sha512-gduYfh/YdBTmb1XzLueNaofiGZVMrkaDg0RSa0GNztKWs4QXIRS+28cjcuWNpV0q5S8aiLMkP7SHQpZKnPCHLw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.8.tgz",
+      "integrity": "sha512-fZlQ7ls3eQswO4RFB0lSi+ritPvud0Z2EQB6SU8qI5+MIS4qU4AHjq/dFJNvhdEdmJqLWHe31K4yHaRdavkSQQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
-        "@formatjs/icu-skeleton-parser": "1.2.8",
+        "@formatjs/ecma402-abstract": "1.9.5",
+        "@formatjs/icu-skeleton-parser": "1.2.9",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1476,11 +1477,11 @@
       }
     },
     "@formatjs/icu-skeleton-parser": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.2.8.tgz",
-      "integrity": "sha512-KLSSAA7Q2Uv7msij8saaOE5rpsHK/2WkfS3737JnDyVTFOYe8l2OarIBUoTC5gi1BnCgiN/1icZlqXwyUX6obA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.2.9.tgz",
+      "integrity": "sha512-cx8Ug1gxRtv0rRddWd6dt5Sn/BhnhktSHvokbmLUVOEp2dy/6Ehvv2e00wow28AaSIzvBvM6ew1Qwe9wzDzcOw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
+        "@formatjs/ecma402-abstract": "1.9.5",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1492,16 +1493,16 @@
       }
     },
     "@formatjs/intl": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.13.2.tgz",
-      "integrity": "sha512-aonTXXaI/Guqr4t87m/XWfmgE9aPefDTLRnCwadxBDkUHw1/HQeUV+lp/3BgiPZfemIdBq9UgdigDCwrpEwrTA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.13.4.tgz",
+      "integrity": "sha512-Hk3jPFsi2g75Yc0bdEsQTgk8TM9CrCBfBwHbngfsNYX0P0QHq00vxIK0kXB/QyOP4SL3hVENA30yRb6cbNp6ww==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
+        "@formatjs/ecma402-abstract": "1.9.5",
         "@formatjs/fast-memoize": "1.1.1",
-        "@formatjs/icu-messageformat-parser": "2.0.7",
-        "@formatjs/intl-displaynames": "5.1.6",
-        "@formatjs/intl-listformat": "6.2.6",
-        "intl-messageformat": "9.7.1",
+        "@formatjs/icu-messageformat-parser": "2.0.8",
+        "@formatjs/intl-displaynames": "5.2.0",
+        "@formatjs/intl-listformat": "6.3.0",
+        "intl-messageformat": "9.8.1",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1513,11 +1514,12 @@
       }
     },
     "@formatjs/intl-displaynames": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.1.6.tgz",
-      "integrity": "sha512-s0eDyQFM2gQIPgn+MyaH+UcCvp6ui2ft9UW1gsIkjBkaprRlzKMd3fjxcUFO/I7oyXXA6FYR4qHR8u1I0+PvXA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.2.0.tgz",
+      "integrity": "sha512-Vox3IbI2I1aG2agCQUKdmtB8aM9C7iaGui2S2Apo50MVC7sJuFz7sXq5vuqp8erCAalhuCfRMQREQ3jw/rwW6w==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
+        "@formatjs/ecma402-abstract": "1.9.5",
+        "@formatjs/intl-localematcher": "0.2.18",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1529,11 +1531,27 @@
       }
     },
     "@formatjs/intl-listformat": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.2.6.tgz",
-      "integrity": "sha512-6FMdQY1+QKqJW5IhsVPFuEaR/uRiBKP+Y1oDvamZKzDfJ2vQmk9jqSF51VztlZH8XSfdO0IgvBzeRPHahKChQA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.3.0.tgz",
+      "integrity": "sha512-xfNODLDWAV2pAZIK3a/HedvNmvg7GJxFVyOSbYMJP3uTrgjxIUZXeUIu5A5aHe8hn6Tv/GdT9QltDol/YlXmcg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
+        "@formatjs/ecma402-abstract": "1.9.5",
+        "@formatjs/intl-localematcher": "0.2.18",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.18.tgz",
+      "integrity": "sha512-xI9X+mi7wbucbh35GNTY+C0+oMJXAp8ueC73SOyJlBpRNjLuOlSwgw3yJaCZxy3WpjcRBCP0laJ5zlpITO0QpA==",
+      "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -1545,12 +1563,12 @@
       }
     },
     "@formatjs/ts-transformer": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.4.5.tgz",
-      "integrity": "sha512-VzjT9jbpizZhwvtX/jaoTOeHQ/nvEx9ttzDrRXcFIGXyxupBZKTxr/+v6j3NjUmeiuN3JfaXhZUYmG+zsS0kxw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.4.6.tgz",
+      "integrity": "sha512-lk44kgdPSC2CW4/NtokdR8KZIrmXJlJfy+u0vAof7214b3IyHTN0usqifAF0w97XAriWKNdZPT5tVPMrjdERAg==",
       "dev": true,
       "requires": {
-        "@formatjs/icu-messageformat-parser": "2.0.7",
+        "@formatjs/icu-messageformat-parser": "2.0.8",
         "chalk": "^4.1.1",
         "tslib": "^2.1.0"
       },
@@ -2997,9 +3015,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.0.0.tgz",
-      "integrity": "sha512-GSpv5VUFqarOXZl6uWPsDnjChkKCxnaMALmQhzvCWGiMxONQxX7ZwlomCMS+wB1KqxLPCA5n6gYt016oEMkHmQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
+      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
@@ -3018,12 +3036,12 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.2.tgz",
-      "integrity": "sha512-imNDDvUMy9YzECcP6zTcKNjwutSwqCYGMZjLPnBHF0kdb3V9URrHWmalD0ZvNEYjwbpm2zw8RPewj3ebCpMBRw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.5.1.tgz",
+      "integrity": "sha512-Al57+OZmO65JpiPk4JS6u6kQ2y9qjoZtY1IWiSshc4N+F7EcrK8Rgy/cUJBB4WIcSFUQyF66EJQK1oKgXWeRNw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.19.1",
+        "@octokit/types": "^6.21.1",
         "deprecation": "^2.3.1"
       }
     },
@@ -3053,24 +3071,24 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.6.8",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.8.tgz",
-      "integrity": "sha512-n2aT0mJL9N/idCPmnBynCino1qNScfRHvr8OeskQdBNhUYAMc7cxoc8KLlv1DMWxlZUNhed+5kVdu7majVdVag==",
+      "version": "18.7.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.7.1.tgz",
+      "integrity": "sha512-790Yv8Xpbqs3BtnMAO5hlOftVICHPdgZ/3qlTmeOoqrQGzT25BIpHkg/KKMeKG9Fg8d598PLxGhf80RswElv9g==",
       "dev": true,
       "requires": {
         "@octokit/core": "^3.5.0",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.4.2"
+        "@octokit/plugin-rest-endpoint-methods": "5.5.1"
       }
     },
     "@octokit/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-hMI2EokQzMG8ABWcnvcrabqQFuFHqUdN0HUOG4DPTaOtnf/jqhzhK1SHOGu5vDlI/x+hWJ60e28VxB7QhOP0CQ==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.21.1.tgz",
+      "integrity": "sha512-PP+m3T5EWZKawru4zi/FvX8KL2vkO5f1fLthx78/7743p7RtJUevt3z7698k+7oAYRA7YuVqfXthSEHqkDvZ8g==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^9.0.0"
+        "@octokit/openapi-types": "^9.1.1"
       }
     },
     "@patternfly/react-charts": {
@@ -3149,12 +3167,12 @@
       "dev": true
     },
     "@react-pdf/font": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-2.0.10.tgz",
-      "integrity": "sha512-viblR5tbZrZ5a3lOK5N7TSN7Qy6mhTrfypiL9NffF2Yi1vCFg7NyrpYXf6n/IKNZzwEa5ScpBnWSU/k5l3r2vQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-2.0.11.tgz",
+      "integrity": "sha512-QM0sjMJRrhuzl166sxkFWNttAQmAjDA+ossk+0RFuJUargoa8GjqznXb+yH2M6lm/A8MNS4JWNHUlwFjvC3g2g==",
       "requires": {
         "@react-pdf/fontkit": "^2.0.6",
-        "@react-pdf/types": "^2.0.3",
+        "@react-pdf/types": "^2.0.4",
         "cross-fetch": "^3.0.4",
         "is-url": "^1.2.4"
       }
@@ -3184,17 +3202,17 @@
       }
     },
     "@react-pdf/layout": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-2.0.16.tgz",
-      "integrity": "sha512-MTFLmnVF8we2UP1rNHW2gtxBOA/CAzJ+YOQx9FBwGR2r0hMG3pcduoAZdEcpeCHc0KuYcGTjB3vuML+LZT1VjQ==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-2.0.17.tgz",
+      "integrity": "sha512-JnV5Rv45Um00KFg75Io0mFFA8G7786B59OTkC+ALRtYLFW6EzOM4JB9jb7coLpmBsqGNc6ZteJrd39PHVgTHmw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-pdf/image": "^2.0.3",
         "@react-pdf/pdfkit": "^2.0.11",
         "@react-pdf/primitives": "^2.0.0",
-        "@react-pdf/stylesheet": "^2.0.8",
+        "@react-pdf/stylesheet": "^2.0.9",
         "@react-pdf/textkit": "^2.0.5",
-        "@react-pdf/types": "^2.0.3",
+        "@react-pdf/types": "^2.0.4",
         "@react-pdf/yoga": "^2.0.2",
         "cross-fetch": "^3.0.4",
         "emoji-regex": "^8.0.0",
@@ -3223,13 +3241,13 @@
       "integrity": "sha512-Yh8TEjzyObnalM271znZVJsy6BiY+s6uTOCjLJL8jSvU1rGA1p45VjK7AnNpgH+n+JzpddXQweT2oE2HWGuYFA=="
     },
     "@react-pdf/render": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-2.0.10.tgz",
-      "integrity": "sha512-nAKJDkRlvI0Jvo7sJWBxtb4EGG4GpyZKXAA0XlJQ4dGktZBRcJn5lquBdM3yHWbipLUACRT7rvnufae7alg8fw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-2.0.11.tgz",
+      "integrity": "sha512-1fYWFGkFhGj7x7+gJik69r1BqmJUr3O+5BDRJyp4tbzJL2uJ3iiE3At4jL1bWhcxVHkGJ4/myVd6s0DAp7K9Ug==",
       "requires": {
         "@react-pdf/primitives": "^2.0.0",
         "@react-pdf/textkit": "^2.0.5",
-        "@react-pdf/types": "^2.0.3",
+        "@react-pdf/types": "^2.0.4",
         "abs-svg-path": "^0.1.1",
         "color-string": "^1.5.3",
         "normalize-svg-path": "^1.1.0",
@@ -3239,17 +3257,17 @@
       }
     },
     "@react-pdf/renderer": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-2.0.16.tgz",
-      "integrity": "sha512-ScdxHMxBONZb92uAEFwTtyPX5FIrpn7XHFyG8ePrQXDIin5fQPJWltnM/oFwbA3V+pL+16Zc0ATy2ngVpJI5mg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-2.0.17.tgz",
+      "integrity": "sha512-4p/S1UtGN/Wx8WtDpk4BCex+JWPNEOvUV6GoLNiuJr9w8QHFPWRT9OnMLnZsN2z8CjCqNHpTIn9fUV6HyYiIfA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@react-pdf/font": "^2.0.10",
-        "@react-pdf/layout": "^2.0.16",
+        "@react-pdf/font": "^2.0.11",
+        "@react-pdf/layout": "^2.0.17",
         "@react-pdf/pdfkit": "^2.0.11",
         "@react-pdf/primitives": "^2.0.0",
-        "@react-pdf/render": "^2.0.10",
-        "@react-pdf/types": "^2.0.3",
+        "@react-pdf/render": "^2.0.11",
+        "@react-pdf/types": "^2.0.4",
         "blob-stream": "^0.1.3",
         "queue": "^6.0.1",
         "ramda": "^0.26.1",
@@ -3258,11 +3276,11 @@
       }
     },
     "@react-pdf/stylesheet": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-2.0.8.tgz",
-      "integrity": "sha512-4h2BbZv9dSqiZBlI3FySvjUAXFwydXLB+1MycvdNHI+6FUKtMN6FEaOhb6DpuqRl268D/yhKtENckdzIw5xhoQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-2.0.9.tgz",
+      "integrity": "sha512-DVCpM+m2+PKT9rdAWuvIOt8BXI+EAsD+dg1PwgyqXBbEwG/kz+U12bWrFixf7EvdhHn43bxprCmzHO99DuZpJA==",
       "requires": {
-        "@react-pdf/types": "^2.0.3",
+        "@react-pdf/types": "^2.0.4",
         "color-string": "^1.5.3",
         "hsl-to-hex": "^1.0.0",
         "media-engine": "^1.0.3",
@@ -3281,9 +3299,9 @@
       }
     },
     "@react-pdf/types": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.0.3.tgz",
-      "integrity": "sha512-yrcq/hkDU7+hcZKf3+NN4sa3gYcOfdPBaJPsaCq7aNI/Wk4FNG+R5qimo5PSiOiaowkkXFZtFadVq0RlbrWXeg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.0.4.tgz",
+      "integrity": "sha512-6UJGPg6dhrhwz2I5UWPiDAahPoOWdAotyheHRL3PjqemjR+JD2ReSjTrLXczC0SufTMKV4NW9ZtFbru0hSCVDA=="
     },
     "@react-pdf/unicode-properties": {
       "version": "2.4.1",
@@ -3313,9 +3331,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.2.7.tgz",
-      "integrity": "sha512-Sni/S40JrXUAYfuc/Lgaaefd7urAFjYBjwZhShuGBpUBclQnhLb7u8eyQQrM144iYXg6tSF2IzrVd2KnWDwGyA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.3.1.tgz",
+      "integrity": "sha512-eDdpy+TliT7zPKA+7KaC2GnaxZ0Enc+cFYmhM0cHujV9neRMkhXC/kJ+4ta77Upr/AwNvz/ZoYcrO9n9HZzOPA==",
       "dev": true,
       "requires": {
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.3.2",
@@ -3330,6 +3348,7 @@
         "glob": "^7.0.0",
         "html-replace-webpack-plugin": "^2.6.0",
         "html-webpack-plugin": "^5.3.1",
+        "https-proxy-agent": "^5.0.0",
         "js-yaml": "^4.0.0",
         "jws": "^4.0.0",
         "mini-css-extract-plugin": "^1.6.0",
@@ -3349,9 +3368,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.3.4.tgz",
-      "integrity": "sha512-2B4wG9Xfm8TM0Y6N3i8o7wr+viJvQ6Mk7DDl6unTu2wB1eh3jp5GHhLlDEkiHxn0xvCWQ3Mx/b2c23gd3pAQxA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.4.3.tgz",
+      "integrity": "sha512-zv5szaKloiSZxATbpGPYL+t/NUB/uywf3PPE1FvKZgnHGfFzfI9KYb7OqXA1vaO5fcJsduVNNXEmmhtsyF2bdw==",
       "dev": true
     },
     "@redhat-cloud-services/frontend-components-inventory-insights": {
@@ -3690,9 +3709,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.2.tgz",
-      "integrity": "sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -4279,9 +4298,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-      "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
+      "version": "14.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+      "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4314,9 +4333,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
-      "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.15.tgz",
+      "integrity": "sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6108,9 +6127,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001246",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
-      "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==",
+      "version": "1.0.30001247",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+      "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==",
       "dev": true
     },
     "capture-exit": {
@@ -6855,9 +6874,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -7883,9 +7902,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.782",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.782.tgz",
-      "integrity": "sha512-6AI2se1NqWA1SBf/tlD6tQD/6ZOt+yAhqmrTlh4XZw4/g0Mt3p6JhTQPZxRPxPZiOg0o7ss1EBP/CpYejfnoIA==",
+      "version": "1.3.786",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+      "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw==",
       "dev": true
     },
     "emittery": {
@@ -10361,12 +10380,12 @@
       "dev": true
     },
     "intl-messageformat": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.7.1.tgz",
-      "integrity": "sha512-DNiuD+/59G9qaYu3U0KgwCV0zpN9XRoUvc8izSNCNAA5MknhiIUONFE0WtScP+E/7JfoENu+CX57P/SURRbI0A==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.8.1.tgz",
+      "integrity": "sha512-2rSZQu8GmLOlxNiehRvxWjkIqzemW833zm8ZS63JNvSpSuGnpqSWRqqwqv1kEBto/97/UBjtWy14m/CIdwVqFg==",
       "requires": {
         "@formatjs/fast-memoize": "1.1.1",
-        "@formatjs/icu-messageformat-parser": "2.0.7",
+        "@formatjs/icu-messageformat-parser": "2.0.8",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -10783,9 +10802,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-string": {
@@ -14917,9 +14936,9 @@
       "dev": true
     },
     "npm": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.20.0.tgz",
-      "integrity": "sha512-59Eje4RcXP9EKYPIJvBvQGTyfEvZWaKdOx5+YZ+IJ+fqYhJJH5ng78qcdD8sFPyA1g1MFBR0DYXKfncwbxXpVA==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.20.1.tgz",
+      "integrity": "sha512-Fau808Ybtzja6SdOglKyUfEX1vC57Gq9zR20IfK2z+iwaLmYOHvHqf3zQoeXzNLDzT5bf+CnKns3EhHLFLguew==",
       "dev": true,
       "requires": {
         "@npmcli/arborist": "^2.7.1",
@@ -14971,14 +14990,14 @@
         "npm-profile": "^5.0.3",
         "npm-registry-fetch": "^11.0.0",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
+        "npmlog": "^5.0.0",
         "opener": "^1.5.2",
         "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
         "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
+        "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
@@ -15457,6 +15476,11 @@
           "bundled": true,
           "dev": true
         },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
@@ -15509,7 +15533,7 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15642,43 +15666,18 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
+            "has-unicode": "^2.0.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "string-width": "^1.0.1 || ^2.0.0",
+            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "wide-align": "^1.1.2"
           }
         },
         "getpass": {
@@ -15874,7 +15873,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -16259,6 +16258,57 @@
             "semver": "^7.3.2",
             "tar": "^6.0.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
           }
         },
         "nopt": {
@@ -16368,14 +16418,14 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^1.1.5",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -16552,7 +16602,7 @@
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17731,9 +17781,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -18441,9 +18491,9 @@
       }
     },
     "postcss-modules": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.2.0.tgz",
-      "integrity": "sha512-zyqjOVr7hqIXgi4ADbSd2Tjaq90mDj+H6EWySE1KQFlRwBGKcvCJnD5Yf7Y4XU6HzN9SyXb+TxVGQbLdRwE78w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.2.2.tgz",
+      "integrity": "sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==",
       "dev": true,
       "requires": {
         "generic-names": "^2.0.1",
@@ -19673,18 +19723,18 @@
       }
     },
     "react-intl": {
-      "version": "5.20.4",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.20.4.tgz",
-      "integrity": "sha512-lYUL8hWkRHbpVtedGSjpQ1kK/x2AAGZHGgOHsU0SFDufHo2aS7xdvRcaxXD3PMVDuh53KcU+vTaun+bcrwKpbA==",
+      "version": "5.20.6",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.20.6.tgz",
+      "integrity": "sha512-+G5HIb0GCBgIMd/OWISCnUCbRE6fHOkNJxaefbrjvXwCXZLLpUUYtO65DJOEuc+hB3VkAsM6QJDJ6AarO3hPKQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.4",
-        "@formatjs/icu-messageformat-parser": "2.0.7",
-        "@formatjs/intl": "1.13.2",
-        "@formatjs/intl-displaynames": "5.1.6",
-        "@formatjs/intl-listformat": "6.2.6",
+        "@formatjs/ecma402-abstract": "1.9.5",
+        "@formatjs/icu-messageformat-parser": "2.0.8",
+        "@formatjs/intl": "1.13.4",
+        "@formatjs/intl-displaynames": "5.2.0",
+        "@formatjs/intl-listformat": "6.3.0",
         "@types/hoist-non-react-statics": "^3.3.1",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "9.7.1",
+        "intl-messageformat": "9.8.1",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -19964,9 +20014,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -20229,9 +20279,9 @@
       }
     },
     "rollup": {
-      "version": "2.53.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.3.tgz",
-      "integrity": "sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==",
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.54.0.tgz",
+      "integrity": "sha512-RHzvstAVwm9A751NxWIbGPFXs3zL4qe/eYg+N7WwGtIXVLy1cK64MiU37+hXeFm1jqipK6DGgMi6Z2hhPuCC3A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -20750,9 +20800,9 @@
       }
     },
     "sass": {
-      "version": "1.35.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.2.tgz",
-      "integrity": "sha512-jhO5KAR+AMxCEwIH3v+4zbB2WB0z67V1X0jbapfVwQQdjHZUGUyukpnoM6+iCMfsIUC016w9OPKQ5jrNOS9uXw==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.36.0.tgz",
+      "integrity": "sha512-fQzEjipfOv5kh930nu3Imzq3ie/sGDc/4KtQMJlt7RRdrkQSfe37Bwi/Rf/gfuYHsIuE1fIlDMvpyMcEwjnPvg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -23284,9 +23334,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
-      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.0.tgz",
+      "integrity": "sha512-R/tiGB1ZXp2BC+TkRGLwj8xUZgdfT2f4UZEgX6aVjJ5uttPrr4fYmwTWDGqVnBCLbOXRMY6nr/BTbwCtVfps0g==",
       "dev": true,
       "optional": true
     },
@@ -23545,9 +23595,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -23713,66 +23763,66 @@
       }
     },
     "victory-area": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.9.0.tgz",
-      "integrity": "sha512-vUlQoVNl4l2SsPwx7Rf8YkDpDVCrRv5t+Zde8kvo211em9FaROfWQvDcha48hRPH9v/AeH19whMWMgCdDsx/rA==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.9.3.tgz",
+      "integrity": "sha512-3ZTDR6/cvI+L3aa2LhyMRe94PPldI9bZlShXu1mxK0mVtuaiIT19C5ou1huNwZtli6rflMQghDuMsoHaAXCJoA==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-axis": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.9.0.tgz",
-      "integrity": "sha512-i54nlB4F3i7QklkuIUli9PzaIjYZ87pxvOdokqggjxEZCyxF4g2zGa1sm/4K6o5i34W+Ce01TIOaYyW3L92Byg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.9.3.tgz",
+      "integrity": "sha512-OLgYilR8T6ymw1P6RiH1aKK6/8V31t3DwY0a9g9eAyLRzRG/zMUpLLfMVcMvwj1iYN8ZceDniO5SFCvXsmjLEw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-bar": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.9.0.tgz",
-      "integrity": "sha512-IjqzsJ60cCH/kXpmmlfCshwttNJGjlQs8khr/R5IzOg5bN0y6XO2roW9sWnXLdSt6pUB2z4t9tJ9gOOBADLB7A==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.9.3.tgz",
+      "integrity": "sha512-u0T8LhbmAKacQPhteBxXXW0U5WjUDXys01o5hMndELZvGsiE/dwd8mLCKaf2jZfgmQcZZ19JCZQi+Zs9V7eI4g==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-brush-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.9.0.tgz",
-      "integrity": "sha512-34vd/T2jyugXSM3KZGGUarnjblptVTh/Z2cQuMCW7nPws3cqlpOut3bQmayPePyUPPp6UbI4/uaRfw+u8TTMlQ==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.9.3.tgz",
+      "integrity": "sha512-P0E+bWIsHzo5kboxKsQYXV7DsQi1rIedTWwvyZ5bDQsDH9a8B0cmUej/DKHJq1BfLEPb7YEL71T5WorXum+LAw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-chart": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.9.0.tgz",
-      "integrity": "sha512-TIk8Ipij28UWzJky+cnjhCVhRqwbg6eDylOXLXxTAW6hPeZAhvfJSfnv/PZb5gq8kPiDklfK6sN3RSmYugHqHg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.9.3.tgz",
+      "integrity": "sha512-mVT3qMKSv4dMEQbiRaUm6L5BvMLRXhABlWUfSdSyEGSV9VZmu4VNvocwj6FUsvVgNJ6WaBH+3QAvLr2SF0BpEg==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-axis": "^35.9.0",
-        "victory-core": "^35.9.0",
-        "victory-polar-axis": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-axis": "^35.9.3",
+        "victory-core": "^35.9.3",
+        "victory-polar-axis": "^35.9.3",
+        "victory-shared-events": "^35.9.3"
       }
     },
     "victory-core": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.9.0.tgz",
-      "integrity": "sha512-t949a5U/p3fzMalcIAjcNexqj16e5kSyL+F0f6mamZZRy7ShhcyCqT4tm/rlog3cNpm/3gYnTWttiWrAulEoHg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.9.3.tgz",
+      "integrity": "sha512-EW3MELBKm1RlEggcBbEDsFINs3MArx5AAAvvy0lUTJ/qCqk0nJQrJvc29MbvbfKQ4RRTu1gAt6qJ3WkszF11aA==",
       "requires": {
         "d3-ease": "^1.0.0",
         "d3-interpolate": "^1.1.1",
@@ -23785,158 +23835,158 @@
       }
     },
     "victory-create-container": {
-      "version": "35.9.1",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.9.1.tgz",
-      "integrity": "sha512-SzVZUsYxGVuGGAOeCdZgLITMM1nTELrtnJjL0J3vwW8l9QW77LDEi/oRLG+052zNupJGYaEU2kCt2sqTctraRw==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.9.3.tgz",
+      "integrity": "sha512-+mU+bHYhUperqmJ6anPb50u//2CnkKyjVCiBX6O6Fpg5q++iiP5ndQtAk0XQedzFjd+Df5qAqZv5sEE8WPvlAQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^35.9.0",
-        "victory-core": "^35.9.0",
-        "victory-cursor-container": "^35.9.0",
-        "victory-selection-container": "^35.9.0",
-        "victory-voronoi-container": "^35.9.1",
-        "victory-zoom-container": "^35.9.0"
+        "victory-brush-container": "^35.9.3",
+        "victory-core": "^35.9.3",
+        "victory-cursor-container": "^35.9.3",
+        "victory-selection-container": "^35.9.3",
+        "victory-voronoi-container": "^35.9.3",
+        "victory-zoom-container": "^35.9.3"
       }
     },
     "victory-cursor-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.9.0.tgz",
-      "integrity": "sha512-rOct5asJ/LjmbS+AFlY4WRv7vVacumdp6zrJrPCAjT4AF+6bpcN0Im9GVcAiSa88gqf/EYpBa3txnf9wLnikFw==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.9.3.tgz",
+      "integrity": "sha512-aaQ+fYMTxK2JPxInrFrh0Ds7NLHtQhDDwXgDrwovg654cJ6P2wRXodl4stkjDdjsSYBt94az5jhvzCKY0s5zjw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-group": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.9.0.tgz",
-      "integrity": "sha512-5ynuM2dO0dnjakcjVjs9lDohbXZ5VpI0O7qF1iK51rdh4JCN4vMhJ+dcHX/uECJ9AntxQETwbcqyJYN1n2O4SA==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.9.3.tgz",
+      "integrity": "sha512-+wsiZYDo/0DJ5q4wBbdSuBvheRPZFocamgkVPbgtUXu2eEBeIF9vqXc1Flm8jQtfeJm0DG+iEuRXDhyC4IMb/Q==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-core": "^35.9.3",
+        "victory-shared-events": "^35.9.3"
       }
     },
     "victory-legend": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.9.0.tgz",
-      "integrity": "sha512-JGbMH14XERP+0v6OLbfhUuYrZs7+nQDwtO3xJ/oozuFBcC1tPaMXqNgHUb986CGttrw2fG8g8bRahYZy5YdJuQ==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.9.3.tgz",
+      "integrity": "sha512-klOIW8GU03i1FJBxt9U3FGme0Eb3LUEfr6lSTEM4Nyn1Ac9KVCcZEsSj3OqDs31dGRnU06S9E5rjqxSV5vRbWQ==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-line": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.9.0.tgz",
-      "integrity": "sha512-CeAUZpdBd7zETWGqEWfKuyP643Y66FjcdgYcfdLhO8IBwyFOnWuvLadsrtvAXz7XuUhi59G1kOgzWmuvPp4a/Q==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.9.3.tgz",
+      "integrity": "sha512-654fGlsq4o9Zo5BxUknA1FCg1YNBK4ZiZ9njCHYwxAM/yzKJk5dxYAnW9McQXywL/3uUEpxdP1dpLqH6WK3Bcw==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-pie": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.9.0.tgz",
-      "integrity": "sha512-xT4A2ltGLnj26uliVDfNFjEVcAzuDRzM6zZqoN4T7gDZOIus5LOLL/SwTnKpMmzqKcp9fybZmuWDMIxTZvsL4A==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.9.3.tgz",
+      "integrity": "sha512-+RidhGVTHo91Z67/A6CgrYZWvh1vJhmDyG2JG+diSK9T97Jt2d9rjtYnOtnJyZKC5bLAf0u733O+fr3p262t5A==",
       "requires": {
         "d3-shape": "^1.0.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-polar-axis": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.9.0.tgz",
-      "integrity": "sha512-dKEic/vr2FL3d3JtL4DcWAcxnrC6a/j2GPvDkby2aMimLMf5z8zZgr1/KQ3Xru40J4I6ML0Bvdm/1kNRyOq6sA==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.9.3.tgz",
+      "integrity": "sha512-LRX0NcDxv50sJEOlYNzDs7FdcEYYV81xouSCPRH2aQMuVQRTCLhWRdlhMS+77Xmo5/T69y3UozfnjC4+H5vEIA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-scatter": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.9.0.tgz",
-      "integrity": "sha512-xbltDOzLxdGDwdzEHjzz/9r2t0g2TZzudzIQuTfuJiUBy6gzfeTMGliLLJFPzonp48CElUtJUHe6wuvNeai6sQ==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.9.3.tgz",
+      "integrity": "sha512-iRfMRXhc455UH7wZRconqkt3YvtHKYT2KCH9j9j/vgRQ34MrpXiEaqgplsM+o31tYgNf63zlSSX/fwZWgn4BKw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-selection-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.9.0.tgz",
-      "integrity": "sha512-/DRkvAkfI4DGOELJDrIsU3GYozH+lwcXu56p3hD03VVa2xmM+ek7e/wzFZvlLAczRuilOgO54BYZ6rU/cQDmVg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.9.3.tgz",
+      "integrity": "sha512-1fpnCyWBiERwW5Ruh2jIbHWTon5C+QMkeX47xmaB5dYYEmK916xDhcE+wQdskh2IsEBjxSmZ4POER4vI57LNPA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-shared-events": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.9.0.tgz",
-      "integrity": "sha512-5DFaZ3DZnyAAl+Dmkq0bzAskw0cXonF7rFz4PLtQxUQfqOXwmABvyrJ43sqzzApdRoNHWuYibqAEqEiDE5kQjQ==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.9.3.tgz",
+      "integrity": "sha512-r6izA98vVFrqCxE3iYxuH7ha5iH2iybiRCQTKuonDjjDz+UCJAyWrX3ASxWUzJ/sDiuVBkPckNmfJbv/uYprcw==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-stack": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.9.0.tgz",
-      "integrity": "sha512-b7DNisxEqJybs2UF2VJ9Tf7zctTcfgQMwU4LY4JfIIbvNEArKAe7si1ezb2DaiZvgYg7fnB/6iR/X8ixKMHw/Q==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.9.3.tgz",
+      "integrity": "sha512-84dXkIxhXgpWlzuZM/YHWugFDh4LTIb2SmvjNR9noJWwofqlJbcP5Kx4VO9S65oB1+PRswyVASHwBy+ACk15KA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-core": "^35.9.3",
+        "victory-shared-events": "^35.9.3"
       }
     },
     "victory-tooltip": {
-      "version": "35.9.1",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.9.1.tgz",
-      "integrity": "sha512-VQmH2Rf9+bFSoFKXKezsFTW9vF0l+0WAmKVueeSNTyxXF9nQnaqKPtuz9w29CimVbYe3VCJ2HHGWX36bzwLoHg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.9.3.tgz",
+      "integrity": "sha512-QhbSK38ly6zhfZnqlLrtQvpaW9NE6SJEzE1QoZqE0atDitUg1MBajCBhOo6YWy+D2nMTJHmWyDxJPsxWHxW9gw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "victory-voronoi-container": {
-      "version": "35.9.1",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.9.1.tgz",
-      "integrity": "sha512-1ex52heROKg62S8aqBh2tEW+8fjwXD+DNfQxH2hjkUc+kl3K8BVjwsl/c//DM32lvjbRoBv3BifJiIsfDbnBGg==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.9.3.tgz",
+      "integrity": "sha512-IgF+oKxJaBAaNBoh60X2Ku4aI8zUyzbaau5iWatXS1MHHA6pjGyJfgC173zVkl5adXnPm/0T5ggTkQ0ktZ5OBw==",
       "requires": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-tooltip": "^35.9.1"
+        "victory-core": "^35.9.3",
+        "victory-tooltip": "^35.9.3"
       }
     },
     "victory-zoom-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.9.0.tgz",
-      "integrity": "sha512-OFFy4KPwUvx7IUbOmgECkvv0ihaCvZEVbPaKTkpDUCQa4YLRosL9j5gP9JdcGXYs2E3cssS1lgKiVsqzher9eA==",
+      "version": "35.9.3",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.9.3.tgz",
+      "integrity": "sha512-rDqWD+69ePcPzdrdbbVCVtmEmqSGoILntNEw89QF9Bvel1OW8rZvpccXTsMWeaYr1qKTcCypmmVl6/wRmSMWZQ==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.9.3"
       }
     },
     "vlq": {
@@ -24006,9 +24056,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.45.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.45.1.tgz",
-      "integrity": "sha512-68VT2ZgG9EHs6h6UxfV2SEYewA9BA3SOLSnC2NEbJJiEwbAiueDL033R1xX0jzjmXvMh0oSeKnKgbO2bDXIEyQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.46.0.tgz",
+      "integrity": "sha512-qxD0t/KTedJbpcXUmvMxY5PUvXDbF8LsThCzqomeGaDlCA6k998D8yYVwZMvO8sSM3BTEOaD4uzFniwpHaTIJw==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -24033,7 +24083,7 @@
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.2.0",
-        "webpack-sources": "^2.3.0"
+        "webpack-sources": "^2.3.1"
       },
       "dependencies": {
         "@types/estree": {

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -39,6 +39,10 @@ export const CVEs = () => {
     const selectedCves = useSelector(
         ({ CVEsStore }) => CVEsStore.selectedCves
     );
+
+    const selectedRowsRawData = useSelector(
+        ({ CVEsStore }) => CVEsStore.selectedRowsRawData
+    );
     const expandedRows = useSelector(
         ({ CVEsStore }) => CVEsStore.expandedRows
     );
@@ -105,6 +109,7 @@ export const CVEs = () => {
             <CVETableContext.Provider
                 value={{
                     cves,
+                    selectedRowsRawData,
                     params: parameters,
                     selectedCves,
                     expandedRows,

--- a/src/Components/SmartComponents/CVEs/CVEs.test.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.test.js
@@ -140,6 +140,7 @@ describe('CVEs', () => {
                     },
                     params: {},
                     selectedCves: [],
+                    selectedRowsRawData: [],
                     expandedRows: [],
                     isAllExpanded: false,
                     methods: {

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -39,7 +39,7 @@ const CVEsTableToolbarWithContext = (props) => {
     };
 
     const { context } = props;
-    const { cves, params, methods, selectedCves, isAllExpanded } = context;
+    const { cves, params, methods, selectedCves, isAllExpanded, selectedRowsRawData } = context;
     const { filter } = params;
     const selectedCvesCount = selectedCves && selectedCves.length;
 
@@ -55,20 +55,20 @@ const CVEsTableToolbarWithContext = (props) => {
         '', // #NOTE empty intentionally, Remediation holder
         {
             label: props.intl.formatMessage(messages.editBusinessRisk),
-            onClick: () => methods.showBusinessRiskModal(cves.data.filter(item => selectedCves.includes(item.id)).map(item => ({
-                id: item.id,
-                business_risk_id: item.business_risk_id,
-                business_risk_text: item.business_risk_justification
+            onClick: () => methods.showBusinessRiskModal(selectedRowsRawData.map(({ id, attributes }) => ({
+                id,
+                business_risk_id: attributes.business_risk_id,
+                business_risk_text: attributes.business_risk_justification
             }))),
             props: { isDisabled: !selectedCvesCount }
         },
         {
             label: props.intl.formatMessage(messages.editStatus),
-            onClick: () => methods.showStatusModal(cves.data.filter(item => selectedCves.includes(item.id)).map(item => ({
-                id: item.id,
-                exposed_systems_count: item.exposed_systems_count,
-                justification: item.status_justification,
-                status_id: item.status_id
+            onClick: () => methods.showStatusModal(selectedRowsRawData.map(({ id, attributes }) => ({
+                id,
+                exposed_systems_count: attributes.exposed_systems_count,
+                justification: attributes.status_justification,
+                status_id: attributes.status_id
             }), [])),
             props: { isDisabled: !selectedCvesCount }
         }

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.test.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.test.js
@@ -59,6 +59,33 @@ const mockContext = {
     },
     params: {},
     selectedCves: [],
+    selectedRowsRawData: [
+        {
+          attributes: {
+            business_risk: 'Not Defined',
+            business_risk_id: 0,
+            business_risk_text: null,
+            cvss2_score: null,
+            cvss3_score: '8.600',
+            description: 'There\'s a flaw in libxml2. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.',
+            impact: 'Moderate',
+            known_exploit: false,
+            public_date: '2021-04-22T00:00:00+00:00',
+            rules: [],
+            status: 'Resolved',
+            status_id: 2,
+            status_text: null,
+            synopsis: 'CVE-2019-6454',
+            systems_affected: 497,
+            systems_status_divergent: 497,
+            status_justification: 'testhello',
+            exposed_systems_count: 1,
+            business_risk_justification: null 
+          },
+          id: 'CVE-2019-6454',
+          type: 'cve'
+        }
+    ],
     expandedRows: [],
     isAllExpanded: false,
     methods: {

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -197,6 +197,7 @@ exports[`CVEs Should render without props 1`] = `
                           },
                           "params": Object {},
                           "selectedCves": Array [],
+                          "selectedRowsRawData": Array [],
                         }
                       }
                       downloadReport={[Function]}
@@ -3491,6 +3492,7 @@ exports[`CVEs Should render without props 1`] = `
                         },
                         "params": Object {},
                         "selectedCves": Array [],
+                        "selectedRowsRawData": Array [],
                       }
                     }
                     header={

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
@@ -97,6 +97,33 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
           },
           "params": Object {},
           "selectedCves": Array [],
+          "selectedRowsRawData": Array [
+            Object {
+              "attributes": Object {
+                "business_risk": "Not Defined",
+                "business_risk_id": 0,
+                "business_risk_justification": null,
+                "business_risk_text": null,
+                "cvss2_score": null,
+                "cvss3_score": "8.600",
+                "description": "There's a flaw in libxml2. An attacker who is able to submit a crafted file to be processed by an application linked with libxml2 could trigger a use-after-free. The greatest impact from this flaw is to confidentiality, integrity, and availability.",
+                "exposed_systems_count": 1,
+                "impact": "Moderate",
+                "known_exploit": false,
+                "public_date": "2021-04-22T00:00:00+00:00",
+                "rules": Array [],
+                "status": "Resolved",
+                "status_id": 2,
+                "status_justification": "testhello",
+                "status_text": null,
+                "synopsis": "CVE-2019-6454",
+                "systems_affected": 497,
+                "systems_status_divergent": 497,
+              },
+              "id": "CVE-2019-6454",
+              "type": "cve",
+            },
+          ],
         }
       }
       downloadReport={[Function]}

--- a/src/Store/Reducers/CVEsStore.js
+++ b/src/Store/Reducers/CVEsStore.js
@@ -1,6 +1,7 @@
 import * as ActionTypes from '../ActionTypes';
 import { applyGlobalFilter, isTimestampValid } from './reducersHelper';
 import { CVES_DEFAULT_FILTERS } from '../../Helpers/constants';
+import unionBy from 'lodash/unionBy';
 
 // Initial State
 export const initialState = {
@@ -13,7 +14,9 @@ export const initialState = {
         sort: '-public_date',
         ...CVES_DEFAULT_FILTERS
     },
+    prevLoadedRows: [],
     selectedCves: [],
+    selectedRowsRawData: [],
     expandedRows: [],
     isAllExpanded: false
 };
@@ -47,6 +50,7 @@ export const CVEsStore = (state = initialState, action) => {
                         payload: action.payload,
                         isLoading: false
                     },
+                    prevLoadedRows: unionBy(state.prevLoadedRows, action.payload.data, 'id'),
                     ...state.isAllExpanded && { expandedRows: action.payload.data.map(({ id }) => id) }
                 };
 
@@ -61,6 +65,8 @@ export const CVEsStore = (state = initialState, action) => {
 
         case ActionTypes.SELECT_CVE: {
             let selectedCves = newState.selectedCves.slice();
+            let prevLoadedRows = [].concat(state.prevLoadedRows);
+
             if (Array.isArray(action.payload)) {
                 selectedCves = action.payload;
             } else {
@@ -68,7 +74,13 @@ export const CVEsStore = (state = initialState, action) => {
                     selectedCves.push(action.payload);
             }
 
-            return { ...newState, selectedCves  };
+            let selectedRowsRawData = prevLoadedRows.filter(({ id }) => selectedCves.includes(id));
+
+            return {
+                ...newState,
+                selectedCves,
+                selectedRowsRawData
+            };
         }
 
         case ActionTypes.EXPAND_CVE: {

--- a/src/Store/Reducers/CVEsStore.test.js
+++ b/src/Store/Reducers/CVEsStore.test.js
@@ -86,7 +86,8 @@ describe('CVE reducer:', () => {
             },
             selectedCves: ['cve-1', 'cve-2', 'cve-3'],
             expandedRows: [],
-            isAllExpanded: false
+            isAllExpanded: false,
+            prevLoadedRows: [{id: 'cve-1'}]
         };
 
         action.type = ActionTypes.SELECT_CVE;


### PR DESCRIPTION
Here is my proposal for the [bug 1793](https://issues.redhat.com/browse/VULN-1793). I applied the changes only to landing page, if we agree on the solution it should be applied to all pages.

Few words about the  implementation: 

1. I store in redux the previously loaded rows + the current loaded rows in the variable `prevLoadedRows`
2. with that I can retrieve the data of previously visited loaded rows
3. use `unionBy` functionality to avoid the duplicates in case you go back and forth (pages) it will store it only once

Drawback? 

- Storing potential big set of data in redux if the use decides to visit all pages 


known issues:
- We still have the issue with the Select all functionality, this PR doesn't fix this problem 