### PR TITLE
Simplify passing arguments on fetch functions

### DIFF
--- a/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
+++ b/src/Components/PresentationalComponents/ErrorHandler/ErrorHandler.js
@@ -6,7 +6,7 @@ import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorStat
 import { NotAuthorized } from '../EmptyStates/EmptyStates';
 
 const ErrorHandler = ({ code }) => {
-    switch (code) {
+    switch (parseInt(code)) {
         case 403:
             return <NotAuthorized />;
 

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -55,7 +55,7 @@ const CVEDetailsPage = ({ match }) => {
                     cves={cves}
                     updateRef={() => {
                         dispatch(fetchCveDetails(cveName));
-                        dispatch(fetchAffectedSystemsByCVE(cveName));
+                        dispatch(fetchAffectedSystemsByCVE({ id: cveName }));
                     }}
                 />
         );

--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
@@ -82,7 +82,6 @@ describe('CVE details:', () => {
             </Provider>
         );
         expect(store.getActions().some(({ type }) => type === 'FETCH_CVE_DETAILS' )).toBeTruthy();
-        expect(store.getActions().some(({ type }) => type === 'FETCH_AFFECTED_SYSTEMS_BY_CVE' )).toBeTruthy();
     });
 
     describe('test modals: ', () => {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -42,8 +42,7 @@ import {
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import * as APIHelper from '../../../Helpers/APIHelper';
-import { useGetEntities } from '../../../Helpers/Hooks';
-import { useBulkSelect } from '../../../Helpers/Hooks';
+import { useGetEntities, useBulkSelect } from '../../../Helpers/Hooks';
 
 const SystemsExposedTable = ({
     cve: cveId,

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -7,10 +7,8 @@ import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import React, { useEffect, useState, useMemo } from 'react';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
-import { middlewareListener } from '../../../Utilities/ReducerRegistry';
-import selectAllCheckbox from '../../../Helpers/selectAllCheckboxHelper';
 import { Text, TextContent, TextVariants, Stack, StackItem } from '@patternfly/react-core';
-import { systemExposedTableRowActions, createExposedSystemsTable } from '../../../Helpers/CVEHelper';
+import { systemExposedTableRowActions, createExposedSystemsRows } from '../../../Helpers/CVEHelper';
 import { inventoryEntitiesReducer } from '../../../Store/Reducers/InventoryEntitiesReducer';
 import DownloadReport from '../../../Helpers/DownloadReport';
 import Remediation from '../Remediation/Remediation';
@@ -22,6 +20,7 @@ import {
     fetchAffectedSystemsByCVE,
     fetchCveDetails,
     expandRow,
+    selectRows,
     changeExposedSystemsParameters,
     fetchAffectedSystemsIdsByCve,
     clearInventoryStore
@@ -44,82 +43,47 @@ import {
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import * as APIHelper from '../../../Helpers/APIHelper';
 import { useGetEntities } from '../../../Helpers/Hooks';
+import { useBulkSelect } from '../../../Helpers/Hooks';
 
-const SystemsExposedTable = (props) => {
+const SystemsExposedTable = ({
+    cve: cveId,
+    intl,
+    cveStatusDetails,
+    filterRuleValues
+}) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);
-    const [selectedHosts, setSelectedHosts] = useState(undefined);
 
     const inventory = React.createRef();
     const dispatch = useDispatch();
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_EXPOSED_ALLOWED_PARAMS);
-    const [isFirstMount, setFirstMount] = useState(true);
-
-    const affectedSystems = useSelector(
-        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.affectedSystemsByCVE
-    );
-
-    const isLoading = useSelector(
-        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.affectedSystemsByCVE.isLoading
-    );
 
     const parameters = useSelector(
         ({ CVEDetailsPageStore }) => CVEDetailsPageStore.parameters,
         shallowEqual
     );
 
-    const metadata = useSelector(
-        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.affectedSystemsByCVE.payload.meta
-    );
-    const items = useMemo(() => createExposedSystemsTable({ ...affectedSystems }, props.cve), [affectedSystems, props.cve]);
-
-    const { error } = useSelector(
-        ({ CVEDetailsPageStore }) => CVEDetailsPageStore.affectedSystemsByCVE
-    );
+    const items = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
+    const totalItems = useSelector(({ entities }) => entities?.total);
+    const meta = useSelector(({ entities }) => entities?.meta || {});
+    const error = useSelector(({ entities }) => entities?.error || {});
+    const loaded = useSelector(({ entities }) => entities?.loaded || false);
+    const selectedRows = useSelector(({ entities }) => entities?.selectedRows || {});
+    const selectedRowsCount = Object.keys(selectedRows).length || 0;
 
     const apply = (config) => dispatch(
         changeExposedSystemsParameters(config)
     );
 
-    const inventoryRefresh = ({ page, per_page: pageSize }) => {
-
-        if (inventory.current && (metadata.page !== page || metadata.limit !== pageSize)) {
-            apply({ page, page_size: pageSize });
-        }
-
-        if (metadata && metadata.total_items <= pageSize && inventory.current) {
-            inventory.current.onRefreshData({ page, page_size: pageSize });
-        }
-    };
-
-    const handleSelect = (isChecked, payload) => {
-        const selectedHosts = payload ? payload : [];
-        setSelectedHosts(selectedHosts);
-    };
-
-    const onSelect = (payload) => {
-        const newSelected = payload.data.selected ? [payload.data.id, ...(selectedHosts || [])]
-            : selectedHosts && selectedHosts.filter(item => item !== payload.data.id);
-
-        handleSelect(false, newSelected);
-    };
-
-    middlewareListener.addNew({
-        on: 'SELECT_ENTITY',
-        callback: payload => onSelect(payload)
-    });
+    const handleSelect = (payload) => dispatch(selectRows(payload));
 
     useEffect(() => {
         apply(urlParameters);
-        setFirstMount(false);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useDeepCompareEffect(() => {
-        if (!isFirstMount) {
-            setUrlParams({ ...parameters });
-            // dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));
-        }
-    }, [parameters, isFirstMount]);
+        setUrlParams({ ...parameters });
+    }, [parameters]);
 
     useEffect(() => {
         return () => {
@@ -128,12 +92,32 @@ const SystemsExposedTable = (props) => {
     }, [dispatch]);
 
     const downloadReport = format => {
-        let params = [props.cve, { ...parameters }];
-        DownloadReport.exec(fetchAffectedSystemsByCVE, params, format, 'systems-exposed', notification => dispatch(
-            addNotification(notification)), () => dispatch(clearNotifications()));
+        DownloadReport.exec(
+            fetchAffectedSystemsByCVE,
+            { id: cveId, ...parameters },
+            format,
+            'systems-exposed',
+            notification => dispatch(addNotification(notification)),
+            () => dispatch(clearNotifications())
+        );
     };
 
-    const getEntities = useGetEntities(APIHelper.getAffectedSystemsByCVE, { id: props.cve, setUrlParams });
+    const getEntities = useGetEntities(
+        APIHelper.getAffectedSystemsByCVE,
+        {
+            createRows: createExposedSystemsRows,
+            id: cveId,
+            setUrlParams
+        }
+    );
+
+    const bulkSelectProps = useBulkSelect({
+        rawData: { data: items, meta },
+        selectedRows,
+        selectedRowsCount,
+        handleSelect,
+        fetchResource: ops => fetchAffectedSystemsIdsByCve(cveId, { ...parameters, ...ops })
+    });
 
     const showStatusModal = (cves, inventories) => {
         setStatusModal(
@@ -141,11 +125,11 @@ const SystemsExposedTable = (props) => {
                 <CvePairStatusModal
                     cveList={cves}
                     updateRef={() => {
-                        items.meta.page === 1
-                            ? dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }))
+                        meta.page === 1
+                            ? dispatch(fetchAffectedSystemsByCVE({ id: cveId, ...parameters }))
                             : apply({ page: 1 });
 
-                        dispatch(fetchCveDetails(props.cve));
+                        dispatch(fetchCveDetails(cveId));
                     }}
                     inventoryList={inventories}
                     type={'systemsExposed'}
@@ -153,36 +137,15 @@ const SystemsExposedTable = (props) => {
         );
     };
 
-    const getSelectedSystemsData = () => {
-        let systemsList = items.data?.filter(item => selectedHosts.includes(item.inventory_id));
-        // eslint-disable-next-line camelcase
-        systemsList = systemsList.map(({ inventory_id, display_name, status_id, status_text: justification }) =>
-            ({ inventory_id, display_name, status_id, justification })); // omit properties we don't need
-
-        return systemsList;
-    };
+    const selectedRowsData = useMemo(() => items?.filter(s => selectedRows[s.id] === true), [selectedRows, items]);
 
     const kebabOptions = ['',
         {
-            label: props.intl.formatMessage(messages.editStatus),
-            onClick: () => showStatusModal(
-                [props.cveStatusDetails],
-                getSelectedSystemsData()
-            ),
-            props: { isDisabled: !selectedHosts || selectedHosts.length === 0 }
+            label: intl.formatMessage(messages.editStatus),
+            onClick: () => showStatusModal([cveStatusDetails], selectedRowsData),
+            props: { isDisabled: !selectedRows || selectedRowsCount === 0 }
         }
     ];
-
-    const selectOptions = useMemo(() => selectAllCheckbox({
-        selectedItems: selectedHosts || [],
-        selectorHandler: handleSelect,
-        items: items.data && items || { data: [], meta: { total_items: 0 } },
-        fetchResource: ops => fetchAffectedSystemsIdsByCve(props.cve, { ...parameters, ...ops })
-    }), [items, selectedHosts, parameters, props.cve]);
-
-    const selectedHostsData = useMemo(() => (
-        items?.data?.filter(s => selectedHosts?.includes(s.id))
-    ), [selectedHosts, items]);
 
     const sortingHeader = items?.meta?.patch_access
         ? SYSTEMS_EXPOSED_SORTING_HEADER
@@ -191,7 +154,7 @@ const SystemsExposedTable = (props) => {
     const sortBy = () =>
         createSortBy(
             sortingHeader,
-            metadata.sort
+            meta.sort
         );
 
     const onSort = (_event, index, direction) =>
@@ -218,13 +181,13 @@ const SystemsExposedTable = (props) => {
                 <StackItem>
                     <TextContent>
                         <Text component={TextVariants.h2}>
-                            {props.intl.formatMessage(messages.affectsSystems)}
+                            {intl.formatMessage(messages.affectsSystems)}
                         </Text>
                     </TextContent>
                 </StackItem>
                 <StackItem>
-                    {error?.hasError
-                        ? <ErrorHandler code={error?.errorCode} />
+                    { Object.keys(error).length > 0
+                        ? <ErrorHandler code={error?.status} />
                         : <InventoryTable
                             disableDefaultColumns
                             onLoad={({ mergeWithEntities }) => {
@@ -232,75 +195,75 @@ const SystemsExposedTable = (props) => {
                                     ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER))
                                 });
                             }}
-                            getEntities={getEntities}
                             tableProps={{
                                 isStickyHeader: true,
                                 canSelectAll: false,
-                                onSort: (items.data.length > 0) && onSort,
-                                sortBy: (items.data.length > 0) && sortBy(),
+                                onSort: (totalItems > 0) && onSort,
+                                sortBy: (totalItems > 0) && sortBy(),
                                 actionResolver: (rowData, rowIndex) => (
-                                    items.data.length > 0 &&
-                                    systemExposedTableRowActions(
-                                        showStatusModal,
-                                        props.cveStatusDetails,
-                                        rowIndex.rowIndex
-                                    )
+                                    totalItems > 0 &&
+                                        systemExposedTableRowActions(
+                                            showStatusModal,
+                                            cveStatusDetails,
+                                            rowIndex.rowIndex
+                                        )
                                 ),
                                 variant: TableVariant.compact
                             }}
+                            autoRefresh
+                            customFilters={{
+                                vulnerabilityParams: {
+                                    ...parameters,
+                                    show_advisories: true
+                                }
+                            }}
+                            getEntities={getEntities}
                             showTags
+                            isFullView
                             key={'inventory'}
                             expandable
                             ref={inventory}
-                            items={items.data}
-                            page={metadata && metadata.page || 1}
-                            perPage={metadata && metadata.page_size || 20}
-                            total={metadata && metadata.total_items || 0}
-                            onRefresh={inventoryRefresh}
-                            hasCheckbox={items && items.length !== 0}
-                            showActions={items && items.length !== 0}
+                            page={meta && meta.page || 1}
+                            perPage={meta && meta.page_size || 20}
+                            total={meta && meta.total_items || 0}
+                            hasCheckbox={items && totalItems !== 0}
+                            showActions={items && totalItems !== 0}
                             onExpandClick={(_e, _i, isOpen, { id }) => dispatch(expandRow(id, isOpen))}
+                            hideFilters={{ all: true }}
                             noSystemsTable={<EmptyStateNoSystems />}
                         >
                             <PrimaryToolbar
                                 className="vuln-systems-primary-toolbar"
                                 exportConfig={{
-                                    isDisabled: items.meta.total_items === 0,
+                                    isDisabled: totalItems === 0,
                                     ouiaId: 'export',
                                     ...exportConfig({ downloadReport })
                                 }}
-                                dedicatedAction={(!isLoading &&
+                                dedicatedAction={loaded &&
                                     <Remediation
                                         manyRules
-                                        systems={selectedHostsData}
-                                        cves={{ id: props.cve, rules: props.filterRuleValues }}
+                                        systems={selectedRowsData}
+                                        cves={{ id: cveId, rules: filterRuleValues }}
                                     />
-                                )}
+                                }
                                 actionsConfig={{
                                     actions: kebabOptions,
-                                    kebabToggleProps: { isDisabled: !selectedHosts || selectedHosts.length === 0 },
+                                    kebabToggleProps: { isDisabled: !selectedRows || selectedRowsCount === 0 },
                                     dropdownProps: { ouiaId: 'toolbar-actions' }
                                 }}
                                 activeFiltersConfig={{
-                                    filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
+                                    filters: buildActiveFilters({ ...parameters }, filterRuleValues),
                                     onDelete: (_, chips) => removeFilters(chips, apply),
-                                    deleteTitle: props.intl.formatMessage(messages.resetFilters)
+                                    deleteTitle: intl.formatMessage(messages.resetFilters)
                                 }}
-                                bulkSelect={selectOptions && {
-                                    count: selectedHosts && selectedHosts.length,
-                                    items: selectOptions.items,
-                                    isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
-                                    checked: Boolean(selectedHosts && selectedHosts.length),
-                                    ouiaId: 'bulk-select',
-                                    onSelect: () => selectOptions.handleOnCheckboxChange()
-                                }}
+                                bulkSelect={bulkSelectProps}
                                 filterConfig={{
                                     items: [
                                         searchFilter,
                                         securityRuleFilter(
                                             apply,
                                             parameters,
-                                            props.filterRuleValues,
+                                            filterRuleValues,
                                             {
                                                 isDynamic: true,
                                                 dropdownItems: RULE_ABSENSE_OPTIONS
@@ -312,7 +275,8 @@ const SystemsExposedTable = (props) => {
                                 }}
                             />
                             {StatusModal && <StatusModal />}
-                        </InventoryTable>}
+                        </InventoryTable>
+                    }
                 </StackItem>
             </Stack>
         </React.Fragment>

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -42,6 +42,8 @@ import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
+import * as APIHelper from '../../../Helpers/APIHelper';
+import { useGetEntities } from '../../../Helpers/Hooks';
 
 const SystemsExposedTable = (props) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);
@@ -115,7 +117,7 @@ const SystemsExposedTable = (props) => {
     useDeepCompareEffect(() => {
         if (!isFirstMount) {
             setUrlParams({ ...parameters });
-            dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));
+            // dispatch(fetchAffectedSystemsByCVE(props.cve, { ...parameters }));
         }
     }, [parameters, isFirstMount]);
 
@@ -130,6 +132,8 @@ const SystemsExposedTable = (props) => {
         DownloadReport.exec(fetchAffectedSystemsByCVE, params, format, 'systems-exposed', notification => dispatch(
             addNotification(notification)), () => dispatch(clearNotifications()));
     };
+
+    const getEntities = useGetEntities(APIHelper.getAffectedSystemsByCVE, { id: props.cve, setUrlParams });
 
     const showStatusModal = (cves, inventories) => {
         setStatusModal(
@@ -223,12 +227,12 @@ const SystemsExposedTable = (props) => {
                         ? <ErrorHandler code={error?.errorCode} />
                         : <InventoryTable
                             disableDefaultColumns
-                            onLoad={({ mergeWithEntities, mergeWithDetail }) => {
+                            onLoad={({ mergeWithEntities }) => {
                                 ReducerRegistry.register({
-                                    ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER)),
-                                    ...mergeWithDetail()
+                                    ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER))
                                 });
                             }}
+                            getEntities={getEntities}
                             tableProps={{
                                 isStickyHeader: true,
                                 canSelectAll: false,
@@ -252,7 +256,6 @@ const SystemsExposedTable = (props) => {
                             page={metadata && metadata.page || 1}
                             perPage={metadata && metadata.page_size || 20}
                             total={metadata && metadata.total_items || 0}
-                            isLoaded={!isLoading}
                             onRefresh={inventoryRefresh}
                             hasCheckbox={items && items.length !== 0}
                             showActions={items && items.length !== 0}

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -52,8 +52,7 @@ const SystemsExposedTable = ({
     filterRuleValues
 }) => {
     const [StatusModal, setStatusModal] = useState(() => () => null);
-
-    const inventory = React.createRef();
+    const inventoryRef = React.createRef();
     const dispatch = useDispatch();
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_EXPOSED_ALLOWED_PARAMS);
 
@@ -125,10 +124,7 @@ const SystemsExposedTable = ({
                 <CvePairStatusModal
                     cveList={cves}
                     updateRef={() => {
-                        meta.page === 1
-                            ? dispatch(fetchAffectedSystemsByCVE({ id: cveId, ...parameters }))
-                            : apply({ page: 1 });
-
+                        inventoryRef.current.onRefreshData(({ page: 1 }));
                         dispatch(fetchCveDetails(cveId));
                     }}
                     inventoryList={inventories}
@@ -222,7 +218,7 @@ const SystemsExposedTable = ({
                             isFullView
                             key={'inventory'}
                             expandable
-                            ref={inventory}
+                            ref={inventoryRef}
                             page={meta && meta.page || 1}
                             perPage={meta && meta.page_size || 20}
                             total={meta && meta.total_items || 0}

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
@@ -83,20 +83,4 @@ describe('SystemsExposedPage', () => {
             expect(dispatchedActions.filter(item => item.type === 'CLEAR_INVENTORY_STORE')).toHaveLength(1);
         })
     });
-
-    it('Should dispatch FETCH_AFFECTED_SYSTEMS_BY_CVE only once on load', () => {        
-        const dispatchedActions = store.getActions();
-        expect(dispatchedActions.filter(item => item.type === 'FETCH_AFFECTED_SYSTEMS_BY_CVE')).toHaveLength(1);
-    });
-
-    it('Should update inventory', () => {
-        const testObj = { page: 2, per_page: 2}
-        wrapper.update(); 
-        act( () => wrapper.find('BaseInvTable').props().onRefresh(testObj)); 
-        const dispatchedActions = store.getActions();
-        expect(dispatchedActions[2]).toEqual({
-            type: 'CHANGE_EXPOSED_SYSTEMS_PARAMETERS',
-            payload: { page: 2, page_size: 2 }
-        });
-    });
 });

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
@@ -22,31 +22,6 @@ jest.mock("../../../Helpers/DownloadReport", () => ({
 
 const state = {
     ...initialState,
-    affectedSystemsByCVE: {
-        isLoading: false,
-        expandedRows: [],
-        payload: {
-            meta: {},
-            data: [
-                {
-                    id: "c3f36a42-5289-4940-8dcf-d1b7c8f90db2",
-                    attributes: {
-                        cve_status_id: 2,
-                        display_name: "f375c7a8-c680-44fc-9fc4-003de8896877",
-                        inventory_id: "f375c7a8-c680-44fc-9fc4-003de8896877",
-                        last_evaluation: "2020-07-21T08:14:11.877214+00:00",
-                        cve_status_id: 2,
-                        reporter: 1,
-                        rule: null,
-                        rules_evaluation: "2020-07-21T08:14:13.272253+00:00",
-                        status_id: 2,
-                        status_text: "testhello",
-                        status_name: "On-Hold"
-                    }
-                }
-            ]
-        }
-    }
 };
 
 const customMiddleWare = store => next => action => {

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -74,7 +74,7 @@ const SystemsPage = () => {
 
     const doOptOut = useOptOutSystems(onRefreshInventory);
     let columnCounter = useMemo(() => columnCounter ? columnCounter++ : 0, []);
-    const getEntities = useGetEntities(APIHelper.getSystems, setUrlParams);
+    const getEntities = useGetEntities(APIHelper.getSystems, { setUrlParams });
 
     return (
         <Fragment>

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -117,14 +117,14 @@ let systemsByCVEparams = [
     'firstReportedTo'
 ];
 
-export function getAffectedSystemsByCVE(synopsis, apiProps) {
+export function getAffectedSystemsByCVE({ id, ...apiProps }) {
     let parameterNames = [
         ...defaultParams,
         ...systemsByCVEparams
     ];
 
     let parameterArray = constructParameters(apiProps, parameterNames);
-    let result = api.getAffectedSystemsByCve(synopsis, ...parameterArray);
+    let result = api.getAffectedSystemsByCve(id, ...parameterArray);
     return result;
 }
 

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -16,27 +16,16 @@ import messages from '../Messages';
  * @param {Array} expandedRows id of opened(expaned) row
  *
  */
-export const createExposedSystemsTable = ({ isLoading, payload, expandedRows }, cve) => {
-    if (isLoading) {
-        return { data: [], meta: {}, isLoading };
-    }
-
-    let { data, meta } = payload;
-
-    const cvesCount = data && data.length;
-    const tableRows = data?.map(item => ({
-        ...item.attributes,
-        id: item.id,
-        cve,
+export const createExposedSystemsRows = ({ items: { data, meta }, id }) => {
+    return data?.map(row => ({
+        id: row.id,
+        ...row.attributes,
         patchAccess: meta.patch_access || false,
-        isOpen: expandedRows.includes(item.id),
-        status: item.attributes.status_name,
-        children: item.attributes.rule
-            ? <InsightsSystemRule cve={cve} rule={item.attributes.rule} />
-            : <InsightsNoSystemRule cve={cve}/>
+        status: row.attributes.status_name,
+        children: row.attributes.rule
+            ? <InsightsSystemRule cve={id} rule={row.attributes.rule} />
+            : <InsightsNoSystemRule cve={id}/>
     }));
-
-    return { data: tableRows, meta: { ...meta, cvesCount  },  isLoading };
 
 };
 

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -11,20 +11,19 @@ import messages from '../Messages';
 /**
  * Creates the tables rows for systems exposed table
  *
- * @param {Boolean} isLoading
- * @param {Array} payload fetched data
- * @param {Array} expandedRows id of opened(expaned) row
+ * @param {Array} items fetched data
+ * @param {Array} cveId CVE id
  *
  */
-export const createExposedSystemsRows = ({ items: { data, meta }, id }) => {
+export const createExposedSystemsRows = ({ items: { data, meta }, cveId }) => {
     return data?.map(row => ({
         id: row.id,
         ...row.attributes,
         patchAccess: meta.patch_access || false,
         status: row.attributes.status_name,
         children: row.attributes.rule
-            ? <InsightsSystemRule cve={id} rule={row.attributes.rule} />
-            : <InsightsNoSystemRule cve={id}/>
+            ? <InsightsSystemRule cve={cveId} rule={row.attributes.rule} />
+            : <InsightsNoSystemRule cve={cveId}/>
     }));
 
 };

--- a/src/Helpers/CVEHelper.test.js
+++ b/src/Helpers/CVEHelper.test.js
@@ -3,7 +3,6 @@ import { processDate } from '@redhat-cloud-services/frontend-components-utilitie
 import Immutable from 'seamless-immutable';
 import { 
     createCveDetailsPage, 
-    createExposedSystemsTable, 
     createMitreLink, 
     createRHDBLink,
     cveTableRowActions,
@@ -62,24 +61,6 @@ const cves_payload = Immutable({
 });
 
 describe('CVEHelper', () => {
-    it('createExposedSystemsTable', () => {
-        const cve = 'CVE-2016-0800';
-        const page = createExposedSystemsTable({ cve, payload: affected_payload, isLoading: false, expandedRows: [] });
-        expect(page.isLoading).toEqual(false);
-        expect(page.meta).toEqual({ ...affected_payload.meta, cvesCount: 2 });
-    });
-
-    it.each`
-        affected_payload                             | expected_data
-        ${{}}                                        | ${[]}
-        ${{ payload: 'testPayload' }}                | ${[]}
-        ${{ payload: { data: ['test1', 'test2'] } }} | ${['test1', 'test2']}
-    `('createExposedSystemsTable - loading', ({ affected_payload, expected_data }) => {
-        const page = createExposedSystemsTable({ ...affected_payload, isLoading: true });
-        expect(page.isLoading).toEqual(true);
-        expect(page.data).toEqual([]);
-    });
-
     it('createCveDetailsPage', () => {
         const page = createCveDetailsPage(cves_payload);
         expect(page.meta.testObject).toEqual('testObject');

--- a/src/Helpers/DownloadReport.js
+++ b/src/Helpers/DownloadReport.js
@@ -10,9 +10,7 @@ class DownloadReport  {
             date: new Date().toISOString().replace(/[T:]/g, '-').split('.')[0] + '-utc'
         };
 
-        this.params = {
-            cve: ''
-        };
+        this.params = { cve: null };
 
         this.pages = ['systems-exposed', 'system-cves', 'cves', 'system-list'];
         this.formats = ['csv', 'json'];
@@ -76,6 +74,7 @@ class DownloadReport  {
         showNotification(this.notifications.start);
 
         this.checkTypes(fetchData, page, format);
+        this.params.cve = params?.id || null;
 
         try {
             let { payload } =

--- a/src/Helpers/DownloadReport.js
+++ b/src/Helpers/DownloadReport.js
@@ -76,16 +76,11 @@ class DownloadReport  {
         showNotification(this.notifications.start);
 
         this.checkTypes(fetchData, page, format);
-        this.params.cve = Array.isArray(params) ? params[0] : '';
 
         try {
-            let { payload } = Array.isArray(params)
-                ? await fetchData(this.params.cve, {
-                    ...params[1],
-                    ...this.defaultParams,
-                    data_format: format
-                }) :
+            let { payload } =
                 await fetchData({
+                    ...params.id && { id: params.id },
                     ...params,
                     ...this.defaultParams,
                     data_format: format

--- a/src/Helpers/DownloadReport.test.js
+++ b/src/Helpers/DownloadReport.test.js
@@ -49,10 +49,10 @@ describe('Download report', () => {
         let fetchDataMock = jest.fn((params) => Promise.resolve({payload: []}))
         let page = 'systems-exposed'
         let format = 'json'
-        let params = ['cve-123', {'arg': '1'}]
+        let params = {id: 'cve-123', 'arg': '1'}
 
-        DownloadReport.exec(fetchDataMock, params, format, page, showNotification, clearNotifications)
-        return expect(fetchDataMock).toBeCalledWith(params[0], { ...params[1], data_format: format, ...defaultParams})
+        DownloadReport.exec(fetchDataMock, params, format, page)
+        return expect(fetchDataMock).toBeCalledWith({...params, data_format: format, ...defaultParams})
     })
 
     test('Should send only the params', () => {
@@ -70,8 +70,8 @@ describe('Download report', () => {
         let fetchDataMock = jest.fn((params) => Promise.resolve({payload: { data }}))
         let page = 'systems-exposed'
         let format = 'csv'
-        let params = ['cve-123', {'arg': '1'}]
-        let filename = `vulnerability_systems-exposed-${params[0]}--${defaultParams.date}`
+        let params = {id: 'cve-123','arg': '1'};
+        let filename = `vulnerability_systems-exposed-cve-123--${defaultParams.date}`
 
         await DownloadReport.exec(fetchDataMock, params, format, page, showNotification, clearNotifications)
         return expect(downloadFile).toBeCalledWith(data, filename, format)

--- a/src/Helpers/DownloadReport.test.js
+++ b/src/Helpers/DownloadReport.test.js
@@ -51,7 +51,7 @@ describe('Download report', () => {
         let format = 'json'
         let params = {id: 'cve-123', 'arg': '1'}
 
-        DownloadReport.exec(fetchDataMock, params, format, page)
+        DownloadReport.exec(fetchDataMock, params, format, page, showNotification, clearNotifications)
         return expect(fetchDataMock).toBeCalledWith({...params, data_format: format, ...defaultParams})
     })
 

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -40,8 +40,7 @@ export const useNotification = (config) => {
     return [addNotification, clearNotifications];
 };
 
-export const useGetEntities = (fetchApi, setUrlParams) => {
-
+export const useGetEntities = (fetchApi, { id, setUrlParams }) => {
     const getEntities = async (
         _items,
         { orderBy, orderDirection, page, per_page: perPage, vulnerabilityParams }
@@ -57,7 +56,12 @@ export const useGetEntities = (fetchApi, setUrlParams) => {
 
         setUrlParams({ ...params });
 
-        const items = await fetchApi({ ...params });
+        const items = await fetchApi(
+            {
+                ...id && { id },
+                ...params
+            }
+        );
 
         return {
             results: items?.data?.map(row => ({ id: row.id, ...row.attributes })),

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -65,7 +65,7 @@ export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
 
         return {
             results: typeof createRows === 'function'
-                ? createRows({ items, id })
+                ? createRows({ items, cveId: id })
                 : items?.data?.map(row => ({ id: row.id, ...row.attributes })),
             total: items?.meta?.total_items,
             meta: items?.meta

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -40,7 +40,7 @@ export const useNotification = (config) => {
     return [addNotification, clearNotifications];
 };
 
-export const useGetEntities = (fetchApi, { id, setUrlParams }) => {
+export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
     const getEntities = async (
         _items,
         { orderBy, orderDirection, page, per_page: perPage, vulnerabilityParams }
@@ -64,8 +64,11 @@ export const useGetEntities = (fetchApi, { id, setUrlParams }) => {
         );
 
         return {
-            results: items?.data?.map(row => ({ id: row.id, ...row.attributes })),
-            total: items?.meta?.total_items
+            results: typeof createRows === 'function'
+                ? createRows({ items, id })
+                : items?.data?.map(row => ({ id: row.id, ...row.attributes })),
+            total: items?.meta?.total_items,
+            meta: items?.meta
         };
     };
 
@@ -132,7 +135,7 @@ export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handle
 
     const handleSelectAll = async () => {
 
-        let { payload } = await fetchResource({ page_size: meta.total_items, page: 1 });
+        let { payload } = await fetchResource({ page_size: meta?.total_items, page: 1 });
 
         payload.then(({ data }) => {
             handleSelect(data.map(mapSelectedRows));

--- a/src/Store/Actions/Actions.js
+++ b/src/Store/Actions/Actions.js
@@ -11,10 +11,10 @@ ReducerRegistry.register({ CVEsStore });
 ReducerRegistry.register({ SystemsPageStore });
 ReducerRegistry.register({ SystemCvesStore });
 
-export const fetchAffectedSystemsByCVE = (cve, apiProps) => ({
+export const fetchAffectedSystemsByCVE = ({ id, ...apiProps }) => ({
     type: ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE,
     payload: new Promise(resolve => {
-        resolve(APIHelper.getAffectedSystemsByCVE(cve, apiProps));
+        resolve(APIHelper.getAffectedSystemsByCVE({ id, ...apiProps }));
     }).then(result => result)
 });
 

--- a/src/Store/Reducers/CVEDetailsPageStore.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.js
@@ -4,17 +4,6 @@ import { applyGlobalFilter } from './reducersHelper';
 
 // Initial State
 export const initialState = Immutable({
-    affectedSystemsByCVE: {
-        isLoading: true,
-        expandedRows: [],
-        payload: {
-            meta: {
-                total_items: 0,
-                page: 1,
-                page_size: 20
-            }
-        }
-    },
     parameters: {
         page: 1,
         page_size: 20,
@@ -48,20 +37,6 @@ export const CVEDetailsPageStore = (state = initialState, action) => {
         case ActionTypes.FETCH_CVE_DETAILS + '_FULFILLED':
             newState = state.setIn(['cveDetails', 'payload'], action.payload);
             newState = newState.setIn(['cveDetails', 'isLoading'], false);
-            return newState;
-
-        case ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE + '_PENDING':
-            newState = state.setIn(['affectedSystemsByCVE', 'isLoading'], true);
-            return newState;
-
-        case ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE + '_FULFILLED':
-            newState = state.setIn(['affectedSystemsByCVE', 'payload'], action.payload);
-            newState = newState.setIn(['affectedSystemsByCVE', 'isLoading'], false);
-            return newState;
-
-        case ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE + '_REJECTED':
-            newState = state.setIn(['affectedSystemsByCVE', 'error'], { hasError: true, errorCode: action.payload.status });
-            newState = newState.setIn(['affectedSystemsByCVE', 'isLoading'], false);
             return newState;
 
         case ActionTypes.CHANGE_EXPOSED_SYSTEMS_PARAMETERS:

--- a/src/Store/Reducers/CVEDetailsPageStore.test.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.test.js
@@ -19,17 +19,6 @@ describe('CVE reducer:', () => {
         expect(CVEDetailsPageStore(undefined, action)).toEqual(initialState);
     });
 
-    it('Should start loading CVE_List for a system', () => {
-        action.type = ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE + '_PENDING';
-        expect(CVEDetailsPageStore(undefined, action).affectedSystemsByCVE.isLoading).toEqual(true);
-    });
-
-    it('Should load CVE_List for a system', () => {
-        let testObject = { testObject: 'value' };
-        action.type = ActionTypes.FETCH_AFFECTED_SYSTEMS_BY_CVE + '_FULFILLED';
-        action.payload = testObject;
-        expect(CVEDetailsPageStore(undefined, action).affectedSystemsByCVE).toEqual({ isLoading: false, payload: testObject, expandedRows: [] });
-    });
 
     it('Should start loading CVE Details ', () => {
         action.type = ActionTypes.FETCH_CVE_DETAILS + '_PENDING';


### PR DESCRIPTION
Simplifying apiHelper to accept an object of params instead of 2 different params. 
Use getEntities for exposed system table