### PR TITLE
fix: Refresh systems exposed page on status edit

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -2,7 +2,7 @@ import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { withRouter } from 'react-router-dom';
-import { useUrlParams, updateRef, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
+import { useUrlParams, createSortBy, handleSortColumn } from '../../../Helpers/MiscHelper';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import React, { useEffect, useState, useMemo } from 'react';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
@@ -137,13 +137,15 @@ const SystemsExposedTable = (props) => {
                 <CvePairStatusModal
                     cveList={cves}
                     updateRef={() => {
-                        updateRef(items.meta, apply);
-                        fetchCveDetails(props.cve);
+                        items.meta.page === 1
+                            ? dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }))
+                            : apply({ page: 1 });
+
+                        dispatch(fetchCveDetails(props.cve));
                     }}
                     inventoryList={inventories}
                     type={'systemsExposed'}
                 />
-
         );
     };
 


### PR DESCRIPTION
Fixes [VULN-1843](https://issues.redhat.com/browse/VULN-1843).

Correctly dispatch `fetchAffectedSystemsByCVE` to update status in table and add `fetchCveDetails` to refresh status breakdown table in CVE detail header.
![statusBreakdown](https://user-images.githubusercontent.com/8426204/127005314-35150684-ad33-42a4-99e9-3138066d0633.png)
