### PR TITLE
VULN-1296 fix(security rules): Introduce new filter for rules in exposed system…

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -43,8 +43,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
     const sortedRules = [].concat(rules).sort((a, b) => (b.systems_affected - a.systems_affected));
 
     const handleExposedSystemFilter = (ruleId) => {
-        const params = { rule_key: ruleId, rule_presence: 'true' };
-        dispatch(changeExposedSystemsParameters(params));
+        dispatch(changeExposedSystemsParameters({ rule: ruleId }));
     };
 
     return <Fragment>
@@ -71,7 +70,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                         >
                                             <Link
                                                 key={rule.rule_id}
-                                                to={`/cves/${synopsis}/?rule_key=${rule.rule_id}`}
+                                                to={`/cves/${synopsis}/?rule=${rule.rule_id}`}
                                             >
                                                 {
                                                     intl.formatMessage(

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
@@ -293,6 +293,6 @@ describe('CSAW Rule Box', () => {
         const dispatchedActions = store.getActions();
         const action = dispatchedActions.filter(item => item.type === 'CHANGE_SYSTEM_CVE_LIST_PARAMETERS');
         expect(fetchMock).toBeCalledTimes(1)
-        expect(fetchMock).toHaveBeenCalledWith({ rule_key: rules[0].rule_id, rule_presence: "true" })
+        expect(fetchMock).toHaveBeenCalledWith({ rule: rules[0].rule_id })
     });
 });

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -177,7 +177,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           onClick={[Function]}
                         >
                           <Link
-                            to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                           >
                             Filter by affected systems
                           </Link>
@@ -411,14 +411,14 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                     >
                                       <Link
                                         key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                       >
                                         <LinkAnchor
-                                          href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                           navigate={[Function]}
                                         >
                                           <a
-                                            href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                             onClick={[Function]}
                                           >
                                             Filter by affected systems
@@ -1352,7 +1352,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           onClick={[Function]}
                         >
                           <Link
-                            to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                           >
                             Filter by affected systems
                           </Link>
@@ -1586,14 +1586,14 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                     >
                                       <Link
                                         key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        to="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                       >
                                         <LinkAnchor
-                                          href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                           navigate={[Function]}
                                         >
                                           <a
-                                            href="/cves/CVE-2019-11135/?rule_key=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
                                             onClick={[Function]}
                                           >
                                             Filter by affected systems

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.js
@@ -6,22 +6,29 @@ import messages from '../../../../Messages';
 import unionWith from 'lodash/unionWith';
 import isEqual from 'lodash/isEqual';
 
