### PR TITLE
VULN-1814 fix(toolbars): Remove unwanted bottom margin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,17 +3119,34 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.135.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.135.0.tgz",
-      "integrity": "sha512-DZcONUGOR7Znd6BsUJ4L+KrrnIpyjUvh3JNcYiHW3loytxShCGcx+a04QjOOcZm+MtFhkgs/t51yiC5IP12abA==",
+      "version": "4.143.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.143.0.tgz",
+      "integrity": "sha512-Ns6JRmaP8ZsnsjuH+F4PBYW9jH5PHAashv3ZpCLsU3qxdBx7n96mDAuxaPWhTS5KHdkmQgQ0vjNccNq0wo8lbQ==",
       "requires": {
-        "@patternfly/react-icons": "^4.11.0",
-        "@patternfly/react-styles": "^4.11.0",
-        "@patternfly/react-tokens": "^4.12.0",
+        "@patternfly/react-icons": "^4.11.5",
+        "@patternfly/react-styles": "^4.11.5",
+        "@patternfly/react-tokens": "^4.12.6",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "1.13.0"
+      },
+      "dependencies": {
+        "@patternfly/react-icons": {
+          "version": "4.11.5",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.5.tgz",
+          "integrity": "sha512-DAJyZleK8Vrn2+xybT/ZjRXLzkXcIprNv7UYUgfxXMCh5nvy8YOGsqPa+u5M91cR6tXXXBl01gse3B2TSKo0/A=="
+        },
+        "@patternfly/react-styles": {
+          "version": "4.11.5",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.5.tgz",
+          "integrity": "sha512-0/MOUSmRnKPmd3CikfZTTaDPoOQVbEiyJD5HGyN2WEJEfXrP+aFlJQVzji81wvlsjd73sqdpOi9jNnEbsfjPMA=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "4.12.6",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.6.tgz",
+          "integrity": "sha512-0aasipmTdr0f18Ocg0+f5RpfkEczZ2DinJ0tHIue7QpDeHe+MtFDH9Y/fG5LEK7Mf6JUE/GOVBOkO4+VyhwcIg=="
+        }
       }
     },
     "@patternfly/react-icons": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@babel/runtime": "^7.14.0",
-    "@patternfly/react-core": "^4.135.0",
+    "@patternfly/react-core": "^4.143.0",
     "@patternfly/react-icons": "^4.11.0",
     "@patternfly/react-table": "^4.29.0",
     "@react-pdf/renderer": "^2.0.16",

--- a/src/App.scss
+++ b/src/App.scss
@@ -71,6 +71,12 @@
     }
 }
 
