### PR TITLE
chore: Remove obsolete chrome 1 compatibility code

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ReducerRegistry from './Utilities/ReducerRegistry';
@@ -9,19 +9,9 @@ import { IntlProvider } from '@redhat-cloud-services/frontend-components-transla
 import messages from '../locales/en.json';
 
 const Vulnerabilities = () => {
-    useEffect(() => {
-        /**
-         * Temporary overflow fix for chrome 1. There is no risk breaking styles for other apps, no SPA
-         * Can be deleted once chtome 2 is deployed everywhere. Overflow is fixed by "vuln-root" class in chrome 2
-         */
-        const elem = document.querySelector('main#root');
-        if (!window.insights.chrome.isChrome2 && elem) {
-            elem.style.overflow = 'inherit';
-        }
-    }, []);
     return (
         <div className="vuln-root">
-            <IntlProvider locale = {navigator.language.slice(0, 2)}  messages={messages}>
+            <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
                 <Provider store={ReducerRegistry.getStore()}>
                     <Router basename={getBaseName(window.location.pathname)}>
                         <App />


### PR DESCRIPTION
Now that chrome 2 is present in all envs, we can remove chrome 1 compatibility code, which fixed the problems with sticky headers while both versions of chrome were present in different envs.