-const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
+const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = [], { ...config }) => {
     let currentValue = [];
     if (currentFilter.rule_presence) {
         currentValue = currentValue.concat(currentFilter.rule_presence.split(','));
     }
 
-    if (currentFilter.rule_key) {
-        currentValue = currentValue.concat(currentFilter.rule_key.split(','));
+    if (currentFilter.rule) {
+        currentValue = currentValue.concat(currentFilter.rule.split(','));
     }
 
     const filterBySecurityRule = values => {
+
         apply({
-            rule_presence: values.filter(value => ['true', 'false'].includes(value)).join(',') || undefined,
-            rule_key: values.filter(value => !['true', 'false'].includes(value)).join(',') || undefined,
+            ...config.isDynamic && { rule: values.join(',') || undefined },
+            ...!config.isDynamic && { rule_presence: values.join(',') || undefined },
             page: 1
         });
+    };
+
+    const dropdownItems	= () => {
+        const items = config.dropdownItems ? config.dropdownItems : RULE_PRESENCE_OPTIONS;
+
+        return unionWith(items, dynamicFilters, isEqual).map(({ label, value }) => ({ label, value }));
     };
 
     return {
@@ -31,8 +38,7 @@ const securityRuleFilter = (apply, currentFilter = {}, dynamicFilters = []) => {
             onChange: (event, value) => {
                 filterBySecurityRule(value);
             },
-            items:
-                unionWith(RULE_PRESENCE_OPTIONS, dynamicFilters, isEqual).map(item => ({ label: item.label, value: item.value })),
+            items: dropdownItems(),
             value: currentValue
         }
     };

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter.test.js
@@ -41,23 +41,55 @@ describe('SecurityRuleFilter', () => {
         comp = securityRuleFilter(applyMock, '5')
         expect(comp.filterValues.value).toMatchObject([])
 
-        comp = securityRuleFilter(applyMock, {rule_presence: 'true', rule_key: 'some_rule'})
+        comp = securityRuleFilter(applyMock, {rule_presence: 'true', rule: 'some_rule'})
         expect(comp.filterValues.value).toMatchObject(['true', 'some_rule'])
 
     })
 
     it('Should use the passed currentValue ', () => {
-        let currentFilter = { rule_presence: 'true', rule_key: 'some_rule' }
+        let currentFilter = { rule_presence: 'true', rule: 'some_rule' }
         let comp = securityRuleFilter(applyMock, currentFilter)
         expect(comp.filterValues.value).toMatchObject(['true', 'some_rule'])
     })
 
     it('Should call apply with params', () => {
         let comp = securityRuleFilter(applyMock, undefined)
-        comp.filterValues.onChange('event', ['true', 'some_rule'])
-        expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "true", "rule_key": "some_rule"})
+        comp.filterValues.onChange('event', ['true'])
+        expect(applyMock).toBeCalledWith({"page": 1, "rule_presence": "true"})
 
         comp.filterValues.onChange('event', [])
         expect(applyMock).toBeCalledWith({"page": 1})
+    })
+
+    it('Should call apply with dynamic prams', () => {
+        const dropdownItems = [ 
+            { label: 'Does not have security rule', value: 'false' }
+        ]
+        const dynamic = [
+            { label: 'security rule 1', value: '1' },
+            { label: 'security rule 1', value: '1' },
+            { label: 'security rule 2', value: '2' },
+
+        ]
+        const options = [ 
+            { label: 'Does not have security rule', value: 'false' },
+            { label: 'security rule 1', value: '1' },
+            { label: 'security rule 2', value: '2' }
+        ]
+  
+        const comp = securityRuleFilter(
+            applyMock,
+             '',
+            dynamic, 
+            {
+                isDynamic: true,
+                dropdownItems
+            }
+        )
+
+        comp.filterValues.onChange('event', ['security rule 1'])
+        expect(applyMock).toBeCalledWith({"page": 1, "rule": "security rule 1"})
+
+        expect(comp.filterValues.items).toStrictEqual(options)
     })
 })

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -30,7 +30,8 @@ import {
 import {
     SYSTEMS_EXPOSED_HEADER,
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
-    SYSTEMS_EXPOSED_SORTING_HEADER
+    SYSTEMS_EXPOSED_SORTING_HEADER,
+    RULE_ABSENSE_OPTIONS
 } from '../../../Helpers/constants';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -293,7 +294,15 @@ const SystemsExposedTable = (props) => {
                                 filterConfig={{
                                     items: [
                                         searchFilter,
-                                        securityRuleFilter(apply, parameters, props.filterRuleValues),
+                                        securityRuleFilter(
+                                            apply,
+                                            parameters,
+                                            props.filterRuleValues,
+                                            {
+                                                isDynamic: true,
+                                                dropdownItems: RULE_ABSENSE_OPTIONS
+                                            }
+                                        ),
                                         statusFilter(apply, parameters),
                                         advisoryFilter
                                     ]

--- a/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTable.test.js.snap
@@ -540,10 +540,6 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                           "filterValues": Object {
                                             "items": Array [
                                               Object {
-                                                "label": "Has security rule",
-                                                "value": "true",
-                                              },
-                                              Object {
                                                 "label": "Does not have security rule",
                                                 "value": "false",
                                               },
@@ -868,10 +864,6 @@ exports[`SystemsExposedPage Should render without props 1`] = `
                                           Object {
                                             "filterValues": Object {
                                               "items": Array [
-                                                Object {
-                                                  "label": "Has security rule",
-                                                  "value": "true",
-                                                },
                                                 Object {
                                                   "label": "Does not have security rule",
                                                   "value": "false",

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -45,10 +45,10 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
 
     // FIXME please!!!
     const filterChips = Object.keys(FILTERS).reduce((array, key) => {
-        if (key === 'security_rule' && (hasValue(currentFilters, 'rule_presence') || hasValue(currentFilters, 'rule_key'))) {
+        if (key === 'security_rule' && (hasValue(currentFilters, 'rule_presence') || hasValue(currentFilters, 'rule'))) {
             const multiValue = [].concat(
                 currentFilters.rule_presence ? currentFilters.rule_presence.split(',') : [],
-                currentFilters.rule_key ? currentFilters.rule_key.split(',') : []);
+                currentFilters.rule ? currentFilters.rule.split(',') : []);
             array.push({ key, multiValue, category: FILTERS[key].title, chips: buildChips(multiValue, key) });
         }
         else if (key === 'cvss_filter' && (hasValue(currentFilters, 'cvss_from') || hasValue(currentFilters, 'cvss_to'))) {
@@ -101,7 +101,7 @@ export const removeFilters = (chips, apply, reset = false, defaultFilters = {}) 
         if (item.key === 'security_rule') {
             const remainingValues = item.multiValue.filter(value => !item.chips.some(chip => chip.value === value));
             obj.rule_presence = remainingValues.filter(value => ['true', 'false'].includes(value)).join(',') || '';
-            obj.rule_key = remainingValues.filter(value => !['true', 'false'].includes(value)).join(',') || '';
+            obj.rule = remainingValues.filter(value => !['true', 'false'].includes(value)).join(',') || '';
         }
         else if (item.key === 'filter' || item.key === 'advisory' || (item.multiValue && item.multiValue.length === 1)) {
             obj[item.key] = '';

--- a/src/Helpers/TableToolbarHelper.test.js
+++ b/src/Helpers/TableToolbarHelper.test.js
@@ -146,7 +146,7 @@ describe('TableToolbarHelper', () => {
 
     it('Should remove filters', () => {
         removeFilters([mockGeneralChip], mockApply);
-        expect(mockApply).toHaveBeenCalledWith({ rule_presence: '', rule_key: '', page: 1 });
+        expect(mockApply).toHaveBeenCalledWith({ rule_presence: '', rule: '', page: 1 });
     });
 
     it('Should remove search filters and multi value filters with only one value safely', () => {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -93,6 +93,9 @@ export const RULE_PRESENCE_OPTIONS = [
     { value: 'false', label: intl.formatMessage(messages.withoutSecurityRule) }
 ];
 
+// exposed table can filter out only without rules systems
+export const RULE_ABSENSE_OPTIONS = [RULE_PRESENCE_OPTIONS[1]];
+
 // NOTE value is passed as string cause there is a bug in ConditionalFilter
 // when you pass boolean (true, false) onChange returns 1 instead of false
 export const KNOWN_EXPLOIT_FILTER_OPTIONS = [
@@ -577,6 +580,7 @@ export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = [
     'uuid',
     'rule_key',
     'rule_presence',
+    'rule',
     'tags',
     'sap_sids',
     'sap_system',


### PR DESCRIPTION
For the exposed system table where we used to combine the filters `rule_presense` and `rule_key` have been combined to one filter `rule` in the backend. The PR contains the changes in the frontend to support it. 

![image](https://user-images.githubusercontent.com/3369346/128694231-51d5b650-9cbf-4a7e-a891-1215e5cff0d2.png)