+.ins-c-primary-toolbar {
+    .pf-c-toolbar__content.pf-m-hidden {
+        display: none !important;
+    }
+}
+
 .ins-c-inventory__list-tags {
     display: block !important; 
     

--- a/src/Components/PresentationalComponents/EmptyStates/__snapshots__/EmptyState.test.js.snap
+++ b/src/Components/PresentationalComponents/EmptyStates/__snapshots__/EmptyState.test.js.snap
@@ -50,6 +50,9 @@ exports[`Empty state should render EmptyCVEList 1`] = `
               >
                 <h5
                   className="pf-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-5"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe={true}
                 >
                   <FormattedMessage
                     defaultMessage="No CVEs reported for connected systems"
@@ -227,6 +230,9 @@ exports[`Empty state should render EmptyCVEListForSystem 1`] = `
               >
                 <h5
                   className="pf-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-3"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe={true}
                 >
                   <FormattedMessage
                     defaultMessage="No CVEs reported for connected systems"
@@ -440,6 +446,9 @@ exports[`Empty state should render EmptyExcludedSystem 1`] = `
                 >
                   <h5
                     className="pf-c-title pf-m-lg"
+                    data-ouia-component-id="OUIA-Generated-Title-4"
+                    data-ouia-component-type="PF4/Title"
+                    data-ouia-safe={true}
                   >
                     <FormattedMessage
                       defaultMessage="Excluded from vulnerability analysis"
@@ -556,6 +565,9 @@ exports[`Empty state should render FilterNotFoundForCVE 1`] = `
               >
                 <h5
                   className="pf-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-1"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe={true}
                 >
                   <FormattedMessage
                     defaultMessage="No matching CVEs found"
@@ -752,6 +764,9 @@ exports[`Empty state should render FilterNotFoundForSystem 1`] = `
               >
                 <h5
                   className="pf-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-2"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe={true}
                 >
                   <FormattedMessage
                     defaultMessage="No CVEs reported for this system"

--- a/src/Components/PresentationalComponents/ErrorHandler/__snapshots__/ErrorHandler.test.js.snap
+++ b/src/Components/PresentationalComponents/ErrorHandler/__snapshots__/ErrorHandler.test.js.snap
@@ -54,6 +54,9 @@ exports[`ErrorHandler component should show Generic error component on other err
           >
             <h4
               className="pf-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-7"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe={true}
             >
               Something went wrong
             </h4>
@@ -152,6 +155,9 @@ exports[`ErrorHandler component should show Invalid Object error component on 40
       >
         <h1
           className="pf-c-title pf-m-3xl"
+          data-ouia-component-id="OUIA-Generated-Title-2"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe={true}
         >
           We lost that page
         </h1>
@@ -403,6 +409,9 @@ exports[`ErrorHandler component should show Invalid Object error component on 40
       >
         <h1
           className="pf-c-title pf-m-xl ins-c-text__sorry"
+          data-ouia-component-id="OUIA-Generated-Title-3"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe={true}
         >
           Let's find you a new one. Try a new search or return home.
         </h1>
@@ -500,6 +509,9 @@ exports[`ErrorHandler component should show Unauthorized error component on 403 
             >
               <h5
                 className="pf-c-title pf-m-lg"
+                data-ouia-component-id="OUIA-Generated-Title-1"
+                data-ouia-component-type="PF4/Title"
+                data-ouia-safe={true}
               >
                 You do not have permissions to view or manage Vulnerability
               </h5>
@@ -598,6 +610,9 @@ exports[`ErrorHandler component should show Unavailable error component on 5XX e
           >
             <h5
               className="pf-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-4"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe={true}
             >
               This page is temporarily unavailable
             </h5>
@@ -676,6 +691,9 @@ exports[`ErrorHandler component should show Unavailable error component on 5XX e
           >
             <h5
               className="pf-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-5"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe={true}
             >
               This page is temporarily unavailable
             </h5>
@@ -754,6 +772,9 @@ exports[`ErrorHandler component should show Unavailable error component on 5XX e
           >
             <h5
               className="pf-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-6"
+              data-ouia-component-type="PF4/Title"
+              data-ouia-safe={true}
             >
               This page is temporarily unavailable
             </h5>

--- a/src/Components/PresentationalComponents/StaticPages/__snapshots__/NoAccessPage.test.js.snap
+++ b/src/Components/PresentationalComponents/StaticPages/__snapshots__/NoAccessPage.test.js.snap
@@ -226,6 +226,9 @@ exports[`NoAccessPage component Should match snapshot 1`] = `
                             >
                               <h1
                                 className="pf-c-title pf-m-2xl"
+                                data-ouia-component-id="OUIA-Generated-Title-1"
+                                data-ouia-component-type="PF4/Title"
+                                data-ouia-safe={true}
                                 widget-type="InsightsPageHeaderTitle"
                               >
                                  
@@ -318,6 +321,9 @@ exports[`NoAccessPage component Should match snapshot 1`] = `
                             >
                               <h5
                                 className="pf-c-title pf-m-lg"
+                                data-ouia-component-id="OUIA-Generated-Title-2"
+                                data-ouia-component-type="PF4/Title"
+                                data-ouia-safe={true}
                               >
                                 You do not have permissions to view or manage Vulnerability
                               </h5>

--- a/src/Components/PresentationalComponents/StaticPages/__snapshots__/UpgradePage.test.js.snap
+++ b/src/Components/PresentationalComponents/StaticPages/__snapshots__/UpgradePage.test.js.snap
@@ -226,6 +226,9 @@ exports[`UpgradePage component Should match snapshot 1`] = `
                             >
                               <h1
                                 className="pf-c-title pf-m-2xl"
+                                data-ouia-component-id="OUIA-Generated-Title-1"
+                                data-ouia-component-type="PF4/Title"
+                                data-ouia-safe={true}
                                 widget-type="InsightsPageHeaderTitle"
                               >
                                  
@@ -309,6 +312,9 @@ exports[`UpgradePage component Should match snapshot 1`] = `
                             >
                               <h5
                                 className="pf-c-title pf-m-lg"
+                                data-ouia-component-id="OUIA-Generated-Title-2"
+                                data-ouia-component-type="PF4/Title"
+                                data-ouia-safe={true}
                               >
                                 Do more with your Red Hat Enterprise Linux environment
                               </h5>

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -609,6 +609,9 @@ exports[`CVEs Should render without props 1`] = `
                         >
                           <div
                             className="pf-c-toolbar  ins-c-primary-toolbar"
+                            data-ouia-component-id="OUIA-Generated-Toolbar-1"
+                            data-ouia-component-type="PF4/Toolbar"
+                            data-ouia-safe={true}
                             id="ins-primary-data-toolbar"
                           >
                             <ToolbarContent
@@ -1845,6 +1848,7 @@ exports[`CVEs Should render without props 1`] = `
                                                             isRequired={false}
                                                             onChange={[Function]}
                                                             onKeyDown={[Function]}
+                                                            ouiaSafe={true}
                                                             placeholder="Search ID or description"
                                                             type="text"
                                                             validated="default"
@@ -1855,7 +1859,9 @@ exports[`CVEs Should render without props 1`] = `
                                                               aria-invalid={false}
                                                               aria-label="search-field"
                                                               className="pf-c-form-control ins-c-conditional-filter "
+                                                              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                                               data-ouia-component-type="PF4/TextInput"
+                                                              data-ouia-safe={true}
                                                               disabled={false}
                                                               id="search-cve"
                                                               onBlur={[Function]}

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
@@ -535,6 +535,9 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
         >
           <div
             className="pf-c-toolbar  ins-c-primary-toolbar"
+            data-ouia-component-id="OUIA-Generated-Toolbar-1"
+            data-ouia-component-type="PF4/Toolbar"
+            data-ouia-safe={true}
             id="ins-primary-data-toolbar"
           >
             <ToolbarContent
@@ -1771,6 +1774,7 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                                             isRequired={false}
                                             onChange={[Function]}
                                             onKeyDown={[Function]}
+                                            ouiaSafe={true}
                                             placeholder="Search ID or description"
                                             type="text"
                                             validated="default"
@@ -1781,7 +1785,9 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                                               aria-invalid={false}
                                               aria-label="search-field"
                                               className="pf-c-form-control ins-c-conditional-filter "
+                                              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                               data-ouia-component-type="PF4/TextInput"
+                                              data-ouia-safe={true}
                                               disabled={false}
                                               id="search-cve"
                                               onBlur={[Function]}

--- a/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
+++ b/src/Components/SmartComponents/Modals/__snapshots__/ReportConfigModal.test.js.snap
@@ -192,6 +192,9 @@ exports[`Report config modal component Should match snapshots 1`] = `
                               <input
                                 aria-invalid="false"
                                 class="pf-c-form-control report-text-input"
+                                data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+                                data-ouia-component-type="PF4/TextInput"
+                                data-ouia-safe="true"
                                 id="horizontal-form-name"
                                 type="text"
                                 value=""
@@ -864,6 +867,7 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                             isReadOnly={false}
                                             isRequired={false}
                                             onChange={[Function]}
+                                            ouiaSafe={true}
                                             type="text"
                                             validated="default"
                                           >
@@ -871,6 +875,9 @@ exports[`Report config modal component Should match snapshots 1`] = `
                                               aria-invalid={false}
                                               aria-label={null}
                                               className="pf-c-form-control report-text-input"
+                                              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+                                              data-ouia-component-type="PF4/TextInput"
+                                              data-ouia-safe={true}
                                               disabled={false}
                                               id="horizontal-form-name"
                                               onBlur={[Function]}

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -68,6 +68,9 @@ exports[`Reports page component Should match snapshots 1`] = `
                         >
                           <h1
                             className="pf-c-title pf-m-2xl"
+                            data-ouia-component-id="OUIA-Generated-Title-1"
+                            data-ouia-component-type="PF4/Title"
+                            data-ouia-safe={true}
                             widget-type="InsightsPageHeaderTitle"
                           >
                              

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -796,6 +796,9 @@ exports[`SystemCves Should match snapshots 1`] = `
                             >
                               <div
                                 className="pf-c-toolbar  ins-c-primary-toolbar"
+                                data-ouia-component-id="OUIA-Generated-Toolbar-1"
+                                data-ouia-component-type="PF4/Toolbar"
+                                data-ouia-safe={true}
                                 id="ins-primary-data-toolbar"
                               >
                                 <ToolbarContent
@@ -2024,6 +2027,7 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                 isRequired={false}
                                                                 onChange={[Function]}
                                                                 onKeyDown={[Function]}
+                                                                ouiaSafe={true}
                                                                 placeholder="Search ID or description"
                                                                 type="text"
                                                                 validated="default"
@@ -2034,7 +2038,9 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                   aria-invalid={false}
                                                                   aria-label="search-field"
                                                                   className="pf-c-form-control ins-c-conditional-filter "
+                                                                  data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                                                   data-ouia-component-type="PF4/TextInput"
+                                                                  data-ouia-safe={true}
                                                                   disabled={false}
                                                                   id="search-cve"
                                                                   onBlur={[Function]}

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -586,6 +586,9 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
         >
           <div
             className="pf-c-toolbar  ins-c-primary-toolbar"
+            data-ouia-component-id="OUIA-Generated-Toolbar-1"
+            data-ouia-component-type="PF4/Toolbar"
+            data-ouia-safe={true}
             id="ins-primary-data-toolbar"
           >
             <ToolbarContent
@@ -1813,6 +1816,7 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                             isRequired={false}
                                             onChange={[Function]}
                                             onKeyDown={[Function]}
+                                            ouiaSafe={true}
                                             placeholder="Search ID or description"
                                             type="text"
                                             validated="default"
@@ -1823,7 +1827,9 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                                               aria-invalid={false}
                                               aria-label="search-field"
                                               className="pf-c-form-control ins-c-conditional-filter "
+                                              data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                               data-ouia-component-type="PF4/TextInput"
+                                              data-ouia-safe={true}
                                               disabled={false}
                                               id="search-cve"
                                               onBlur={[Function]}

--- a/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
+++ b/src/Components/SmartComponents/SystemDetailsPage/__snapshots__/SystemDetails.test.js.snap
@@ -772,6 +772,9 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                   >
                                     <div
                                       className="pf-c-toolbar  ins-c-primary-toolbar"
+                                      data-ouia-component-id="OUIA-Generated-Toolbar-1"
+                                      data-ouia-component-type="PF4/Toolbar"
+                                      data-ouia-safe={true}
                                       id="ins-primary-data-toolbar"
                                     >
                                       <ToolbarContent
@@ -2000,6 +2003,7 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                                       isRequired={false}
                                                                       onChange={[Function]}
                                                                       onKeyDown={[Function]}
+                                                                      ouiaSafe={true}
                                                                       placeholder="Search ID or description"
                                                                       type="text"
                                                                       validated="default"
@@ -2010,7 +2014,9 @@ exports[`SystemDetails Should match snapshot 1`] = `
                                                                         aria-invalid={false}
                                                                         aria-label="search-field"
                                                                         className="pf-c-form-control ins-c-conditional-filter "
+                                                                        data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                                                         data-ouia-component-type="PF4/TextInput"
+                                                                        data-ouia-safe={true}
                                                                         disabled={false}
                                                                         id="search-cve"
                                                                         onBlur={[Function]}

--- a/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
@@ -1501,6 +1501,9 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
               >
                 <div
                   className="pf-c-toolbar vuln-systems-primary-toolbar ins-c-primary-toolbar"
+                  data-ouia-component-id="OUIA-Generated-Toolbar-1"
+                  data-ouia-component-type="PF4/Toolbar"
+                  data-ouia-safe={true}
                   id="ins-primary-data-toolbar"
                 >
                   <ToolbarContent
@@ -2352,6 +2355,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                   isRequired={false}
                                                   onChange={[Function]}
                                                   onKeyDown={[Function]}
+                                                  ouiaSafe={true}
                                                   placeholder="Filter by name"
                                                   type="text"
                                                   validated="default"
@@ -2362,7 +2366,9 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                     aria-invalid={false}
                                                     aria-label="search-field"
                                                     className="pf-c-form-control ins-c-conditional-filter "
+                                                    data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                                                     data-ouia-component-type="PF4/TextInput"
+                                                    data-ouia-safe={true}
                                                     disabled={false}
                                                     id="search-systems.search.name"
                                                     onBlur={[Function]}


### PR DESCRIPTION
Fixes [VULN-1814](https://issues.redhat.com/browse/VULN-1814).

This bug affected all tables. Updated `@patternfly/react-core` to resolve [this issue](https://github.com/patternfly/patternfly-react/issues/5962). This fixed the problem only on landing page, so I had to add a new sass rule, which should not break anything as it is very specific and includes `.pf-m-hidden` so it should had `display: none` either way,

### Before:
![toolbar-margin](https://user-images.githubusercontent.com/8426204/127550559-2bea00d9-36bc-40e6-bb58-5253ce28d8b5.png)

### After:
![toolbar-margin-after](https://user-images.githubusercontent.com/8426204/127550569-3811441e-323b-43c1-9313-4514994c5872.png)
