### PR TITLE
fix(CVE detail page): Update skeleton loading

### DIFF
--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/CVEDetailsPageDescription.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/CVEDetailsPageDescription.js
@@ -3,6 +3,8 @@ import propTypes from 'prop-types';
 import React from 'react';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
+import { CVEPageContext } from '../../SmartComponents/CVEDetailsPage/CVEDetailsPage';
+import WithLoader, { LoaderType } from '../WithLoader/WithLoader';
 
 const CVEDetailsPageDescription = ({ cveAttributes, intl }) => {
     const {
@@ -12,21 +14,38 @@ const CVEDetailsPageDescription = ({ cveAttributes, intl }) => {
     } = cveAttributes;
 
     return (
-        <Stack hasGutter>
-            <StackItem className="pf-u-mt-sm">
-                <div>
-                    {intl.formatMessage(messages.publishDate)}: {publishDate}
-                </div>
-            </StackItem>
-            <StackItem>
-                <TextContent>
-                    <Text component={TextVariants.p}>{description}</Text>
-                </TextContent>
-            </StackItem>
-            <StackItem className="pf-u-mt-sm pf-u-mb-md">
-                {link}
-            </StackItem>
-        </Stack>
+        <CVEPageContext.Consumer>
+            {context =>
+                <Stack hasGutter>
+                    <StackItem className="pf-u-mt-sm">
+                        <div>
+                            <span className="pf-u-mr-xs">{intl.formatMessage(messages.publishDate)}:</span>
+                            <WithLoader
+                                isLoading={context.isLoading}
+                                variant={LoaderType.inlineSkeleton}
+                                style={{ width: '100px' }}
+                            >
+                                {publishDate}
+                            </WithLoader>
+                        </div>
+                    </StackItem>
+                    <StackItem>
+                        <WithLoader
+                            isLoading={context.isLoading}
+                            variant={LoaderType.rectangle}
+                            style={{ height: '132px', width: '100%' }}
+                        >
+                            <TextContent style={{ textAlign: 'justify' }}>
+                                <Text component={TextVariants.p}>{description}</Text>
+                            </TextContent>
+                        </WithLoader>
+                    </StackItem>
+                    <StackItem className="pf-u-mt-sm pf-u-mb-md">
+                        {link}
+                    </StackItem>
+                </Stack>
+            }
+        </CVEPageContext.Consumer>
 
     );
 };

--- a/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/CVEDetailsPageDescription.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageDescription/__snapshots__/CVEDetailsPageDescription.test.js.snap
@@ -95,9 +95,44 @@ exports[`CVEDetailsPageDescription component should render without props 1`] = `
             className="pf-l-stack__item pf-u-mt-sm"
           >
             <div>
-              Publish date
-              : 
-              12 May 2020
+              <span
+                className="pf-u-mr-xs"
+              >
+                Publish date
+                :
+              </span>
+              <WithLoader
+                isLoading={true}
+                style={
+                  Object {
+                    "width": "100px",
+                  }
+                }
+                variant="inlineSkeleton"
+              >
+                <Skeleton
+                  isDark={false}
+                  size="lg"
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "width": "100px",
+                    }
+                  }
+                >
+                  <div
+                    className="ins-c-skeleton ins-c-skeleton__lg"
+                    style={
+                      Object {
+                        "display": "inline-block",
+                        "width": "100px",
+                      }
+                    }
+                  >
+                     
+                  </div>
+                </Skeleton>
+              </WithLoader>
             </div>
           </div>
         </StackItem>
@@ -105,25 +140,41 @@ exports[`CVEDetailsPageDescription component should render without props 1`] = `
           <div
             className="pf-l-stack__item"
           >
-            <TextContent>
-              <div
-                className="pf-c-content"
+            <WithLoader
+              isLoading={true}
+              style={
+                Object {
+                  "height": "132px",
+                  "width": "100%",
+                }
+              }
+              variant="rectangle"
+            >
+              <Skeleton
+                isDark={false}
+                shape="square"
+                size="md"
+                style={
+                  Object {
+                    "height": "132px",
+                    "width": "100%",
+                  }
+                }
               >
-                <Text
-                  component="p"
+                <div
+                  className="ins-c-skeleton ins-c-skeleton__md"
+                  shape="square"
+                  style={
+                    Object {
+                      "height": "132px",
+                      "width": "100%",
+                    }
+                  }
                 >
-                  <p
-                    className=""
-                    data-ouia-component-id="OUIA-Generated-Text-1"
-                    data-ouia-component-type="PF4/Text"
-                    data-ouia-safe={true}
-                    data-pf-content={true}
-                  >
-                    It was found that ghostscript could leak sensitive operators on the operand stack when a pseudo-operator pushes a subroutine. A specially crafted PostScript file could use this flaw to escape the -dSAFER protection in order to, for example, have access to the file system and execute commands.
-                  </p>
-                </Text>
-              </div>
-            </TextContent>
+                   
+                </div>
+              </Skeleton>
+            </WithLoader>
           </div>
         </StackItem>
         <StackItem

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/CVEDetailsPageSidebar.js
@@ -12,6 +12,8 @@ import { STATUS_OPTIONS } from '../../../Helpers/constants';
 import { injectIntl } from 'react-intl';
 import { Shield } from '@redhat-cloud-services/frontend-components/Shield';
 import Label from '../Snippets/Label';
+import { CVEPageContext } from '../../SmartComponents/CVEDetailsPage/CVEDetailsPage';
+import WithLoader from '../WithLoader/WithLoader';
 
 const CVEDetailsPageSidebar = ({ cveAttributes, intl }) => {
     const cveDetails = getImpactDetails(cveAttributes.impact || 'Unknown');
@@ -50,7 +52,6 @@ const CVEDetailsPageSidebar = ({ cveAttributes, intl }) => {
                     {intl.formatMessage(messages.cveStatus)}
                 </Label>
                 {status || '--'}
-
                 <Label className="pf-u-mb-xs pf-u-mt-sm">
                     {intl.formatMessage(messages.justificationNote)}
                 </Label>
@@ -81,50 +82,61 @@ const CVEDetailsPageSidebar = ({ cveAttributes, intl }) => {
     );
 
     return (
-        <Stack hasGutter>
-            <StackItem>
-                <Split hasGutter>
-                    <SplitItem>
-                        <SnippetWithHeaderAndPopover
-                            title={intl.formatMessage(messages.businessRiskLabel)}
-                            value={businessRisk}
-                            content={brPopoverContent}
-                        />
-                    </SplitItem>
-                    <SplitItem className="pf-u-ml-lg">
-                        <SnippetWithHeaderAndPopover
-                            title={intl.formatMessage(messages.statusLabel)}
-                            content={statusPopoverContent}
-                            value={
-                                <span>
-                                    {systemsStatusDivergent > 0 && (
-                                        <ExclamationTriangleIcon color={'var(--pf-global--primary-color--100)'} />
-                                    )}{' '}
-                                    {status}
-                                </span>
-                            }
-                        />
-                    </SplitItem>
-                </Split>
-            </StackItem>
+        <CVEPageContext.Consumer>
+            {context => (
+                <Stack hasGutter>
+                    <StackItem>
+                        <Split hasGutter>
+                            <SplitItem>
+                                <SnippetWithHeaderAndPopover
+                                    title={intl.formatMessage(messages.businessRiskLabel)}
+                                    value={
+                                        <WithLoader isLoading={context.isLoading} style={{ width: '100px' }}>
+                                            {businessRisk}
+                                        </WithLoader>}
+                                    content={brPopoverContent}
+                                />
+                            </SplitItem>
+                            <SplitItem className="pf-u-ml-lg">
+                                <SnippetWithHeaderAndPopover
+                                    title={intl.formatMessage(messages.statusLabel)}
+                                    content={statusPopoverContent}
+                                    value={
+                                        <WithLoader isLoading={context.isLoading} style={{ width: '100px' }}>
+                                            <span>
+                                                {systemsStatusDivergent > 0 && (
+                                                    <ExclamationTriangleIcon color={'var(--pf-global--primary-color--100)'} />
+                                                )}{' '}
+                                                {status}
+                                            </span>
+                                        </WithLoader>
+                                    }
+                                />
+                            </SplitItem>
+                        </Split>
+                    </StackItem>
 
-            <StackItem>
-                <Label className="pf-u-mb-xs" isLarge>
-                    {intl.formatMessage(messages.impact)}
-                </Label>
-                <span id="severity-shield" style={{ color: cveDetails.color }}>
-                    <Shield impact={cveDetails.title} hasLabel/>
-                </span>
-            </StackItem>
+                    <StackItem>
+                        <Label className="pf-u-mb-xs" isLarge>
+                            {intl.formatMessage(messages.impact)}
+                        </Label>
+                        <WithLoader isLoading={context.isLoading} style={{ width: '100px' }}>
+                            <span id="severity-shield" style={{ color: cveDetails.color }}>
+                                <Shield impact={cveDetails.title} hasLabel />
+                            </span>
+                        </WithLoader>
+                    </StackItem>
 
-            <StackItem>
-                <CvssVector
-                    cvss2_metrics={cveAttributes.cvss2_metrics}
-                    cvss3_metrics={cveAttributes.cvss3_metrics}
-                    score={parseCvssScore(cveAttributes.cvss2_score, cveAttributes.cvss3_score)}
-                />
-            </StackItem>
-        </Stack>
+                    <StackItem>
+                        <CvssVector
+                            cvss2_metrics={cveAttributes.cvss2_metrics}
+                            cvss3_metrics={cveAttributes.cvss3_metrics}
+                            score={parseCvssScore(cveAttributes.cvss2_score, cveAttributes.cvss3_score)}
+                        />
+                    </StackItem>
+                </Stack>
+            )}
+        </CVEPageContext.Consumer>
     );
 };
 

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
@@ -906,7 +906,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           colSize={2}
                           isLoading={true}
                           rowSize={8}
-                          variant="compact"
+                          variant="compactTable"
                         >
                           <Table
                             aria-label="Metric breakdown"
@@ -1046,7 +1046,7 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                                   colSize={2}
                                   isLoading={true}
                                   rowSize={8}
-                                  variant="compact"
+                                  variant="compactTable"
                                 >
                                   <Table
                                     aria-label="Metric breakdown"

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
@@ -130,7 +130,18 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                         </Stack>
                       }
                       title="Business risk"
-                      value="Low"
+                      value={
+                        <WithLoader
+                          isLoading={true}
+                          style={
+                            Object {
+                              "width": "100px",
+                            }
+                          }
+                        >
+                          Low
+                        </WithLoader>
+                      }
                     >
                       <Popover
                         appendTo={null}
@@ -252,7 +263,16 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                               </StackItem>
                               <StackItem>
                                 <a>
-                                  Low
+                                  <WithLoader
+                                    isLoading={true}
+                                    style={
+                                      Object {
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                    Low
+                                  </WithLoader>
                                 </a>
                               </StackItem>
                             </Stack>
@@ -294,7 +314,35 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                                     className="pf-l-stack__item"
                                   >
                                     <a>
-                                      Low
+                                      <WithLoader
+                                        isLoading={true}
+                                        style={
+                                          Object {
+                                            "width": "100px",
+                                          }
+                                        }
+                                      >
+                                        <Skeleton
+                                          isDark={false}
+                                          size="lg"
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        >
+                                          <div
+                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                            style={
+                                              Object {
+                                                "width": "100px",
+                                              }
+                                            }
+                                          >
+                                             
+                                          </div>
+                                        </Skeleton>
+                                      </WithLoader>
                                     </a>
                                   </div>
                                 </StackItem>
@@ -387,15 +435,24 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                       }
                       title="Status"
                       value={
-                        <span>
-                          <ExclamationTriangleIcon
-                            color="var(--pf-global--primary-color--100)"
-                            noVerticalAlign={false}
-                            size="sm"
-                          />
-                           
-                          Resolved
-                        </span>
+                        <WithLoader
+                          isLoading={true}
+                          style={
+                            Object {
+                              "width": "100px",
+                            }
+                          }
+                        >
+                          <span>
+                            <ExclamationTriangleIcon
+                              color="var(--pf-global--primary-color--100)"
+                              noVerticalAlign={false}
+                              size="sm"
+                            />
+                             
+                            Resolved
+                          </span>
+                        </WithLoader>
                       }
                     >
                       <Popover
@@ -630,15 +687,24 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                               </StackItem>
                               <StackItem>
                                 <a>
-                                  <span>
-                                    <ExclamationTriangleIcon
-                                      color="var(--pf-global--primary-color--100)"
-                                      noVerticalAlign={false}
-                                      size="sm"
-                                    />
-                                     
-                                    Resolved
-                                  </span>
+                                  <WithLoader
+                                    isLoading={true}
+                                    style={
+                                      Object {
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                    <span>
+                                      <ExclamationTriangleIcon
+                                        color="var(--pf-global--primary-color--100)"
+                                        noVerticalAlign={false}
+                                        size="sm"
+                                      />
+                                       
+                                      Resolved
+                                    </span>
+                                  </WithLoader>
                                 </a>
                               </StackItem>
                             </Stack>
@@ -680,34 +746,35 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                                     className="pf-l-stack__item"
                                   >
                                     <a>
-                                      <span>
-                                        <ExclamationTriangleIcon
-                                          color="var(--pf-global--primary-color--100)"
-                                          noVerticalAlign={false}
-                                          size="sm"
+                                      <WithLoader
+                                        isLoading={true}
+                                        style={
+                                          Object {
+                                            "width": "100px",
+                                          }
+                                        }
+                                      >
+                                        <Skeleton
+                                          isDark={false}
+                                          size="lg"
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
                                         >
-                                          <svg
-                                            aria-hidden={true}
-                                            aria-labelledby={null}
-                                            fill="var(--pf-global--primary-color--100)"
-                                            height="1em"
-                                            role="img"
+                                          <div
+                                            className="ins-c-skeleton ins-c-skeleton__lg"
                                             style={
                                               Object {
-                                                "verticalAlign": "-0.125em",
+                                                "width": "100px",
                                               }
                                             }
-                                            viewBox="0 0 576 512"
-                                            width="1em"
                                           >
-                                            <path
-                                              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                            />
-                                          </svg>
-                                        </ExclamationTriangleIcon>
-                                         
-                                        Resolved
-                                      </span>
+                                             
+                                          </div>
+                                        </Skeleton>
+                                      </WithLoader>
                                     </a>
                                   </div>
                                 </StackItem>
@@ -743,140 +810,35 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                 Severity
               </span>
             </Label>
-            <span
-              id="severity-shield"
+            <WithLoader
+              isLoading={true}
               style={
                 Object {
-                  "color": "var(--pf-global--palette--orange-400)",
+                  "width": "100px",
                 }
               }
             >
-              <Shield
-                hasLabel={true}
-                hasTooltip={true}
-                impact="Important"
-                size="sm"
+              <Skeleton
+                isDark={false}
+                size="lg"
+                style={
+                  Object {
+                    "width": "100px",
+                  }
+                }
               >
-                <span>
-                  <Tooltip
-                    content={
-                      <div>
-                        This rating is given to flaws that can easily compromise the     confidentiality, integrity, or availability of resources. These are the     types of vulnerabilities that allow local users to gain privileges, allow     unauthenticated remote users to view resources that should otherwise be     protected by authentication, allow authenticated remote users to execute     arbitrary code, or allow remote users to cause a denial of service.
-                      </div>
+                <div
+                  className="ins-c-skeleton ins-c-skeleton__lg"
+                  style={
+                    Object {
+                      "width": "100px",
                     }
-                    position="bottom"
-                  >
-                    <Popper
-                      appendTo={[Function]}
-                      distance={15}
-                      enableFlip={true}
-                      flipBehavior={
-                        Array [
-                          "top",
-                          "right",
-                          "bottom",
-                          "left",
-                          "top",
-                          "right",
-                          "bottom",
-                        ]
-                      }
-                      isVisible={false}
-                      onBlur={[Function]}
-                      onDocumentClick={false}
-                      onDocumentKeyDown={[Function]}
-                      onFocus={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onTriggerEnter={[Function]}
-                      placement="bottom"
-                      popper={
-                        <div
-                          className="pf-c-tooltip"
-                          id="pf-tooltip-2"
-                          role="tooltip"
-                          style={
-                            Object {
-                              "maxWidth": null,
-                              "opacity": 0,
-                              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                            }
-                          }
-                        >
-                          <TooltipArrow />
-                          <TooltipContent
-                            isLeftAligned={false}
-                          >
-                            <div>
-                              This rating is given to flaws that can easily compromise the     confidentiality, integrity, or availability of resources. These are the     types of vulnerabilities that allow local users to gain privileges, allow     unauthenticated remote users to view resources that should otherwise be     protected by authentication, allow authenticated remote users to execute     arbitrary code, or allow remote users to cause a denial of service.
-                            </div>
-                          </TooltipContent>
-                        </div>
-                      }
-                      popperMatchesTriggerWidth={false}
-                      positionModifiers={
-                        Object {
-                          "bottom": "pf-m-bottom",
-                          "left": "pf-m-left",
-                          "right": "pf-m-right",
-                          "top": "pf-m-top",
-                        }
-                      }
-                      trigger={
-                        <span>
-                          <SecurityIcon
-                            aria-hidden="false"
-                            aria-label="Important"
-                            color="#ec7a08"
-                            noVerticalAlign={false}
-                            size="sm"
-                          />
-                           
-                          Important
-                        </span>
-                      }
-                      zIndex={9999}
-                    >
-                      <FindRefWrapper
-                        onFoundRef={[Function]}
-                      >
-                        <span>
-                          <SecurityIcon
-                            aria-hidden="false"
-                            aria-label="Important"
-                            color="#ec7a08"
-                            noVerticalAlign={false}
-                            size="sm"
-                          >
-                            <svg
-                              aria-hidden="false"
-                              aria-label="Important"
-                              aria-labelledby={null}
-                              fill="#ec7a08"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 896 1024"
-                              width="1em"
-                            >
-                              <path
-                                d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
-                              />
-                            </svg>
-                          </SecurityIcon>
-                           
-                          Important
-                        </span>
-                      </FindRefWrapper>
-                    </Popper>
-                  </Tooltip>
-                </span>
-              </Shield>
-            </span>
+                  }
+                >
+                   
+                </div>
+              </Skeleton>
+            </WithLoader>
           </div>
         </StackItem>
         <StackItem>
@@ -938,29 +900,326 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                   <div
                     className="pf-c-content"
                   >
-                    <WithLoader
-                      loading={true}
-                    >
-                      <Skeleton
-                        isDark={false}
-                        size="lg"
-                      >
-                        <div
-                          className="ins-c-skeleton ins-c-skeleton__lg"
+                    <Popover
+                      bodyContent={
+                        <WithLoader
+                          colSize={2}
+                          isLoading={true}
+                          rowSize={8}
+                          variant="compact"
                         >
-                           
-                        </div>
-                      </Skeleton>
-                    </WithLoader>
+                          <Table
+                            aria-label="Metric breakdown"
+                            borders={true}
+                            canSelectAll={true}
+                            canSortFavorites={true}
+                            cells={
+                              Array [
+                                "Metric",
+                                "Value",
+                              ]
+                            }
+                            className=""
+                            contentId="expanded-content"
+                            dropdownDirection="down"
+                            dropdownPosition="right"
+                            expandId="expandable-toggle"
+                            gridBreakPoint=""
+                            isStickyHeader={false}
+                            isTreeTable={false}
+                            ouiaSafe={true}
+                            role="grid"
+                            rowLabeledBy="simple-node"
+                            rows={
+                              Array [
+                                Array [
+                                  "Attack vector",
+                                  "Local",
+                                ],
+                                Array [
+                                  "Attack complexity",
+                                  "Low",
+                                ],
+                                Array [
+                                  "Privileges required",
+                                  "Low",
+                                ],
+                                Array [
+                                  "User interaction",
+                                  "None",
+                                ],
+                                Array [
+                                  "Scope",
+                                  "Unchanged",
+                                ],
+                                Array [
+                                  "Confidentiality",
+                                  "High",
+                                ],
+                                Array [
+                                  "Integrity",
+                                  "High",
+                                ],
+                                Array [
+                                  "Availability",
+                                  "High",
+                                ],
+                              ]
+                            }
+                            selectVariant="checkbox"
+                            variant="compact"
+                          >
+                            <TableHeader />
+                            <Unknown />
+                          </Table>
+                        </WithLoader>
+                      }
+                      enableFlip={true}
+                      headerContent="CVSS 3.0  vector breakdown"
+                      id="popover-cvss"
+                      maxWidth="100%"
+                      position="bottom"
+                    >
+                      <Popper
+                        appendTo={[Function]}
+                        distance={25}
+                        enableFlip={true}
+                        flipBehavior={
+                          Array [
+                            "top",
+                            "right",
+                            "bottom",
+                            "left",
+                            "top",
+                            "right",
+                            "bottom",
+                          ]
+                        }
+                        isVisible={false}
+                        onDocumentClick={[Function]}
+                        onDocumentKeyDown={[Function]}
+                        onTriggerClick={[Function]}
+                        onTriggerEnter={[Function]}
+                        placement="bottom"
+                        popper={
+                          <FocusTrap
+                            active={false}
+                            aria-describedby="popover-popover-cvss-body"
+                            aria-labelledby="popover-popover-cvss-header"
+                            aria-modal="true"
+                            className="pf-c-popover"
+                            focusTrapOptions={
+                              Object {
+                                "clickOutsideDeactivates": true,
+                                "fallbackFocus": [Function],
+                                "returnFocusOnDeactivate": true,
+                              }
+                            }
+                            onMouseDown={[Function]}
+                            paused={false}
+                            preventScrollOnDeactivate={true}
+                            role="dialog"
+                            style={
+                              Object {
+                                "maxWidth": "100%",
+                                "minWidth": null,
+                                "opacity": 0,
+                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                              }
+                            }
+                          >
+                            <PopoverArrow />
+                            <PopoverContent>
+                              <PopoverCloseButton
+                                aria-label="Close"
+                                onClose={[Function]}
+                              />
+                              <PopoverHeader
+                                id="popover-popover-cvss-header"
+                              >
+                                CVSS 3.0  vector breakdown
+                              </PopoverHeader>
+                              <PopoverBody
+                                id="popover-popover-cvss-body"
+                              >
+                                <WithLoader
+                                  colSize={2}
+                                  isLoading={true}
+                                  rowSize={8}
+                                  variant="compact"
+                                >
+                                  <Table
+                                    aria-label="Metric breakdown"
+                                    borders={true}
+                                    canSelectAll={true}
+                                    canSortFavorites={true}
+                                    cells={
+                                      Array [
+                                        "Metric",
+                                        "Value",
+                                      ]
+                                    }
+                                    className=""
+                                    contentId="expanded-content"
+                                    dropdownDirection="down"
+                                    dropdownPosition="right"
+                                    expandId="expandable-toggle"
+                                    gridBreakPoint=""
+                                    isStickyHeader={false}
+                                    isTreeTable={false}
+                                    ouiaSafe={true}
+                                    role="grid"
+                                    rowLabeledBy="simple-node"
+                                    rows={
+                                      Array [
+                                        Array [
+                                          "Attack vector",
+                                          "Local",
+                                        ],
+                                        Array [
+                                          "Attack complexity",
+                                          "Low",
+                                        ],
+                                        Array [
+                                          "Privileges required",
+                                          "Low",
+                                        ],
+                                        Array [
+                                          "User interaction",
+                                          "None",
+                                        ],
+                                        Array [
+                                          "Scope",
+                                          "Unchanged",
+                                        ],
+                                        Array [
+                                          "Confidentiality",
+                                          "High",
+                                        ],
+                                        Array [
+                                          "Integrity",
+                                          "High",
+                                        ],
+                                        Array [
+                                          "Availability",
+                                          "High",
+                                        ],
+                                      ]
+                                    }
+                                    selectVariant="checkbox"
+                                    variant="compact"
+                                  >
+                                    <TableHeader />
+                                    <Unknown />
+                                  </Table>
+                                </WithLoader>
+                              </PopoverBody>
+                            </PopoverContent>
+                          </FocusTrap>
+                        }
+                        popperMatchesTriggerWidth={false}
+                        positionModifiers={
+                          Object {
+                            "bottom": "pf-m-bottom",
+                            "left": "pf-m-left",
+                            "right": "pf-m-right",
+                            "top": "pf-m-top",
+                          }
+                        }
+                        trigger={
+                          <React.Fragment>
+                            <Label
+                              className="pf-u-mb-xs pointer"
+                              isLarge={true}
+                            >
+                              CVSS 3.0
+                               
+                               base score
+                              <OutlinedQuestionCircleIcon
+                                className="pf-u-ml-xs"
+                                color="var(--pf-global--secondary-color--100)"
+                                noVerticalAlign={false}
+                                size="sm"
+                              />
+                            </Label>
+                          </React.Fragment>
+                        }
+                        zIndex={9999}
+                      >
+                        <FindRefWrapper
+                          onFoundRef={[Function]}
+                        >
+                          <Label
+                            className="pf-u-mb-xs pointer"
+                            isLarge={true}
+                          >
+                            <span
+                              className="vuln-label pf-u-mb-xs pointer"
+                              style={
+                                Object {
+                                  "display": "block",
+                                  "fontSize": "medium",
+                                }
+                              }
+                            >
+                              CVSS 3.0
+                               
+                               base score
+                              <OutlinedQuestionCircleIcon
+                                className="pf-u-ml-xs"
+                                color="var(--pf-global--secondary-color--100)"
+                                noVerticalAlign={false}
+                                size="sm"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  className="pf-u-ml-xs"
+                                  fill="var(--pf-global--secondary-color--100)"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                  />
+                                </svg>
+                              </OutlinedQuestionCircleIcon>
+                            </span>
+                          </Label>
+                        </FindRefWrapper>
+                      </Popper>
+                    </Popover>
                     <WithLoader
-                      loading={true}
+                      isLoading={true}
+                      style={
+                        Object {
+                          "width": "320px",
+                        }
+                      }
                     >
                       <Skeleton
                         isDark={false}
                         size="lg"
+                        style={
+                          Object {
+                            "width": "320px",
+                          }
+                        }
                       >
                         <div
                           className="ins-c-skeleton ins-c-skeleton__lg"
+                          style={
+                            Object {
+                              "width": "320px",
+                            }
+                          }
                         >
                            
                         </div>

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
@@ -1,39 +1,31 @@
 import { Grid, GridItem } from '@patternfly/react-core';
 import propTypes from 'prop-types';
 import React from 'react';
-import { CVEPageContext } from '../../SmartComponents/CVEDetailsPage/CVEDetailsPage';
 import CVEDetailsPageDescription from '../CVEDetailsPageDescription/CVEDetailsPageDescription';
 import CVEDetailsPageSidebar from '../CVEDetailsPageSidebar/CVEDetailsPageSidebar';
-import WithLoader from '../WithLoader/WithLoader';
 import CSAwRuleBox from '../CSAwRuleBox/CSAwRuleBox';
 import { KnownExploitSummary } from '../KnownExploitSummary/KnownExploitSummary';
 
 const CVEDetailsPageSummary = ({ data, changeExposedSystemsParameters }) => {
     return (
-        <CVEPageContext.Consumer>
-            {context => (
-                <Grid hasGutter>
-                    <GridItem md={8} sm={12}>
-                        <WithLoader loading={context.isLoading} variant="spinner">
-                            <CVEDetailsPageDescription cveAttributes={data.data} />
-                        </WithLoader>
-                    </GridItem>
+        <Grid hasGutter>
+            <GridItem md={8} sm={12}>
+                <CVEDetailsPageDescription cveAttributes={data.data} />
+            </GridItem>
 
-                    <GridItem md={4} sm={12} className="pf-u-mt-sm pf-u-ml-sm">
-                        <CVEDetailsPageSidebar cveAttributes={data.data} />
-                    </GridItem>
-                    {
-                        data.data.known_exploit && <KnownExploitSummary/>
-                    }
+            <GridItem md={4} sm={12} className="pf-u-mt-sm pf-u-ml-sm">
+                <CVEDetailsPageSidebar cveAttributes={data.data} />
+            </GridItem>
+            {
+                data.data.known_exploit && <KnownExploitSummary/>
+            }
 
-                    <CSAwRuleBox
-                        changeExposedSystemsParameters = {changeExposedSystemsParameters}
-                        synopsis={data.data.synopsis}
-                        rules={data.data.rules}
-                    />
-                </Grid>
-            )}
-        </CVEPageContext.Consumer>
+            <CSAwRuleBox
+                changeExposedSystemsParameters = {changeExposedSystemsParameters}
+                synopsis={data.data.synopsis}
+                rules={data.data.rules}
+            />
+        </Grid>
     );
 };
 

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
@@ -120,25 +120,291 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
               <div
                 className="pf-l-grid__item pf-m-12-col-on-sm pf-m-8-col-on-md"
               >
-                <WithLoader
-                  loading={true}
-                  variant="spinner"
+                <injectIntl(CVEDetailsPageDescription)
+                  cveAttributes={
+                    Object {
+                      "data": Object {
+                        "cvss3_score": "7.000",
+                        "description": "Lorem ipsum",
+                        "impact": "Important",
+                        "mitre_link": Object {
+                          "_owner": null,
+                          "_store": Object {},
+                          "key": null,
+                          "props": Object {
+                            "children": "MITRE Database",
+                            "href": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454",
+                          },
+                          "ref": null,
+                          "type": "a",
+                        },
+                        "package_list": Array [
+                          Object {
+                            "_owner": null,
+                            "_store": Object {},
+                            "key": "systemd-resolved-219-62.el7_6.5.i686",
+                            "props": Object {
+                              "children": "systemd-resolved-219-62.el7_6.5.i686",
+                            },
+                            "ref": null,
+                            "type": "li",
+                          },
+                          Object {
+                            "_owner": null,
+                            "_store": Object {},
+                            "key": "systemd-resolved-219-62.el7_6.5.x86_64",
+                            "props": Object {
+                              "children": "systemd-resolved-219-62.el7_6.5.x86_64",
+                            },
+                            "ref": null,
+                            "type": "li",
+                          },
+                          Object {
+                            "_owner": null,
+                            "_store": Object {},
+                            "key": "systemd-devel-219-62.el7_6.5.ppc",
+                            "props": Object {
+                              "children": "systemd-devel-219-62.el7_6.5.ppc",
+                            },
+                            "ref": null,
+                            "type": "li",
+                          },
+                        ],
+                        "public_date": "February 18th, 2019",
+                        "rh_link": Object {
+                          "_owner": null,
+                          "_store": Object {},
+                          "key": null,
+                          "props": Object {
+                            "children": "Red Hat CVE Database",
+                            "href": "https://access.redhat.com/security/cve/CVE-2019-6454",
+                          },
+                          "ref": null,
+                          "type": "a",
+                        },
+                        "synopsis": "CVE-2019-6454",
+                      },
+                      "isLoading": false,
+                      "meta": Object {},
+                    }
+                  }
                 >
-                  <Spinner
-                    centered={true}
+                  <CVEDetailsPageDescription
+                    cveAttributes={
+                      Object {
+                        "data": Object {
+                          "cvss3_score": "7.000",
+                          "description": "Lorem ipsum",
+                          "impact": "Important",
+                          "mitre_link": Object {
+                            "_owner": null,
+                            "_store": Object {},
+                            "key": null,
+                            "props": Object {
+                              "children": "MITRE Database",
+                              "href": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454",
+                            },
+                            "ref": null,
+                            "type": "a",
+                          },
+                          "package_list": Array [
+                            Object {
+                              "_owner": null,
+                              "_store": Object {},
+                              "key": "systemd-resolved-219-62.el7_6.5.i686",
+                              "props": Object {
+                                "children": "systemd-resolved-219-62.el7_6.5.i686",
+                              },
+                              "ref": null,
+                              "type": "li",
+                            },
+                            Object {
+                              "_owner": null,
+                              "_store": Object {},
+                              "key": "systemd-resolved-219-62.el7_6.5.x86_64",
+                              "props": Object {
+                                "children": "systemd-resolved-219-62.el7_6.5.x86_64",
+                              },
+                              "ref": null,
+                              "type": "li",
+                            },
+                            Object {
+                              "_owner": null,
+                              "_store": Object {},
+                              "key": "systemd-devel-219-62.el7_6.5.ppc",
+                              "props": Object {
+                                "children": "systemd-devel-219-62.el7_6.5.ppc",
+                              },
+                              "ref": null,
+                              "type": "li",
+                            },
+                          ],
+                          "public_date": "February 18th, 2019",
+                          "rh_link": Object {
+                            "_owner": null,
+                            "_store": Object {},
+                            "key": null,
+                            "props": Object {
+                              "children": "Red Hat CVE Database",
+                              "href": "https://access.redhat.com/security/cve/CVE-2019-6454",
+                            },
+                            "ref": null,
+                            "type": "a",
+                          },
+                          "synopsis": "CVE-2019-6454",
+                        },
+                        "isLoading": false,
+                        "meta": Object {},
+                      }
+                    }
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {
+                          "default.cancel": "Cancel",
+                          "default.delete": "Delete",
+                          "default.remove": "Remove",
+                          "default.save": "Save",
+                        },
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                        "wrapRichTextChunksInFragment": undefined,
+                      }
+                    }
                   >
-                    <div
-                      className="ins-c-spinner ins-m-center"
-                      role="status"
+                    <Stack
+                      hasGutter={true}
                     >
-                      <span
-                        className="pf-u-screen-reader"
+                      <div
+                        className="pf-l-stack pf-m-gutter"
                       >
-                        Loading...
-                      </span>
-                    </div>
-                  </Spinner>
-                </WithLoader>
+                        <StackItem
+                          className="pf-u-mt-sm"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm"
+                          >
+                            <div>
+                              <span
+                                className="pf-u-mr-xs"
+                              >
+                                Publish date
+                                :
+                              </span>
+                              <WithLoader
+                                isLoading={true}
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
+                                variant="inlineSkeleton"
+                              >
+                                <Skeleton
+                                  isDark={false}
+                                  size="lg"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="ins-c-skeleton ins-c-skeleton__lg"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                     
+                                  </div>
+                                </Skeleton>
+                              </WithLoader>
+                            </div>
+                          </div>
+                        </StackItem>
+                        <StackItem>
+                          <div
+                            className="pf-l-stack__item"
+                          >
+                            <WithLoader
+                              isLoading={true}
+                              style={
+                                Object {
+                                  "height": "132px",
+                                  "width": "100%",
+                                }
+                              }
+                              variant="rectangle"
+                            >
+                              <Skeleton
+                                isDark={false}
+                                shape="square"
+                                size="md"
+                                style={
+                                  Object {
+                                    "height": "132px",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__md"
+                                  shape="square"
+                                  style={
+                                    Object {
+                                      "height": "132px",
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
+                          </div>
+                        </StackItem>
+                        <StackItem
+                          className="pf-u-mt-sm pf-u-mb-md"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm pf-u-mb-md"
+                          />
+                        </StackItem>
+                      </div>
+                    </Stack>
+                  </CVEDetailsPageDescription>
+                </injectIntl(CVEDetailsPageDescription)>
               </div>
             </GridItem>
             <GridItem
@@ -366,6 +632,16 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                         </Stack>
                                       }
                                       title="Business risk"
+                                      value={
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        />
+                                      }
                                     >
                                       <Popover
                                         appendTo={null}
@@ -486,7 +762,16 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                 </Label>
                                               </StackItem>
                                               <StackItem>
-                                                <a />
+                                                <a>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  />
+                                                </a>
                                               </StackItem>
                                             </Stack>
                                           }
@@ -526,7 +811,37 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                   <div
                                                     className="pf-l-stack__item"
                                                   >
-                                                    <a />
+                                                    <a>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
+                                                    </a>
                                                   </div>
                                                 </StackItem>
                                               </div>
@@ -566,9 +881,18 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                       }
                                       title="Status"
                                       value={
-                                        <span>
-                                           
-                                        </span>
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        >
+                                          <span>
+                                             
+                                          </span>
+                                        </WithLoader>
                                       }
                                     >
                                       <Popover
@@ -699,9 +1023,18 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                               </StackItem>
                                               <StackItem>
                                                 <a>
-                                                  <span>
-                                                     
-                                                  </span>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span>
+                                                       
+                                                    </span>
+                                                  </WithLoader>
                                                 </a>
                                               </StackItem>
                                             </Stack>
@@ -743,9 +1076,35 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                     className="pf-l-stack__item"
                                                   >
                                                     <a>
-                                                      <span>
-                                                         
-                                                      </span>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
                                                     </a>
                                                   </div>
                                                 </StackItem>
@@ -781,134 +1140,35 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                 Severity
                               </span>
                             </Label>
-                            <span
-                              id="severity-shield"
+                            <WithLoader
+                              isLoading={true}
                               style={
                                 Object {
-                                  "color": "black",
+                                  "width": "100px",
                                 }
                               }
                             >
-                              <Shield
-                                hasLabel={true}
-                                hasTooltip={true}
-                                impact="Unknown"
-                                size="sm"
+                              <Skeleton
+                                isDark={false}
+                                size="lg"
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
                               >
-                                <span>
-                                  <Tooltip
-                                    content={<div />}
-                                    position="bottom"
-                                  >
-                                    <Popper
-                                      appendTo={[Function]}
-                                      distance={15}
-                                      enableFlip={true}
-                                      flipBehavior={
-                                        Array [
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                          "left",
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                        ]
-                                      }
-                                      isVisible={false}
-                                      onBlur={[Function]}
-                                      onDocumentClick={false}
-                                      onDocumentKeyDown={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onTriggerEnter={[Function]}
-                                      placement="bottom"
-                                      popper={
-                                        <div
-                                          className="pf-c-tooltip"
-                                          id="pf-tooltip-4"
-                                          role="tooltip"
-                                          style={
-                                            Object {
-                                              "maxWidth": null,
-                                              "opacity": 0,
-                                              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                            }
-                                          }
-                                        >
-                                          <TooltipArrow />
-                                          <TooltipContent
-                                            isLeftAligned={false}
-                                          >
-                                            <div />
-                                          </TooltipContent>
-                                        </div>
-                                      }
-                                      popperMatchesTriggerWidth={false}
-                                      positionModifiers={
-                                        Object {
-                                          "bottom": "pf-m-bottom",
-                                          "left": "pf-m-left",
-                                          "right": "pf-m-right",
-                                          "top": "pf-m-top",
-                                        }
-                                      }
-                                      trigger={
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          />
-                                           
-                                          Unknown
-                                        </span>
-                                      }
-                                      zIndex={9999}
-                                    >
-                                      <FindRefWrapper
-                                        onFoundRef={[Function]}
-                                      >
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden="false"
-                                              aria-label="Unknown"
-                                              aria-labelledby={null}
-                                              fill="#737679"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 384 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M202.021 0C122.202 0 70.503 32.703 29.914 91.026c-7.363 10.58-5.093 25.086 5.178 32.874l43.138 32.709c10.373 7.865 25.132 6.026 33.253-4.148 25.049-31.381 43.63-49.449 82.757-49.449 30.764 0 68.816 19.799 68.816 49.631 0 22.552-18.617 34.134-48.993 51.164-35.423 19.86-82.299 44.576-82.299 106.405V320c0 13.255 10.745 24 24 24h72.471c13.255 0 24-10.745 24-24v-5.773c0-42.86 125.268-44.645 125.268-160.627C377.504 66.256 286.902 0 202.021 0zM192 373.459c-38.196 0-69.271 31.075-69.271 69.271 0 38.195 31.075 69.27 69.271 69.27s69.271-31.075 69.271-69.271-31.075-69.27-69.271-69.27z"
-                                              />
-                                            </svg>
-                                          </QuestionIcon>
-                                           
-                                          Unknown
-                                        </span>
-                                      </FindRefWrapper>
-                                    </Popper>
-                                  </Tooltip>
-                                </span>
-                              </Shield>
-                            </span>
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__lg"
+                                  style={
+                                    Object {
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
                           </div>
                         </StackItem>
                         <StackItem>
@@ -984,29 +1244,200 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                   <div
                                     className="pf-c-content"
                                   >
-                                    <WithLoader
-                                      loading={true}
-                                    >
-                                      <Skeleton
-                                        isDark={false}
-                                        size="lg"
-                                      >
-                                        <div
-                                          className="ins-c-skeleton ins-c-skeleton__lg"
+                                    <Popover
+                                      bodyContent={
+                                        <WithLoader
+                                          colSize={2}
+                                          isLoading={true}
+                                          rowSize={8}
+                                          variant="compact"
                                         >
-                                           
-                                        </div>
-                                      </Skeleton>
-                                    </WithLoader>
+                                          N/A
+                                        </WithLoader>
+                                      }
+                                      enableFlip={true}
+                                      headerContent="CVSS 3.0  vector breakdown"
+                                      id="popover-cvss"
+                                      maxWidth="100%"
+                                      position="bottom"
+                                    >
+                                      <Popper
+                                        appendTo={[Function]}
+                                        distance={25}
+                                        enableFlip={true}
+                                        flipBehavior={
+                                          Array [
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                            "left",
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                          ]
+                                        }
+                                        isVisible={false}
+                                        onDocumentClick={[Function]}
+                                        onDocumentKeyDown={[Function]}
+                                        onTriggerClick={[Function]}
+                                        onTriggerEnter={[Function]}
+                                        placement="bottom"
+                                        popper={
+                                          <FocusTrap
+                                            active={false}
+                                            aria-describedby="popover-popover-cvss-body"
+                                            aria-labelledby="popover-popover-cvss-header"
+                                            aria-modal="true"
+                                            className="pf-c-popover"
+                                            focusTrapOptions={
+                                              Object {
+                                                "clickOutsideDeactivates": true,
+                                                "fallbackFocus": [Function],
+                                                "returnFocusOnDeactivate": true,
+                                              }
+                                            }
+                                            onMouseDown={[Function]}
+                                            paused={false}
+                                            preventScrollOnDeactivate={true}
+                                            role="dialog"
+                                            style={
+                                              Object {
+                                                "maxWidth": "100%",
+                                                "minWidth": null,
+                                                "opacity": 0,
+                                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                              }
+                                            }
+                                          >
+                                            <PopoverArrow />
+                                            <PopoverContent>
+                                              <PopoverCloseButton
+                                                aria-label="Close"
+                                                onClose={[Function]}
+                                              />
+                                              <PopoverHeader
+                                                id="popover-popover-cvss-header"
+                                              >
+                                                CVSS 3.0  vector breakdown
+                                              </PopoverHeader>
+                                              <PopoverBody
+                                                id="popover-popover-cvss-body"
+                                              >
+                                                <WithLoader
+                                                  colSize={2}
+                                                  isLoading={true}
+                                                  rowSize={8}
+                                                  variant="compact"
+                                                >
+                                                  N/A
+                                                </WithLoader>
+                                              </PopoverBody>
+                                            </PopoverContent>
+                                          </FocusTrap>
+                                        }
+                                        popperMatchesTriggerWidth={false}
+                                        positionModifiers={
+                                          Object {
+                                            "bottom": "pf-m-bottom",
+                                            "left": "pf-m-left",
+                                            "right": "pf-m-right",
+                                            "top": "pf-m-top",
+                                          }
+                                        }
+                                        trigger={
+                                          <React.Fragment>
+                                            <Label
+                                              className="pf-u-mb-xs pointer"
+                                              isLarge={true}
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              />
+                                            </Label>
+                                          </React.Fragment>
+                                        }
+                                        zIndex={9999}
+                                      >
+                                        <FindRefWrapper
+                                          onFoundRef={[Function]}
+                                        >
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            <span
+                                              className="vuln-label pf-u-mb-xs pointer"
+                                              style={
+                                                Object {
+                                                  "display": "block",
+                                                  "fontSize": "medium",
+                                                }
+                                              }
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  aria-labelledby={null}
+                                                  className="pf-u-ml-xs"
+                                                  fill="var(--pf-global--secondary-color--100)"
+                                                  height="1em"
+                                                  role="img"
+                                                  style={
+                                                    Object {
+                                                      "verticalAlign": "-0.125em",
+                                                    }
+                                                  }
+                                                  viewBox="0 0 512 512"
+                                                  width="1em"
+                                                >
+                                                  <path
+                                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                                  />
+                                                </svg>
+                                              </OutlinedQuestionCircleIcon>
+                                            </span>
+                                          </Label>
+                                        </FindRefWrapper>
+                                      </Popper>
+                                    </Popover>
                                     <WithLoader
-                                      loading={true}
+                                      isLoading={true}
+                                      style={
+                                        Object {
+                                          "width": "320px",
+                                        }
+                                      }
                                     >
                                       <Skeleton
                                         isDark={false}
                                         size="lg"
+                                        style={
+                                          Object {
+                                            "width": "320px",
+                                          }
+                                        }
                                       >
                                         <div
                                           className="ins-c-skeleton ins-c-skeleton__lg"
+                                          style={
+                                            Object {
+                                              "width": "320px",
+                                            }
+                                          }
                                         >
                                            
                                         </div>
@@ -1138,25 +1569,171 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
               <div
                 className="pf-l-grid__item pf-m-12-col-on-sm pf-m-8-col-on-md"
               >
-                <WithLoader
-                  loading={true}
-                  variant="spinner"
+                <injectIntl(CVEDetailsPageDescription)
+                  cveAttributes={
+                    Object {
+                      "data": Object {},
+                      "isLoading": true,
+                      "meta": Object {},
+                    }
+                  }
                 >
-                  <Spinner
-                    centered={true}
+                  <CVEDetailsPageDescription
+                    cveAttributes={
+                      Object {
+                        "data": Object {},
+                        "isLoading": true,
+                        "meta": Object {},
+                      }
+                    }
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {
+                          "default.cancel": "Cancel",
+                          "default.delete": "Delete",
+                          "default.remove": "Remove",
+                          "default.save": "Save",
+                        },
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                        "wrapRichTextChunksInFragment": undefined,
+                      }
+                    }
                   >
-                    <div
-                      className="ins-c-spinner ins-m-center"
-                      role="status"
+                    <Stack
+                      hasGutter={true}
                     >
-                      <span
-                        className="pf-u-screen-reader"
+                      <div
+                        className="pf-l-stack pf-m-gutter"
                       >
-                        Loading...
-                      </span>
-                    </div>
-                  </Spinner>
-                </WithLoader>
+                        <StackItem
+                          className="pf-u-mt-sm"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm"
+                          >
+                            <div>
+                              <span
+                                className="pf-u-mr-xs"
+                              >
+                                Publish date
+                                :
+                              </span>
+                              <WithLoader
+                                isLoading={true}
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
+                                variant="inlineSkeleton"
+                              >
+                                <Skeleton
+                                  isDark={false}
+                                  size="lg"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="ins-c-skeleton ins-c-skeleton__lg"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                     
+                                  </div>
+                                </Skeleton>
+                              </WithLoader>
+                            </div>
+                          </div>
+                        </StackItem>
+                        <StackItem>
+                          <div
+                            className="pf-l-stack__item"
+                          >
+                            <WithLoader
+                              isLoading={true}
+                              style={
+                                Object {
+                                  "height": "132px",
+                                  "width": "100%",
+                                }
+                              }
+                              variant="rectangle"
+                            >
+                              <Skeleton
+                                isDark={false}
+                                shape="square"
+                                size="md"
+                                style={
+                                  Object {
+                                    "height": "132px",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__md"
+                                  shape="square"
+                                  style={
+                                    Object {
+                                      "height": "132px",
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
+                          </div>
+                        </StackItem>
+                        <StackItem
+                          className="pf-u-mt-sm pf-u-mb-md"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm pf-u-mb-md"
+                          />
+                        </StackItem>
+                      </div>
+                    </Stack>
+                  </CVEDetailsPageDescription>
+                </injectIntl(CVEDetailsPageDescription)>
               </div>
             </GridItem>
             <GridItem
@@ -1264,6 +1841,16 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                         </Stack>
                                       }
                                       title="Business risk"
+                                      value={
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        />
+                                      }
                                     >
                                       <Popover
                                         appendTo={null}
@@ -1384,7 +1971,16 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                 </Label>
                                               </StackItem>
                                               <StackItem>
-                                                <a />
+                                                <a>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  />
+                                                </a>
                                               </StackItem>
                                             </Stack>
                                           }
@@ -1424,7 +2020,37 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                   <div
                                                     className="pf-l-stack__item"
                                                   >
-                                                    <a />
+                                                    <a>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
+                                                    </a>
                                                   </div>
                                                 </StackItem>
                                               </div>
@@ -1464,9 +2090,18 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                       }
                                       title="Status"
                                       value={
-                                        <span>
-                                           
-                                        </span>
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        >
+                                          <span>
+                                             
+                                          </span>
+                                        </WithLoader>
                                       }
                                     >
                                       <Popover
@@ -1597,9 +2232,18 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                               </StackItem>
                                               <StackItem>
                                                 <a>
-                                                  <span>
-                                                     
-                                                  </span>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span>
+                                                       
+                                                    </span>
+                                                  </WithLoader>
                                                 </a>
                                               </StackItem>
                                             </Stack>
@@ -1641,9 +2285,35 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                     className="pf-l-stack__item"
                                                   >
                                                     <a>
-                                                      <span>
-                                                         
-                                                      </span>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
                                                     </a>
                                                   </div>
                                                 </StackItem>
@@ -1679,134 +2349,35 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                 Severity
                               </span>
                             </Label>
-                            <span
-                              id="severity-shield"
+                            <WithLoader
+                              isLoading={true}
                               style={
                                 Object {
-                                  "color": "black",
+                                  "width": "100px",
                                 }
                               }
                             >
-                              <Shield
-                                hasLabel={true}
-                                hasTooltip={true}
-                                impact="Unknown"
-                                size="sm"
+                              <Skeleton
+                                isDark={false}
+                                size="lg"
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
                               >
-                                <span>
-                                  <Tooltip
-                                    content={<div />}
-                                    position="bottom"
-                                  >
-                                    <Popper
-                                      appendTo={[Function]}
-                                      distance={15}
-                                      enableFlip={true}
-                                      flipBehavior={
-                                        Array [
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                          "left",
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                        ]
-                                      }
-                                      isVisible={false}
-                                      onBlur={[Function]}
-                                      onDocumentClick={false}
-                                      onDocumentKeyDown={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onTriggerEnter={[Function]}
-                                      placement="bottom"
-                                      popper={
-                                        <div
-                                          className="pf-c-tooltip"
-                                          id="pf-tooltip-8"
-                                          role="tooltip"
-                                          style={
-                                            Object {
-                                              "maxWidth": null,
-                                              "opacity": 0,
-                                              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                            }
-                                          }
-                                        >
-                                          <TooltipArrow />
-                                          <TooltipContent
-                                            isLeftAligned={false}
-                                          >
-                                            <div />
-                                          </TooltipContent>
-                                        </div>
-                                      }
-                                      popperMatchesTriggerWidth={false}
-                                      positionModifiers={
-                                        Object {
-                                          "bottom": "pf-m-bottom",
-                                          "left": "pf-m-left",
-                                          "right": "pf-m-right",
-                                          "top": "pf-m-top",
-                                        }
-                                      }
-                                      trigger={
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          />
-                                           
-                                          Unknown
-                                        </span>
-                                      }
-                                      zIndex={9999}
-                                    >
-                                      <FindRefWrapper
-                                        onFoundRef={[Function]}
-                                      >
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden="false"
-                                              aria-label="Unknown"
-                                              aria-labelledby={null}
-                                              fill="#737679"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 384 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M202.021 0C122.202 0 70.503 32.703 29.914 91.026c-7.363 10.58-5.093 25.086 5.178 32.874l43.138 32.709c10.373 7.865 25.132 6.026 33.253-4.148 25.049-31.381 43.63-49.449 82.757-49.449 30.764 0 68.816 19.799 68.816 49.631 0 22.552-18.617 34.134-48.993 51.164-35.423 19.86-82.299 44.576-82.299 106.405V320c0 13.255 10.745 24 24 24h72.471c13.255 0 24-10.745 24-24v-5.773c0-42.86 125.268-44.645 125.268-160.627C377.504 66.256 286.902 0 202.021 0zM192 373.459c-38.196 0-69.271 31.075-69.271 69.271 0 38.195 31.075 69.27 69.271 69.27s69.271-31.075 69.271-69.271-31.075-69.27-69.271-69.27z"
-                                              />
-                                            </svg>
-                                          </QuestionIcon>
-                                           
-                                          Unknown
-                                        </span>
-                                      </FindRefWrapper>
-                                    </Popper>
-                                  </Tooltip>
-                                </span>
-                              </Shield>
-                            </span>
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__lg"
+                                  style={
+                                    Object {
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
                           </div>
                         </StackItem>
                         <StackItem>
@@ -1882,29 +2453,200 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                   <div
                                     className="pf-c-content"
                                   >
-                                    <WithLoader
-                                      loading={true}
-                                    >
-                                      <Skeleton
-                                        isDark={false}
-                                        size="lg"
-                                      >
-                                        <div
-                                          className="ins-c-skeleton ins-c-skeleton__lg"
+                                    <Popover
+                                      bodyContent={
+                                        <WithLoader
+                                          colSize={2}
+                                          isLoading={true}
+                                          rowSize={8}
+                                          variant="compact"
                                         >
-                                           
-                                        </div>
-                                      </Skeleton>
-                                    </WithLoader>
+                                          N/A
+                                        </WithLoader>
+                                      }
+                                      enableFlip={true}
+                                      headerContent="CVSS 3.0  vector breakdown"
+                                      id="popover-cvss"
+                                      maxWidth="100%"
+                                      position="bottom"
+                                    >
+                                      <Popper
+                                        appendTo={[Function]}
+                                        distance={25}
+                                        enableFlip={true}
+                                        flipBehavior={
+                                          Array [
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                            "left",
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                          ]
+                                        }
+                                        isVisible={false}
+                                        onDocumentClick={[Function]}
+                                        onDocumentKeyDown={[Function]}
+                                        onTriggerClick={[Function]}
+                                        onTriggerEnter={[Function]}
+                                        placement="bottom"
+                                        popper={
+                                          <FocusTrap
+                                            active={false}
+                                            aria-describedby="popover-popover-cvss-body"
+                                            aria-labelledby="popover-popover-cvss-header"
+                                            aria-modal="true"
+                                            className="pf-c-popover"
+                                            focusTrapOptions={
+                                              Object {
+                                                "clickOutsideDeactivates": true,
+                                                "fallbackFocus": [Function],
+                                                "returnFocusOnDeactivate": true,
+                                              }
+                                            }
+                                            onMouseDown={[Function]}
+                                            paused={false}
+                                            preventScrollOnDeactivate={true}
+                                            role="dialog"
+                                            style={
+                                              Object {
+                                                "maxWidth": "100%",
+                                                "minWidth": null,
+                                                "opacity": 0,
+                                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                              }
+                                            }
+                                          >
+                                            <PopoverArrow />
+                                            <PopoverContent>
+                                              <PopoverCloseButton
+                                                aria-label="Close"
+                                                onClose={[Function]}
+                                              />
+                                              <PopoverHeader
+                                                id="popover-popover-cvss-header"
+                                              >
+                                                CVSS 3.0  vector breakdown
+                                              </PopoverHeader>
+                                              <PopoverBody
+                                                id="popover-popover-cvss-body"
+                                              >
+                                                <WithLoader
+                                                  colSize={2}
+                                                  isLoading={true}
+                                                  rowSize={8}
+                                                  variant="compact"
+                                                >
+                                                  N/A
+                                                </WithLoader>
+                                              </PopoverBody>
+                                            </PopoverContent>
+                                          </FocusTrap>
+                                        }
+                                        popperMatchesTriggerWidth={false}
+                                        positionModifiers={
+                                          Object {
+                                            "bottom": "pf-m-bottom",
+                                            "left": "pf-m-left",
+                                            "right": "pf-m-right",
+                                            "top": "pf-m-top",
+                                          }
+                                        }
+                                        trigger={
+                                          <React.Fragment>
+                                            <Label
+                                              className="pf-u-mb-xs pointer"
+                                              isLarge={true}
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              />
+                                            </Label>
+                                          </React.Fragment>
+                                        }
+                                        zIndex={9999}
+                                      >
+                                        <FindRefWrapper
+                                          onFoundRef={[Function]}
+                                        >
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            <span
+                                              className="vuln-label pf-u-mb-xs pointer"
+                                              style={
+                                                Object {
+                                                  "display": "block",
+                                                  "fontSize": "medium",
+                                                }
+                                              }
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  aria-labelledby={null}
+                                                  className="pf-u-ml-xs"
+                                                  fill="var(--pf-global--secondary-color--100)"
+                                                  height="1em"
+                                                  role="img"
+                                                  style={
+                                                    Object {
+                                                      "verticalAlign": "-0.125em",
+                                                    }
+                                                  }
+                                                  viewBox="0 0 512 512"
+                                                  width="1em"
+                                                >
+                                                  <path
+                                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                                  />
+                                                </svg>
+                                              </OutlinedQuestionCircleIcon>
+                                            </span>
+                                          </Label>
+                                        </FindRefWrapper>
+                                      </Popper>
+                                    </Popover>
                                     <WithLoader
-                                      loading={true}
+                                      isLoading={true}
+                                      style={
+                                        Object {
+                                          "width": "320px",
+                                        }
+                                      }
                                     >
                                       <Skeleton
                                         isDark={false}
                                         size="lg"
+                                        style={
+                                          Object {
+                                            "width": "320px",
+                                          }
+                                        }
                                       >
                                         <div
                                           className="ins-c-skeleton ins-c-skeleton__lg"
+                                          style={
+                                            Object {
+                                              "width": "320px",
+                                            }
+                                          }
                                         >
                                            
                                         </div>
@@ -2043,25 +2785,185 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
               <div
                 className="pf-l-grid__item pf-m-12-col-on-sm pf-m-8-col-on-md"
               >
-                <WithLoader
-                  loading={true}
-                  variant="spinner"
+                <injectIntl(CVEDetailsPageDescription)
+                  cveAttributes={
+                    Object {
+                      "data": Object {
+                        "cvss3_score": "7.000",
+                        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi consectetur molestie tristique. Proin ornare urna ut consequat pellentesque. Sed commodo porta sollicitudin. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque habitant morbi tristique senectus et netus et nullam.",
+                        "impact": "Important",
+                        "package_list": Array [],
+                        "public_date": "February 18th, 2019",
+                        "synopsis": "CVE-2019-6454",
+                      },
+                      "isLoading": false,
+                      "meta": Object {},
+                    }
+                  }
                 >
-                  <Spinner
-                    centered={true}
+                  <CVEDetailsPageDescription
+                    cveAttributes={
+                      Object {
+                        "data": Object {
+                          "cvss3_score": "7.000",
+                          "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi consectetur molestie tristique. Proin ornare urna ut consequat pellentesque. Sed commodo porta sollicitudin. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque habitant morbi tristique senectus et netus et nullam.",
+                          "impact": "Important",
+                          "package_list": Array [],
+                          "public_date": "February 18th, 2019",
+                          "synopsis": "CVE-2019-6454",
+                        },
+                        "isLoading": false,
+                        "meta": Object {},
+                      }
+                    }
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {
+                          "default.cancel": "Cancel",
+                          "default.delete": "Delete",
+                          "default.remove": "Remove",
+                          "default.save": "Save",
+                        },
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                        "wrapRichTextChunksInFragment": undefined,
+                      }
+                    }
                   >
-                    <div
-                      className="ins-c-spinner ins-m-center"
-                      role="status"
+                    <Stack
+                      hasGutter={true}
                     >
-                      <span
-                        className="pf-u-screen-reader"
+                      <div
+                        className="pf-l-stack pf-m-gutter"
                       >
-                        Loading...
-                      </span>
-                    </div>
-                  </Spinner>
-                </WithLoader>
+                        <StackItem
+                          className="pf-u-mt-sm"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm"
+                          >
+                            <div>
+                              <span
+                                className="pf-u-mr-xs"
+                              >
+                                Publish date
+                                :
+                              </span>
+                              <WithLoader
+                                isLoading={true}
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
+                                variant="inlineSkeleton"
+                              >
+                                <Skeleton
+                                  isDark={false}
+                                  size="lg"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="ins-c-skeleton ins-c-skeleton__lg"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                     
+                                  </div>
+                                </Skeleton>
+                              </WithLoader>
+                            </div>
+                          </div>
+                        </StackItem>
+                        <StackItem>
+                          <div
+                            className="pf-l-stack__item"
+                          >
+                            <WithLoader
+                              isLoading={true}
+                              style={
+                                Object {
+                                  "height": "132px",
+                                  "width": "100%",
+                                }
+                              }
+                              variant="rectangle"
+                            >
+                              <Skeleton
+                                isDark={false}
+                                shape="square"
+                                size="md"
+                                style={
+                                  Object {
+                                    "height": "132px",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__md"
+                                  shape="square"
+                                  style={
+                                    Object {
+                                      "height": "132px",
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
+                          </div>
+                        </StackItem>
+                        <StackItem
+                          className="pf-u-mt-sm pf-u-mb-md"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm pf-u-mb-md"
+                          />
+                        </StackItem>
+                      </div>
+                    </Stack>
+                  </CVEDetailsPageDescription>
+                </injectIntl(CVEDetailsPageDescription)>
               </div>
             </GridItem>
             <GridItem
@@ -2183,6 +3085,16 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                         </Stack>
                                       }
                                       title="Business risk"
+                                      value={
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        />
+                                      }
                                     >
                                       <Popover
                                         appendTo={null}
@@ -2303,7 +3215,16 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                 </Label>
                                               </StackItem>
                                               <StackItem>
-                                                <a />
+                                                <a>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  />
+                                                </a>
                                               </StackItem>
                                             </Stack>
                                           }
@@ -2343,7 +3264,37 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                   <div
                                                     className="pf-l-stack__item"
                                                   >
-                                                    <a />
+                                                    <a>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
+                                                    </a>
                                                   </div>
                                                 </StackItem>
                                               </div>
@@ -2383,9 +3334,18 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                       }
                                       title="Status"
                                       value={
-                                        <span>
-                                           
-                                        </span>
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        >
+                                          <span>
+                                             
+                                          </span>
+                                        </WithLoader>
                                       }
                                     >
                                       <Popover
@@ -2516,9 +3476,18 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                               </StackItem>
                                               <StackItem>
                                                 <a>
-                                                  <span>
-                                                     
-                                                  </span>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span>
+                                                       
+                                                    </span>
+                                                  </WithLoader>
                                                 </a>
                                               </StackItem>
                                             </Stack>
@@ -2560,9 +3529,35 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                     className="pf-l-stack__item"
                                                   >
                                                     <a>
-                                                      <span>
-                                                         
-                                                      </span>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
                                                     </a>
                                                   </div>
                                                 </StackItem>
@@ -2598,134 +3593,35 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                 Severity
                               </span>
                             </Label>
-                            <span
-                              id="severity-shield"
+                            <WithLoader
+                              isLoading={true}
                               style={
                                 Object {
-                                  "color": "black",
+                                  "width": "100px",
                                 }
                               }
                             >
-                              <Shield
-                                hasLabel={true}
-                                hasTooltip={true}
-                                impact="Unknown"
-                                size="sm"
+                              <Skeleton
+                                isDark={false}
+                                size="lg"
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
                               >
-                                <span>
-                                  <Tooltip
-                                    content={<div />}
-                                    position="bottom"
-                                  >
-                                    <Popper
-                                      appendTo={[Function]}
-                                      distance={15}
-                                      enableFlip={true}
-                                      flipBehavior={
-                                        Array [
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                          "left",
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                        ]
-                                      }
-                                      isVisible={false}
-                                      onBlur={[Function]}
-                                      onDocumentClick={false}
-                                      onDocumentKeyDown={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onTriggerEnter={[Function]}
-                                      placement="bottom"
-                                      popper={
-                                        <div
-                                          className="pf-c-tooltip"
-                                          id="pf-tooltip-6"
-                                          role="tooltip"
-                                          style={
-                                            Object {
-                                              "maxWidth": null,
-                                              "opacity": 0,
-                                              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                            }
-                                          }
-                                        >
-                                          <TooltipArrow />
-                                          <TooltipContent
-                                            isLeftAligned={false}
-                                          >
-                                            <div />
-                                          </TooltipContent>
-                                        </div>
-                                      }
-                                      popperMatchesTriggerWidth={false}
-                                      positionModifiers={
-                                        Object {
-                                          "bottom": "pf-m-bottom",
-                                          "left": "pf-m-left",
-                                          "right": "pf-m-right",
-                                          "top": "pf-m-top",
-                                        }
-                                      }
-                                      trigger={
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          />
-                                           
-                                          Unknown
-                                        </span>
-                                      }
-                                      zIndex={9999}
-                                    >
-                                      <FindRefWrapper
-                                        onFoundRef={[Function]}
-                                      >
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden="false"
-                                              aria-label="Unknown"
-                                              aria-labelledby={null}
-                                              fill="#737679"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 384 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M202.021 0C122.202 0 70.503 32.703 29.914 91.026c-7.363 10.58-5.093 25.086 5.178 32.874l43.138 32.709c10.373 7.865 25.132 6.026 33.253-4.148 25.049-31.381 43.63-49.449 82.757-49.449 30.764 0 68.816 19.799 68.816 49.631 0 22.552-18.617 34.134-48.993 51.164-35.423 19.86-82.299 44.576-82.299 106.405V320c0 13.255 10.745 24 24 24h72.471c13.255 0 24-10.745 24-24v-5.773c0-42.86 125.268-44.645 125.268-160.627C377.504 66.256 286.902 0 202.021 0zM192 373.459c-38.196 0-69.271 31.075-69.271 69.271 0 38.195 31.075 69.27 69.271 69.27s69.271-31.075 69.271-69.271-31.075-69.27-69.271-69.27z"
-                                              />
-                                            </svg>
-                                          </QuestionIcon>
-                                           
-                                          Unknown
-                                        </span>
-                                      </FindRefWrapper>
-                                    </Popper>
-                                  </Tooltip>
-                                </span>
-                              </Shield>
-                            </span>
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__lg"
+                                  style={
+                                    Object {
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
                           </div>
                         </StackItem>
                         <StackItem>
@@ -2801,29 +3697,200 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                   <div
                                     className="pf-c-content"
                                   >
-                                    <WithLoader
-                                      loading={true}
-                                    >
-                                      <Skeleton
-                                        isDark={false}
-                                        size="lg"
-                                      >
-                                        <div
-                                          className="ins-c-skeleton ins-c-skeleton__lg"
+                                    <Popover
+                                      bodyContent={
+                                        <WithLoader
+                                          colSize={2}
+                                          isLoading={true}
+                                          rowSize={8}
+                                          variant="compact"
                                         >
-                                           
-                                        </div>
-                                      </Skeleton>
-                                    </WithLoader>
+                                          N/A
+                                        </WithLoader>
+                                      }
+                                      enableFlip={true}
+                                      headerContent="CVSS 3.0  vector breakdown"
+                                      id="popover-cvss"
+                                      maxWidth="100%"
+                                      position="bottom"
+                                    >
+                                      <Popper
+                                        appendTo={[Function]}
+                                        distance={25}
+                                        enableFlip={true}
+                                        flipBehavior={
+                                          Array [
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                            "left",
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                          ]
+                                        }
+                                        isVisible={false}
+                                        onDocumentClick={[Function]}
+                                        onDocumentKeyDown={[Function]}
+                                        onTriggerClick={[Function]}
+                                        onTriggerEnter={[Function]}
+                                        placement="bottom"
+                                        popper={
+                                          <FocusTrap
+                                            active={false}
+                                            aria-describedby="popover-popover-cvss-body"
+                                            aria-labelledby="popover-popover-cvss-header"
+                                            aria-modal="true"
+                                            className="pf-c-popover"
+                                            focusTrapOptions={
+                                              Object {
+                                                "clickOutsideDeactivates": true,
+                                                "fallbackFocus": [Function],
+                                                "returnFocusOnDeactivate": true,
+                                              }
+                                            }
+                                            onMouseDown={[Function]}
+                                            paused={false}
+                                            preventScrollOnDeactivate={true}
+                                            role="dialog"
+                                            style={
+                                              Object {
+                                                "maxWidth": "100%",
+                                                "minWidth": null,
+                                                "opacity": 0,
+                                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                              }
+                                            }
+                                          >
+                                            <PopoverArrow />
+                                            <PopoverContent>
+                                              <PopoverCloseButton
+                                                aria-label="Close"
+                                                onClose={[Function]}
+                                              />
+                                              <PopoverHeader
+                                                id="popover-popover-cvss-header"
+                                              >
+                                                CVSS 3.0  vector breakdown
+                                              </PopoverHeader>
+                                              <PopoverBody
+                                                id="popover-popover-cvss-body"
+                                              >
+                                                <WithLoader
+                                                  colSize={2}
+                                                  isLoading={true}
+                                                  rowSize={8}
+                                                  variant="compact"
+                                                >
+                                                  N/A
+                                                </WithLoader>
+                                              </PopoverBody>
+                                            </PopoverContent>
+                                          </FocusTrap>
+                                        }
+                                        popperMatchesTriggerWidth={false}
+                                        positionModifiers={
+                                          Object {
+                                            "bottom": "pf-m-bottom",
+                                            "left": "pf-m-left",
+                                            "right": "pf-m-right",
+                                            "top": "pf-m-top",
+                                          }
+                                        }
+                                        trigger={
+                                          <React.Fragment>
+                                            <Label
+                                              className="pf-u-mb-xs pointer"
+                                              isLarge={true}
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              />
+                                            </Label>
+                                          </React.Fragment>
+                                        }
+                                        zIndex={9999}
+                                      >
+                                        <FindRefWrapper
+                                          onFoundRef={[Function]}
+                                        >
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            <span
+                                              className="vuln-label pf-u-mb-xs pointer"
+                                              style={
+                                                Object {
+                                                  "display": "block",
+                                                  "fontSize": "medium",
+                                                }
+                                              }
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  aria-labelledby={null}
+                                                  className="pf-u-ml-xs"
+                                                  fill="var(--pf-global--secondary-color--100)"
+                                                  height="1em"
+                                                  role="img"
+                                                  style={
+                                                    Object {
+                                                      "verticalAlign": "-0.125em",
+                                                    }
+                                                  }
+                                                  viewBox="0 0 512 512"
+                                                  width="1em"
+                                                >
+                                                  <path
+                                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                                  />
+                                                </svg>
+                                              </OutlinedQuestionCircleIcon>
+                                            </span>
+                                          </Label>
+                                        </FindRefWrapper>
+                                      </Popper>
+                                    </Popover>
                                     <WithLoader
-                                      loading={true}
+                                      isLoading={true}
+                                      style={
+                                        Object {
+                                          "width": "320px",
+                                        }
+                                      }
                                     >
                                       <Skeleton
                                         isDark={false}
                                         size="lg"
+                                        style={
+                                          Object {
+                                            "width": "320px",
+                                          }
+                                        }
                                       >
                                         <div
                                           className="ins-c-skeleton ins-c-skeleton__lg"
+                                          style={
+                                            Object {
+                                              "width": "320px",
+                                            }
+                                          }
                                         >
                                            
                                         </div>
@@ -2953,25 +4020,159 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
               <div
                 className="pf-l-grid__item pf-m-12-col-on-sm pf-m-8-col-on-md"
               >
-                <WithLoader
-                  loading={true}
-                  variant="spinner"
+                <injectIntl(CVEDetailsPageDescription)
+                  cveAttributes={Object {}}
                 >
-                  <Spinner
-                    centered={true}
+                  <CVEDetailsPageDescription
+                    cveAttributes={Object {}}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {
+                          "default.cancel": "Cancel",
+                          "default.delete": "Delete",
+                          "default.remove": "Remove",
+                          "default.save": "Save",
+                        },
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                        "wrapRichTextChunksInFragment": undefined,
+                      }
+                    }
                   >
-                    <div
-                      className="ins-c-spinner ins-m-center"
-                      role="status"
+                    <Stack
+                      hasGutter={true}
                     >
-                      <span
-                        className="pf-u-screen-reader"
+                      <div
+                        className="pf-l-stack pf-m-gutter"
                       >
-                        Loading...
-                      </span>
-                    </div>
-                  </Spinner>
-                </WithLoader>
+                        <StackItem
+                          className="pf-u-mt-sm"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm"
+                          >
+                            <div>
+                              <span
+                                className="pf-u-mr-xs"
+                              >
+                                Publish date
+                                :
+                              </span>
+                              <WithLoader
+                                isLoading={true}
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
+                                variant="inlineSkeleton"
+                              >
+                                <Skeleton
+                                  isDark={false}
+                                  size="lg"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="ins-c-skeleton ins-c-skeleton__lg"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": "100px",
+                                      }
+                                    }
+                                  >
+                                     
+                                  </div>
+                                </Skeleton>
+                              </WithLoader>
+                            </div>
+                          </div>
+                        </StackItem>
+                        <StackItem>
+                          <div
+                            className="pf-l-stack__item"
+                          >
+                            <WithLoader
+                              isLoading={true}
+                              style={
+                                Object {
+                                  "height": "132px",
+                                  "width": "100%",
+                                }
+                              }
+                              variant="rectangle"
+                            >
+                              <Skeleton
+                                isDark={false}
+                                shape="square"
+                                size="md"
+                                style={
+                                  Object {
+                                    "height": "132px",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__md"
+                                  shape="square"
+                                  style={
+                                    Object {
+                                      "height": "132px",
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
+                          </div>
+                        </StackItem>
+                        <StackItem
+                          className="pf-u-mt-sm pf-u-mb-md"
+                        >
+                          <div
+                            className="pf-l-stack__item pf-u-mt-sm pf-u-mb-md"
+                          />
+                        </StackItem>
+                      </div>
+                    </Stack>
+                  </CVEDetailsPageDescription>
+                </injectIntl(CVEDetailsPageDescription)>
               </div>
             </GridItem>
             <GridItem
@@ -3067,6 +4268,16 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                         </Stack>
                                       }
                                       title="Business risk"
+                                      value={
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        />
+                                      }
                                     >
                                       <Popover
                                         appendTo={null}
@@ -3187,7 +4398,16 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                 </Label>
                                               </StackItem>
                                               <StackItem>
-                                                <a />
+                                                <a>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  />
+                                                </a>
                                               </StackItem>
                                             </Stack>
                                           }
@@ -3227,7 +4447,37 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                   <div
                                                     className="pf-l-stack__item"
                                                   >
-                                                    <a />
+                                                    <a>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
+                                                    </a>
                                                   </div>
                                                 </StackItem>
                                               </div>
@@ -3267,9 +4517,18 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                       }
                                       title="Status"
                                       value={
-                                        <span>
-                                           
-                                        </span>
+                                        <WithLoader
+                                          isLoading={true}
+                                          style={
+                                            Object {
+                                              "width": "100px",
+                                            }
+                                          }
+                                        >
+                                          <span>
+                                             
+                                          </span>
+                                        </WithLoader>
                                       }
                                     >
                                       <Popover
@@ -3400,9 +4659,18 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                               </StackItem>
                                               <StackItem>
                                                 <a>
-                                                  <span>
-                                                     
-                                                  </span>
+                                                  <WithLoader
+                                                    isLoading={true}
+                                                    style={
+                                                      Object {
+                                                        "width": "100px",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span>
+                                                       
+                                                    </span>
+                                                  </WithLoader>
                                                 </a>
                                               </StackItem>
                                             </Stack>
@@ -3444,9 +4712,35 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                     className="pf-l-stack__item"
                                                   >
                                                     <a>
-                                                      <span>
-                                                         
-                                                      </span>
+                                                      <WithLoader
+                                                        isLoading={true}
+                                                        style={
+                                                          Object {
+                                                            "width": "100px",
+                                                          }
+                                                        }
+                                                      >
+                                                        <Skeleton
+                                                          isDark={false}
+                                                          size="lg"
+                                                          style={
+                                                            Object {
+                                                              "width": "100px",
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="ins-c-skeleton ins-c-skeleton__lg"
+                                                            style={
+                                                              Object {
+                                                                "width": "100px",
+                                                              }
+                                                            }
+                                                          >
+                                                             
+                                                          </div>
+                                                        </Skeleton>
+                                                      </WithLoader>
                                                     </a>
                                                   </div>
                                                 </StackItem>
@@ -3482,134 +4776,35 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                 Severity
                               </span>
                             </Label>
-                            <span
-                              id="severity-shield"
+                            <WithLoader
+                              isLoading={true}
                               style={
                                 Object {
-                                  "color": "black",
+                                  "width": "100px",
                                 }
                               }
                             >
-                              <Shield
-                                hasLabel={true}
-                                hasTooltip={true}
-                                impact="Unknown"
-                                size="sm"
+                              <Skeleton
+                                isDark={false}
+                                size="lg"
+                                style={
+                                  Object {
+                                    "width": "100px",
+                                  }
+                                }
                               >
-                                <span>
-                                  <Tooltip
-                                    content={<div />}
-                                    position="bottom"
-                                  >
-                                    <Popper
-                                      appendTo={[Function]}
-                                      distance={15}
-                                      enableFlip={true}
-                                      flipBehavior={
-                                        Array [
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                          "left",
-                                          "top",
-                                          "right",
-                                          "bottom",
-                                        ]
-                                      }
-                                      isVisible={false}
-                                      onBlur={[Function]}
-                                      onDocumentClick={false}
-                                      onDocumentKeyDown={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      onTriggerEnter={[Function]}
-                                      placement="bottom"
-                                      popper={
-                                        <div
-                                          className="pf-c-tooltip"
-                                          id="pf-tooltip-2"
-                                          role="tooltip"
-                                          style={
-                                            Object {
-                                              "maxWidth": null,
-                                              "opacity": 0,
-                                              "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                            }
-                                          }
-                                        >
-                                          <TooltipArrow />
-                                          <TooltipContent
-                                            isLeftAligned={false}
-                                          >
-                                            <div />
-                                          </TooltipContent>
-                                        </div>
-                                      }
-                                      popperMatchesTriggerWidth={false}
-                                      positionModifiers={
-                                        Object {
-                                          "bottom": "pf-m-bottom",
-                                          "left": "pf-m-left",
-                                          "right": "pf-m-right",
-                                          "top": "pf-m-top",
-                                        }
-                                      }
-                                      trigger={
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          />
-                                           
-                                          Unknown
-                                        </span>
-                                      }
-                                      zIndex={9999}
-                                    >
-                                      <FindRefWrapper
-                                        onFoundRef={[Function]}
-                                      >
-                                        <span>
-                                          <QuestionIcon
-                                            aria-hidden="false"
-                                            aria-label="Unknown"
-                                            color="#737679"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden="false"
-                                              aria-label="Unknown"
-                                              aria-labelledby={null}
-                                              fill="#737679"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 384 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M202.021 0C122.202 0 70.503 32.703 29.914 91.026c-7.363 10.58-5.093 25.086 5.178 32.874l43.138 32.709c10.373 7.865 25.132 6.026 33.253-4.148 25.049-31.381 43.63-49.449 82.757-49.449 30.764 0 68.816 19.799 68.816 49.631 0 22.552-18.617 34.134-48.993 51.164-35.423 19.86-82.299 44.576-82.299 106.405V320c0 13.255 10.745 24 24 24h72.471c13.255 0 24-10.745 24-24v-5.773c0-42.86 125.268-44.645 125.268-160.627C377.504 66.256 286.902 0 202.021 0zM192 373.459c-38.196 0-69.271 31.075-69.271 69.271 0 38.195 31.075 69.27 69.271 69.27s69.271-31.075 69.271-69.271-31.075-69.27-69.271-69.27z"
-                                              />
-                                            </svg>
-                                          </QuestionIcon>
-                                           
-                                          Unknown
-                                        </span>
-                                      </FindRefWrapper>
-                                    </Popper>
-                                  </Tooltip>
-                                </span>
-                              </Shield>
-                            </span>
+                                <div
+                                  className="ins-c-skeleton ins-c-skeleton__lg"
+                                  style={
+                                    Object {
+                                      "width": "100px",
+                                    }
+                                  }
+                                >
+                                   
+                                </div>
+                              </Skeleton>
+                            </WithLoader>
                           </div>
                         </StackItem>
                         <StackItem>
@@ -3685,29 +4880,200 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                   <div
                                     className="pf-c-content"
                                   >
-                                    <WithLoader
-                                      loading={true}
-                                    >
-                                      <Skeleton
-                                        isDark={false}
-                                        size="lg"
-                                      >
-                                        <div
-                                          className="ins-c-skeleton ins-c-skeleton__lg"
+                                    <Popover
+                                      bodyContent={
+                                        <WithLoader
+                                          colSize={2}
+                                          isLoading={true}
+                                          rowSize={8}
+                                          variant="compact"
                                         >
-                                           
-                                        </div>
-                                      </Skeleton>
-                                    </WithLoader>
+                                          N/A
+                                        </WithLoader>
+                                      }
+                                      enableFlip={true}
+                                      headerContent="CVSS 3.0  vector breakdown"
+                                      id="popover-cvss"
+                                      maxWidth="100%"
+                                      position="bottom"
+                                    >
+                                      <Popper
+                                        appendTo={[Function]}
+                                        distance={25}
+                                        enableFlip={true}
+                                        flipBehavior={
+                                          Array [
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                            "left",
+                                            "top",
+                                            "right",
+                                            "bottom",
+                                          ]
+                                        }
+                                        isVisible={false}
+                                        onDocumentClick={[Function]}
+                                        onDocumentKeyDown={[Function]}
+                                        onTriggerClick={[Function]}
+                                        onTriggerEnter={[Function]}
+                                        placement="bottom"
+                                        popper={
+                                          <FocusTrap
+                                            active={false}
+                                            aria-describedby="popover-popover-cvss-body"
+                                            aria-labelledby="popover-popover-cvss-header"
+                                            aria-modal="true"
+                                            className="pf-c-popover"
+                                            focusTrapOptions={
+                                              Object {
+                                                "clickOutsideDeactivates": true,
+                                                "fallbackFocus": [Function],
+                                                "returnFocusOnDeactivate": true,
+                                              }
+                                            }
+                                            onMouseDown={[Function]}
+                                            paused={false}
+                                            preventScrollOnDeactivate={true}
+                                            role="dialog"
+                                            style={
+                                              Object {
+                                                "maxWidth": "100%",
+                                                "minWidth": null,
+                                                "opacity": 0,
+                                                "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                              }
+                                            }
+                                          >
+                                            <PopoverArrow />
+                                            <PopoverContent>
+                                              <PopoverCloseButton
+                                                aria-label="Close"
+                                                onClose={[Function]}
+                                              />
+                                              <PopoverHeader
+                                                id="popover-popover-cvss-header"
+                                              >
+                                                CVSS 3.0  vector breakdown
+                                              </PopoverHeader>
+                                              <PopoverBody
+                                                id="popover-popover-cvss-body"
+                                              >
+                                                <WithLoader
+                                                  colSize={2}
+                                                  isLoading={true}
+                                                  rowSize={8}
+                                                  variant="compact"
+                                                >
+                                                  N/A
+                                                </WithLoader>
+                                              </PopoverBody>
+                                            </PopoverContent>
+                                          </FocusTrap>
+                                        }
+                                        popperMatchesTriggerWidth={false}
+                                        positionModifiers={
+                                          Object {
+                                            "bottom": "pf-m-bottom",
+                                            "left": "pf-m-left",
+                                            "right": "pf-m-right",
+                                            "top": "pf-m-top",
+                                          }
+                                        }
+                                        trigger={
+                                          <React.Fragment>
+                                            <Label
+                                              className="pf-u-mb-xs pointer"
+                                              isLarge={true}
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              />
+                                            </Label>
+                                          </React.Fragment>
+                                        }
+                                        zIndex={9999}
+                                      >
+                                        <FindRefWrapper
+                                          onFoundRef={[Function]}
+                                        >
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            <span
+                                              className="vuln-label pf-u-mb-xs pointer"
+                                              style={
+                                                Object {
+                                                  "display": "block",
+                                                  "fontSize": "medium",
+                                                }
+                                              }
+                                            >
+                                              CVSS 3.0
+                                               
+                                               base score
+                                              <OutlinedQuestionCircleIcon
+                                                className="pf-u-ml-xs"
+                                                color="var(--pf-global--secondary-color--100)"
+                                                noVerticalAlign={false}
+                                                size="sm"
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  aria-labelledby={null}
+                                                  className="pf-u-ml-xs"
+                                                  fill="var(--pf-global--secondary-color--100)"
+                                                  height="1em"
+                                                  role="img"
+                                                  style={
+                                                    Object {
+                                                      "verticalAlign": "-0.125em",
+                                                    }
+                                                  }
+                                                  viewBox="0 0 512 512"
+                                                  width="1em"
+                                                >
+                                                  <path
+                                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                                  />
+                                                </svg>
+                                              </OutlinedQuestionCircleIcon>
+                                            </span>
+                                          </Label>
+                                        </FindRefWrapper>
+                                      </Popper>
+                                    </Popover>
                                     <WithLoader
-                                      loading={true}
+                                      isLoading={true}
+                                      style={
+                                        Object {
+                                          "width": "320px",
+                                        }
+                                      }
                                     >
                                       <Skeleton
                                         isDark={false}
                                         size="lg"
+                                        style={
+                                          Object {
+                                            "width": "320px",
+                                          }
+                                        }
                                       >
                                         <div
                                           className="ins-c-skeleton ins-c-skeleton__lg"
+                                          style={
+                                            Object {
+                                              "width": "320px",
+                                            }
+                                          }
                                         >
                                            
                                         </div>

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
@@ -1250,7 +1250,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           colSize={2}
                                           isLoading={true}
                                           rowSize={8}
-                                          variant="compact"
+                                          variant="compactTable"
                                         >
                                           N/A
                                         </WithLoader>
@@ -1327,7 +1327,7 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                                   colSize={2}
                                                   isLoading={true}
                                                   rowSize={8}
-                                                  variant="compact"
+                                                  variant="compactTable"
                                                 >
                                                   N/A
                                                 </WithLoader>
@@ -2459,7 +2459,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           colSize={2}
                                           isLoading={true}
                                           rowSize={8}
-                                          variant="compact"
+                                          variant="compactTable"
                                         >
                                           N/A
                                         </WithLoader>
@@ -2536,7 +2536,7 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                                   colSize={2}
                                                   isLoading={true}
                                                   rowSize={8}
-                                                  variant="compact"
+                                                  variant="compactTable"
                                                 >
                                                   N/A
                                                 </WithLoader>
@@ -3703,7 +3703,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           colSize={2}
                                           isLoading={true}
                                           rowSize={8}
-                                          variant="compact"
+                                          variant="compactTable"
                                         >
                                           N/A
                                         </WithLoader>
@@ -3780,7 +3780,7 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                                   colSize={2}
                                                   isLoading={true}
                                                   rowSize={8}
-                                                  variant="compact"
+                                                  variant="compactTable"
                                                 >
                                                   N/A
                                                 </WithLoader>
@@ -4886,7 +4886,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           colSize={2}
                                           isLoading={true}
                                           rowSize={8}
-                                          variant="compact"
+                                          variant="compactTable"
                                         >
                                           N/A
                                         </WithLoader>
@@ -4963,7 +4963,7 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                                   colSize={2}
                                                   isLoading={true}
                                                   rowSize={8}
-                                                  variant="compact"
+                                                  variant="compactTable"
                                                 >
                                                   N/A
                                                 </WithLoader>

--- a/src/Components/PresentationalComponents/CvssVector/CvssVector.js
+++ b/src/Components/PresentationalComponents/CvssVector/CvssVector.js
@@ -4,7 +4,7 @@ import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-t
 import propTypes from 'prop-types';
 import React from 'react';
 import { CVEPageContext } from '../../SmartComponents/CVEDetailsPage/CVEDetailsPage';
-import WithLoader from '../WithLoader/WithLoader';
+import WithLoader, { LoaderType } from '../WithLoader/WithLoader';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { V3names, V2names } from './vectorNames';
@@ -31,52 +31,50 @@ const CvssVector = props => {
     const namesMapping = (CVSS3Vector && V3names) || (CVSS2Vector && V2names);
     const parsedVector = parseVector(cvssVector, namesMapping);
     const notAvailable = 'N/A';
-    // eslint-disable-next-line no-unused-vars
-    const { cvssVersion, ...values } = parsedVector;
+    delete parsedVector.cvssVersion;
 
     return (
         <CVEPageContext.Consumer>
             {context => (
                 <TextContent>
-                    <WithLoader loading={context.isLoading}>
-                        <Popover
-                            id="popover-cvss"
-                            position="bottom"
-                            maxWidth={'100%'}
-                            enableFlip
-                            headerContent={ `${cvssVer} ${intl.formatMessage(messages.cvssVectorPopoverTitle)}` }
-                            bodyContent={
-                                cvssVector ?
-                                    (
-                                        <Table
-                                            aria-label={'Metric breakdown'}
-                                            variant={TableVariant.compact}
-                                            gridBreakPoint=""
-                                            cells={
-                                                [intl.formatMessage(messages.cvssVectorMetric),
-                                                    intl.formatMessage(messages.cvssVectorValue)]
-                                            }
-                                            rows={Object.entries(values)}
-                                        >
-                                            <TableHeader />
-                                            <TableBody />
-                                        </Table>
-                                    ) : (notAvailable)
-                            }
-                        >
-                            <React.Fragment>
-                                <Label isLarge className="pf-u-mb-xs pointer">
-                                    {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
-                                    <OutlinedQuestionCircleIcon
-                                        color={'var(--pf-global--secondary-color--100)'}
-                                        className="pf-u-ml-xs"
-                                    />
-                                </Label>
-                            </React.Fragment>
-                        </Popover>
-                    </WithLoader>
+                    <Popover
+                        id="popover-cvss"
+                        position="bottom"
+                        maxWidth={'100%'}
+                        enableFlip
+                        headerContent={`${cvssVer} ${intl.formatMessage(messages.cvssVectorPopoverTitle)}`}
+                        bodyContent={
+                            <WithLoader isLoading={context.isLoading} colSize={2} rowSize={8} variant={LoaderType.compactTable}>
+                                {cvssVector ?
+                                    (<Table
+                                        aria-label={'Metric breakdown'}
+                                        variant={TableVariant.compact}
+                                        gridBreakPoint=""
+                                        cells={
+                                            [intl.formatMessage(messages.cvssVectorMetric),
+                                                intl.formatMessage(messages.cvssVectorValue)]
+                                        }
+                                        rows={Object.entries(parsedVector)}
+                                    >
+                                        <TableHeader />
+                                        <TableBody />
+                                    </Table>
+                                    ) : (notAvailable)}
+                            </WithLoader>
+                        }
+                    >
+                        <React.Fragment>
+                            <Label isLarge className="pf-u-mb-xs pointer">
+                                {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
+                                <OutlinedQuestionCircleIcon
+                                    color={'var(--pf-global--secondary-color--100)'}
+                                    className="pf-u-ml-xs"
+                                />
+                            </Label>
+                        </React.Fragment>
+                    </Popover>
 
-                    <WithLoader loading={context.isLoading}>
+                    <WithLoader isLoading={context.isLoading} style={{ width: '320px' }}>
                         <span className="pf-u-mr-md">{props.score}</span>
                         <span id="cvss-vector-content">
                             {intl.formatMessage(messages.vector) + ': '}

--- a/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
+++ b/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
@@ -60,7 +60,7 @@ exports[`CvssVector Should render CVSSv3 when given both 1`] = `
               colSize={2}
               isLoading={true}
               rowSize={8}
-              variant="compact"
+              variant="compactTable"
             >
               <Table
                 aria-label="Metric breakdown"
@@ -200,7 +200,7 @@ exports[`CvssVector Should render CVSSv3 when given both 1`] = `
                       colSize={2}
                       isLoading={true}
                       rowSize={8}
-                      variant="compact"
+                      variant="compactTable"
                     >
                       <Table
                         aria-label="Metric breakdown"
@@ -443,7 +443,7 @@ exports[`CvssVector Should render with CVSSv2 1`] = `
               colSize={2}
               isLoading={true}
               rowSize={8}
-              variant="compact"
+              variant="compactTable"
             >
               <Table
                 aria-label="Metric breakdown"
@@ -575,7 +575,7 @@ exports[`CvssVector Should render with CVSSv2 1`] = `
                       colSize={2}
                       isLoading={true}
                       rowSize={8}
-                      variant="compact"
+                      variant="compactTable"
                     >
                       <Table
                         aria-label="Metric breakdown"
@@ -810,7 +810,7 @@ exports[`CvssVector Should render with CVSSv3 1`] = `
               colSize={2}
               isLoading={true}
               rowSize={8}
-              variant="compact"
+              variant="compactTable"
             >
               <Table
                 aria-label="Metric breakdown"
@@ -950,7 +950,7 @@ exports[`CvssVector Should render with CVSSv3 1`] = `
                       colSize={2}
                       isLoading={true}
                       rowSize={8}
-                      variant="compact"
+                      variant="compactTable"
                     >
                       <Table
                         aria-label="Metric breakdown"
@@ -1190,7 +1190,7 @@ exports[`CvssVector Should render without parameters 1`] = `
               colSize={2}
               isLoading={true}
               rowSize={8}
-              variant="compact"
+              variant="compactTable"
             >
               N/A
             </WithLoader>
@@ -1267,7 +1267,7 @@ exports[`CvssVector Should render without parameters 1`] = `
                       colSize={2}
                       isLoading={true}
                       rowSize={8}
-                      variant="compact"
+                      variant="compactTable"
                     >
                       N/A
                     </WithLoader>

--- a/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
+++ b/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
@@ -54,29 +54,326 @@ exports[`CvssVector Should render CVSSv3 when given both 1`] = `
       <div
         className="pf-c-content"
       >
-        <WithLoader
-          loading={true}
-        >
-          <Skeleton
-            isDark={false}
-            size="lg"
-          >
-            <div
-              className="ins-c-skeleton ins-c-skeleton__lg"
+        <Popover
+          bodyContent={
+            <WithLoader
+              colSize={2}
+              isLoading={true}
+              rowSize={8}
+              variant="compact"
             >
-               
-            </div>
-          </Skeleton>
-        </WithLoader>
+              <Table
+                aria-label="Metric breakdown"
+                borders={true}
+                canSelectAll={true}
+                canSortFavorites={true}
+                cells={
+                  Array [
+                    "Metric",
+                    "Value",
+                  ]
+                }
+                className=""
+                contentId="expanded-content"
+                dropdownDirection="down"
+                dropdownPosition="right"
+                expandId="expandable-toggle"
+                gridBreakPoint=""
+                isStickyHeader={false}
+                isTreeTable={false}
+                ouiaSafe={true}
+                role="grid"
+                rowLabeledBy="simple-node"
+                rows={
+                  Array [
+                    Array [
+                      "Attack vector",
+                      "Adjacent",
+                    ],
+                    Array [
+                      "Attack complexity",
+                      "Low",
+                    ],
+                    Array [
+                      "Privileges required",
+                      "Low",
+                    ],
+                    Array [
+                      "User interaction",
+                      "Required",
+                    ],
+                    Array [
+                      "Scope",
+                      "Unchanged",
+                    ],
+                    Array [
+                      "Confidentiality",
+                      "Low",
+                    ],
+                    Array [
+                      "Integrity",
+                      "None",
+                    ],
+                    Array [
+                      "Availability",
+                      "None",
+                    ],
+                  ]
+                }
+                selectVariant="checkbox"
+                variant="compact"
+              >
+                <TableHeader />
+                <Unknown />
+              </Table>
+            </WithLoader>
+          }
+          enableFlip={true}
+          headerContent="CVSS 3.0  vector breakdown"
+          id="popover-cvss"
+          maxWidth="100%"
+          position="bottom"
+        >
+          <Popper
+            appendTo={[Function]}
+            distance={25}
+            enableFlip={true}
+            flipBehavior={
+              Array [
+                "top",
+                "right",
+                "bottom",
+                "left",
+                "top",
+                "right",
+                "bottom",
+              ]
+            }
+            isVisible={false}
+            onDocumentClick={[Function]}
+            onDocumentKeyDown={[Function]}
+            onTriggerClick={[Function]}
+            onTriggerEnter={[Function]}
+            placement="bottom"
+            popper={
+              <FocusTrap
+                active={false}
+                aria-describedby="popover-popover-cvss-body"
+                aria-labelledby="popover-popover-cvss-header"
+                aria-modal="true"
+                className="pf-c-popover"
+                focusTrapOptions={
+                  Object {
+                    "clickOutsideDeactivates": true,
+                    "fallbackFocus": [Function],
+                    "returnFocusOnDeactivate": true,
+                  }
+                }
+                onMouseDown={[Function]}
+                paused={false}
+                preventScrollOnDeactivate={true}
+                role="dialog"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "minWidth": null,
+                    "opacity": 0,
+                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                  }
+                }
+              >
+                <PopoverArrow />
+                <PopoverContent>
+                  <PopoverCloseButton
+                    aria-label="Close"
+                    onClose={[Function]}
+                  />
+                  <PopoverHeader
+                    id="popover-popover-cvss-header"
+                  >
+                    CVSS 3.0  vector breakdown
+                  </PopoverHeader>
+                  <PopoverBody
+                    id="popover-popover-cvss-body"
+                  >
+                    <WithLoader
+                      colSize={2}
+                      isLoading={true}
+                      rowSize={8}
+                      variant="compact"
+                    >
+                      <Table
+                        aria-label="Metric breakdown"
+                        borders={true}
+                        canSelectAll={true}
+                        canSortFavorites={true}
+                        cells={
+                          Array [
+                            "Metric",
+                            "Value",
+                          ]
+                        }
+                        className=""
+                        contentId="expanded-content"
+                        dropdownDirection="down"
+                        dropdownPosition="right"
+                        expandId="expandable-toggle"
+                        gridBreakPoint=""
+                        isStickyHeader={false}
+                        isTreeTable={false}
+                        ouiaSafe={true}
+                        role="grid"
+                        rowLabeledBy="simple-node"
+                        rows={
+                          Array [
+                            Array [
+                              "Attack vector",
+                              "Adjacent",
+                            ],
+                            Array [
+                              "Attack complexity",
+                              "Low",
+                            ],
+                            Array [
+                              "Privileges required",
+                              "Low",
+                            ],
+                            Array [
+                              "User interaction",
+                              "Required",
+                            ],
+                            Array [
+                              "Scope",
+                              "Unchanged",
+                            ],
+                            Array [
+                              "Confidentiality",
+                              "Low",
+                            ],
+                            Array [
+                              "Integrity",
+                              "None",
+                            ],
+                            Array [
+                              "Availability",
+                              "None",
+                            ],
+                          ]
+                        }
+                        selectVariant="checkbox"
+                        variant="compact"
+                      >
+                        <TableHeader />
+                        <Unknown />
+                      </Table>
+                    </WithLoader>
+                  </PopoverBody>
+                </PopoverContent>
+              </FocusTrap>
+            }
+            popperMatchesTriggerWidth={false}
+            positionModifiers={
+              Object {
+                "bottom": "pf-m-bottom",
+                "left": "pf-m-left",
+                "right": "pf-m-right",
+                "top": "pf-m-top",
+              }
+            }
+            trigger={
+              <React.Fragment>
+                <Label
+                  className="pf-u-mb-xs pointer"
+                  isLarge={true}
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </Label>
+              </React.Fragment>
+            }
+            zIndex={9999}
+          >
+            <FindRefWrapper
+              onFoundRef={[Function]}
+            >
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                <span
+                  className="vuln-label pf-u-mb-xs pointer"
+                  style={
+                    Object {
+                      "display": "block",
+                      "fontSize": "medium",
+                    }
+                  }
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-u-ml-xs"
+                      fill="var(--pf-global--secondary-color--100)"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </OutlinedQuestionCircleIcon>
+                </span>
+              </Label>
+            </FindRefWrapper>
+          </Popper>
+        </Popover>
         <WithLoader
-          loading={true}
+          isLoading={true}
+          style={
+            Object {
+              "width": "320px",
+            }
+          }
         >
           <Skeleton
             isDark={false}
             size="lg"
+            style={
+              Object {
+                "width": "320px",
+              }
+            }
           >
             <div
               className="ins-c-skeleton ins-c-skeleton__lg"
+              style={
+                Object {
+                  "width": "320px",
+                }
+              }
             >
                
             </div>
@@ -140,29 +437,310 @@ exports[`CvssVector Should render with CVSSv2 1`] = `
       <div
         className="pf-c-content"
       >
-        <WithLoader
-          loading={true}
-        >
-          <Skeleton
-            isDark={false}
-            size="lg"
-          >
-            <div
-              className="ins-c-skeleton ins-c-skeleton__lg"
+        <Popover
+          bodyContent={
+            <WithLoader
+              colSize={2}
+              isLoading={true}
+              rowSize={8}
+              variant="compact"
             >
-               
-            </div>
-          </Skeleton>
-        </WithLoader>
+              <Table
+                aria-label="Metric breakdown"
+                borders={true}
+                canSelectAll={true}
+                canSortFavorites={true}
+                cells={
+                  Array [
+                    "Metric",
+                    "Value",
+                  ]
+                }
+                className=""
+                contentId="expanded-content"
+                dropdownDirection="down"
+                dropdownPosition="right"
+                expandId="expandable-toggle"
+                gridBreakPoint=""
+                isStickyHeader={false}
+                isTreeTable={false}
+                ouiaSafe={true}
+                role="grid"
+                rowLabeledBy="simple-node"
+                rows={
+                  Array [
+                    Array [
+                      "Access vector",
+                      "Local",
+                    ],
+                    Array [
+                      "Access complexity",
+                      "High",
+                    ],
+                    Array [
+                      "Authentication",
+                      "None",
+                    ],
+                    Array [
+                      "Confidentiality impact",
+                      "None",
+                    ],
+                    Array [
+                      "Integrity impact",
+                      "None",
+                    ],
+                    Array [
+                      "Availability impact",
+                      "Partial",
+                    ],
+                  ]
+                }
+                selectVariant="checkbox"
+                variant="compact"
+              >
+                <TableHeader />
+                <Unknown />
+              </Table>
+            </WithLoader>
+          }
+          enableFlip={true}
+          headerContent="CVSS 2.0  vector breakdown"
+          id="popover-cvss"
+          maxWidth="100%"
+          position="bottom"
+        >
+          <Popper
+            appendTo={[Function]}
+            distance={25}
+            enableFlip={true}
+            flipBehavior={
+              Array [
+                "top",
+                "right",
+                "bottom",
+                "left",
+                "top",
+                "right",
+                "bottom",
+              ]
+            }
+            isVisible={false}
+            onDocumentClick={[Function]}
+            onDocumentKeyDown={[Function]}
+            onTriggerClick={[Function]}
+            onTriggerEnter={[Function]}
+            placement="bottom"
+            popper={
+              <FocusTrap
+                active={false}
+                aria-describedby="popover-popover-cvss-body"
+                aria-labelledby="popover-popover-cvss-header"
+                aria-modal="true"
+                className="pf-c-popover"
+                focusTrapOptions={
+                  Object {
+                    "clickOutsideDeactivates": true,
+                    "fallbackFocus": [Function],
+                    "returnFocusOnDeactivate": true,
+                  }
+                }
+                onMouseDown={[Function]}
+                paused={false}
+                preventScrollOnDeactivate={true}
+                role="dialog"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "minWidth": null,
+                    "opacity": 0,
+                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                  }
+                }
+              >
+                <PopoverArrow />
+                <PopoverContent>
+                  <PopoverCloseButton
+                    aria-label="Close"
+                    onClose={[Function]}
+                  />
+                  <PopoverHeader
+                    id="popover-popover-cvss-header"
+                  >
+                    CVSS 2.0  vector breakdown
+                  </PopoverHeader>
+                  <PopoverBody
+                    id="popover-popover-cvss-body"
+                  >
+                    <WithLoader
+                      colSize={2}
+                      isLoading={true}
+                      rowSize={8}
+                      variant="compact"
+                    >
+                      <Table
+                        aria-label="Metric breakdown"
+                        borders={true}
+                        canSelectAll={true}
+                        canSortFavorites={true}
+                        cells={
+                          Array [
+                            "Metric",
+                            "Value",
+                          ]
+                        }
+                        className=""
+                        contentId="expanded-content"
+                        dropdownDirection="down"
+                        dropdownPosition="right"
+                        expandId="expandable-toggle"
+                        gridBreakPoint=""
+                        isStickyHeader={false}
+                        isTreeTable={false}
+                        ouiaSafe={true}
+                        role="grid"
+                        rowLabeledBy="simple-node"
+                        rows={
+                          Array [
+                            Array [
+                              "Access vector",
+                              "Local",
+                            ],
+                            Array [
+                              "Access complexity",
+                              "High",
+                            ],
+                            Array [
+                              "Authentication",
+                              "None",
+                            ],
+                            Array [
+                              "Confidentiality impact",
+                              "None",
+                            ],
+                            Array [
+                              "Integrity impact",
+                              "None",
+                            ],
+                            Array [
+                              "Availability impact",
+                              "Partial",
+                            ],
+                          ]
+                        }
+                        selectVariant="checkbox"
+                        variant="compact"
+                      >
+                        <TableHeader />
+                        <Unknown />
+                      </Table>
+                    </WithLoader>
+                  </PopoverBody>
+                </PopoverContent>
+              </FocusTrap>
+            }
+            popperMatchesTriggerWidth={false}
+            positionModifiers={
+              Object {
+                "bottom": "pf-m-bottom",
+                "left": "pf-m-left",
+                "right": "pf-m-right",
+                "top": "pf-m-top",
+              }
+            }
+            trigger={
+              <React.Fragment>
+                <Label
+                  className="pf-u-mb-xs pointer"
+                  isLarge={true}
+                >
+                  CVSS 2.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </Label>
+              </React.Fragment>
+            }
+            zIndex={9999}
+          >
+            <FindRefWrapper
+              onFoundRef={[Function]}
+            >
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                <span
+                  className="vuln-label pf-u-mb-xs pointer"
+                  style={
+                    Object {
+                      "display": "block",
+                      "fontSize": "medium",
+                    }
+                  }
+                >
+                  CVSS 2.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-u-ml-xs"
+                      fill="var(--pf-global--secondary-color--100)"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </OutlinedQuestionCircleIcon>
+                </span>
+              </Label>
+            </FindRefWrapper>
+          </Popper>
+        </Popover>
         <WithLoader
-          loading={true}
+          isLoading={true}
+          style={
+            Object {
+              "width": "320px",
+            }
+          }
         >
           <Skeleton
             isDark={false}
             size="lg"
+            style={
+              Object {
+                "width": "320px",
+              }
+            }
           >
             <div
               className="ins-c-skeleton ins-c-skeleton__lg"
+              style={
+                Object {
+                  "width": "320px",
+                }
+              }
             >
                
             </div>
@@ -226,29 +804,326 @@ exports[`CvssVector Should render with CVSSv3 1`] = `
       <div
         className="pf-c-content"
       >
-        <WithLoader
-          loading={true}
-        >
-          <Skeleton
-            isDark={false}
-            size="lg"
-          >
-            <div
-              className="ins-c-skeleton ins-c-skeleton__lg"
+        <Popover
+          bodyContent={
+            <WithLoader
+              colSize={2}
+              isLoading={true}
+              rowSize={8}
+              variant="compact"
             >
-               
-            </div>
-          </Skeleton>
-        </WithLoader>
+              <Table
+                aria-label="Metric breakdown"
+                borders={true}
+                canSelectAll={true}
+                canSortFavorites={true}
+                cells={
+                  Array [
+                    "Metric",
+                    "Value",
+                  ]
+                }
+                className=""
+                contentId="expanded-content"
+                dropdownDirection="down"
+                dropdownPosition="right"
+                expandId="expandable-toggle"
+                gridBreakPoint=""
+                isStickyHeader={false}
+                isTreeTable={false}
+                ouiaSafe={true}
+                role="grid"
+                rowLabeledBy="simple-node"
+                rows={
+                  Array [
+                    Array [
+                      "Attack vector",
+                      "Adjacent",
+                    ],
+                    Array [
+                      "Attack complexity",
+                      "Low",
+                    ],
+                    Array [
+                      "Privileges required",
+                      "Low",
+                    ],
+                    Array [
+                      "User interaction",
+                      "Required",
+                    ],
+                    Array [
+                      "Scope",
+                      "Unchanged",
+                    ],
+                    Array [
+                      "Confidentiality",
+                      "Low",
+                    ],
+                    Array [
+                      "Integrity",
+                      "None",
+                    ],
+                    Array [
+                      "Availability",
+                      "None",
+                    ],
+                  ]
+                }
+                selectVariant="checkbox"
+                variant="compact"
+              >
+                <TableHeader />
+                <Unknown />
+              </Table>
+            </WithLoader>
+          }
+          enableFlip={true}
+          headerContent="CVSS 3.0  vector breakdown"
+          id="popover-cvss"
+          maxWidth="100%"
+          position="bottom"
+        >
+          <Popper
+            appendTo={[Function]}
+            distance={25}
+            enableFlip={true}
+            flipBehavior={
+              Array [
+                "top",
+                "right",
+                "bottom",
+                "left",
+                "top",
+                "right",
+                "bottom",
+              ]
+            }
+            isVisible={false}
+            onDocumentClick={[Function]}
+            onDocumentKeyDown={[Function]}
+            onTriggerClick={[Function]}
+            onTriggerEnter={[Function]}
+            placement="bottom"
+            popper={
+              <FocusTrap
+                active={false}
+                aria-describedby="popover-popover-cvss-body"
+                aria-labelledby="popover-popover-cvss-header"
+                aria-modal="true"
+                className="pf-c-popover"
+                focusTrapOptions={
+                  Object {
+                    "clickOutsideDeactivates": true,
+                    "fallbackFocus": [Function],
+                    "returnFocusOnDeactivate": true,
+                  }
+                }
+                onMouseDown={[Function]}
+                paused={false}
+                preventScrollOnDeactivate={true}
+                role="dialog"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "minWidth": null,
+                    "opacity": 0,
+                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                  }
+                }
+              >
+                <PopoverArrow />
+                <PopoverContent>
+                  <PopoverCloseButton
+                    aria-label="Close"
+                    onClose={[Function]}
+                  />
+                  <PopoverHeader
+                    id="popover-popover-cvss-header"
+                  >
+                    CVSS 3.0  vector breakdown
+                  </PopoverHeader>
+                  <PopoverBody
+                    id="popover-popover-cvss-body"
+                  >
+                    <WithLoader
+                      colSize={2}
+                      isLoading={true}
+                      rowSize={8}
+                      variant="compact"
+                    >
+                      <Table
+                        aria-label="Metric breakdown"
+                        borders={true}
+                        canSelectAll={true}
+                        canSortFavorites={true}
+                        cells={
+                          Array [
+                            "Metric",
+                            "Value",
+                          ]
+                        }
+                        className=""
+                        contentId="expanded-content"
+                        dropdownDirection="down"
+                        dropdownPosition="right"
+                        expandId="expandable-toggle"
+                        gridBreakPoint=""
+                        isStickyHeader={false}
+                        isTreeTable={false}
+                        ouiaSafe={true}
+                        role="grid"
+                        rowLabeledBy="simple-node"
+                        rows={
+                          Array [
+                            Array [
+                              "Attack vector",
+                              "Adjacent",
+                            ],
+                            Array [
+                              "Attack complexity",
+                              "Low",
+                            ],
+                            Array [
+                              "Privileges required",
+                              "Low",
+                            ],
+                            Array [
+                              "User interaction",
+                              "Required",
+                            ],
+                            Array [
+                              "Scope",
+                              "Unchanged",
+                            ],
+                            Array [
+                              "Confidentiality",
+                              "Low",
+                            ],
+                            Array [
+                              "Integrity",
+                              "None",
+                            ],
+                            Array [
+                              "Availability",
+                              "None",
+                            ],
+                          ]
+                        }
+                        selectVariant="checkbox"
+                        variant="compact"
+                      >
+                        <TableHeader />
+                        <Unknown />
+                      </Table>
+                    </WithLoader>
+                  </PopoverBody>
+                </PopoverContent>
+              </FocusTrap>
+            }
+            popperMatchesTriggerWidth={false}
+            positionModifiers={
+              Object {
+                "bottom": "pf-m-bottom",
+                "left": "pf-m-left",
+                "right": "pf-m-right",
+                "top": "pf-m-top",
+              }
+            }
+            trigger={
+              <React.Fragment>
+                <Label
+                  className="pf-u-mb-xs pointer"
+                  isLarge={true}
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </Label>
+              </React.Fragment>
+            }
+            zIndex={9999}
+          >
+            <FindRefWrapper
+              onFoundRef={[Function]}
+            >
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                <span
+                  className="vuln-label pf-u-mb-xs pointer"
+                  style={
+                    Object {
+                      "display": "block",
+                      "fontSize": "medium",
+                    }
+                  }
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-u-ml-xs"
+                      fill="var(--pf-global--secondary-color--100)"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </OutlinedQuestionCircleIcon>
+                </span>
+              </Label>
+            </FindRefWrapper>
+          </Popper>
+        </Popover>
         <WithLoader
-          loading={true}
+          isLoading={true}
+          style={
+            Object {
+              "width": "320px",
+            }
+          }
         >
           <Skeleton
             isDark={false}
             size="lg"
+            style={
+              Object {
+                "width": "320px",
+              }
+            }
           >
             <div
               className="ins-c-skeleton ins-c-skeleton__lg"
+              style={
+                Object {
+                  "width": "320px",
+                }
+              }
             >
                
             </div>
@@ -309,29 +1184,200 @@ exports[`CvssVector Should render without parameters 1`] = `
       <div
         className="pf-c-content"
       >
-        <WithLoader
-          loading={true}
-        >
-          <Skeleton
-            isDark={false}
-            size="lg"
-          >
-            <div
-              className="ins-c-skeleton ins-c-skeleton__lg"
+        <Popover
+          bodyContent={
+            <WithLoader
+              colSize={2}
+              isLoading={true}
+              rowSize={8}
+              variant="compact"
             >
-               
-            </div>
-          </Skeleton>
-        </WithLoader>
+              N/A
+            </WithLoader>
+          }
+          enableFlip={true}
+          headerContent="CVSS 3.0  vector breakdown"
+          id="popover-cvss"
+          maxWidth="100%"
+          position="bottom"
+        >
+          <Popper
+            appendTo={[Function]}
+            distance={25}
+            enableFlip={true}
+            flipBehavior={
+              Array [
+                "top",
+                "right",
+                "bottom",
+                "left",
+                "top",
+                "right",
+                "bottom",
+              ]
+            }
+            isVisible={false}
+            onDocumentClick={[Function]}
+            onDocumentKeyDown={[Function]}
+            onTriggerClick={[Function]}
+            onTriggerEnter={[Function]}
+            placement="bottom"
+            popper={
+              <FocusTrap
+                active={false}
+                aria-describedby="popover-popover-cvss-body"
+                aria-labelledby="popover-popover-cvss-header"
+                aria-modal="true"
+                className="pf-c-popover"
+                focusTrapOptions={
+                  Object {
+                    "clickOutsideDeactivates": true,
+                    "fallbackFocus": [Function],
+                    "returnFocusOnDeactivate": true,
+                  }
+                }
+                onMouseDown={[Function]}
+                paused={false}
+                preventScrollOnDeactivate={true}
+                role="dialog"
+                style={
+                  Object {
+                    "maxWidth": "100%",
+                    "minWidth": null,
+                    "opacity": 0,
+                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                  }
+                }
+              >
+                <PopoverArrow />
+                <PopoverContent>
+                  <PopoverCloseButton
+                    aria-label="Close"
+                    onClose={[Function]}
+                  />
+                  <PopoverHeader
+                    id="popover-popover-cvss-header"
+                  >
+                    CVSS 3.0  vector breakdown
+                  </PopoverHeader>
+                  <PopoverBody
+                    id="popover-popover-cvss-body"
+                  >
+                    <WithLoader
+                      colSize={2}
+                      isLoading={true}
+                      rowSize={8}
+                      variant="compact"
+                    >
+                      N/A
+                    </WithLoader>
+                  </PopoverBody>
+                </PopoverContent>
+              </FocusTrap>
+            }
+            popperMatchesTriggerWidth={false}
+            positionModifiers={
+              Object {
+                "bottom": "pf-m-bottom",
+                "left": "pf-m-left",
+                "right": "pf-m-right",
+                "top": "pf-m-top",
+              }
+            }
+            trigger={
+              <React.Fragment>
+                <Label
+                  className="pf-u-mb-xs pointer"
+                  isLarge={true}
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </Label>
+              </React.Fragment>
+            }
+            zIndex={9999}
+          >
+            <FindRefWrapper
+              onFoundRef={[Function]}
+            >
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                <span
+                  className="vuln-label pf-u-mb-xs pointer"
+                  style={
+                    Object {
+                      "display": "block",
+                      "fontSize": "medium",
+                    }
+                  }
+                >
+                  CVSS 3.0
+                   
+                   base score
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-xs"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      className="pf-u-ml-xs"
+                      fill="var(--pf-global--secondary-color--100)"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                      />
+                    </svg>
+                  </OutlinedQuestionCircleIcon>
+                </span>
+              </Label>
+            </FindRefWrapper>
+          </Popper>
+        </Popover>
         <WithLoader
-          loading={true}
+          isLoading={true}
+          style={
+            Object {
+              "width": "320px",
+            }
+          }
         >
           <Skeleton
             isDark={false}
             size="lg"
+            style={
+              Object {
+                "width": "320px",
+              }
+            }
           >
             <div
               className="ins-c-skeleton ins-c-skeleton__lg"
+              style={
+                Object {
+                  "width": "320px",
+                }
+              }
             >
                
             </div>

--- a/src/Components/PresentationalComponents/WithLoader/WithLoader.js
+++ b/src/Components/PresentationalComponents/WithLoader/WithLoader.js
@@ -1,66 +1,43 @@
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable/SkeletonTable';
 import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import propTypes from 'prop-types';
 import React from 'react';
-import ContentLoader, { BulletList, List } from 'react-content-loader';
+import { TableVariant } from '@patternfly/react-table';
 
-const WithLoader = props => {
-    if (props === undefined || props.loading !== false) {
-        switch (props.variant) {
-            case 'spinner':
-                return <Spinner centered />;
-            case 'cvePageOverviewItem':
-                return <CVEPageOverviewItemLoader />;
-            case 'list':
-                return <List />;
-            case 'bulletList':
-                return <BulletList />;
-            case 'trendBox':
-                return <TrendBoxLoader />;
-            case 'currentVulnerabilitiesItem':
-                return <CurrentVulnerabilitiesItemLoader />;
+export const LoaderType = {
+    spinner: 'spinner',
+    table: 'table',
+    compactTable: 'compactTable',
+    rectangle: 'rectangle',
+    inlineSkeleton: 'inlineSkeleton',
+    skeleton: 'skeleton'
+};
+
+const WithLoader = ({ isLoading, variant, ...props }) => {
+    if (isLoading) {
+        switch (variant) {
+            case LoaderType.spinner:
+                return <Spinner centered {...props}/>;
+            case LoaderType.table:
+                return <SkeletonTable {...props}/>;
+            case LoaderType.compactTable:
+                return <SkeletonTable variant={TableVariant.compact} {...props}/>;
+            case LoaderType.rectangle:
+                return <Skeleton shape="square" {...props}/>;
+            case LoaderType.inlineSkeleton:
+                return <Skeleton size={SkeletonSize.lg} {...props} style={{ display: 'inline-block', ...props.style }}/>;
             default:
-                return <Skeleton size={SkeletonSize.lg} />;
+                return <Skeleton size={SkeletonSize.lg} {...props}/>;
         }
     }
 
     return props.children;
 };
 
-// Loaders
-const CVEPageOverviewItemLoader = () => {
-    return (
-        <ContentLoader height={61} width={120}>
-            <rect x="35" y="0" rx="0" ry="0" width="50" height="35" />
-            <rect x="0" y="45" rx="0" ry="0" width="120" height="16" />
-        </ContentLoader>
-    );
-};
-
-const TrendBoxLoader = () => {
-    return (
-        <ContentLoader height={100} width={300}>
-            <rect x="388.58" y="109.13" rx="0" ry="0" width="0" height="0" />
-            <rect x="11.58" y="16.13" rx="0" ry="0" width="37" height="62" />
-            <rect x="52.58" y="52.13" rx="0" ry="0" width="17" height="26" />
-            <rect x="76.58" y="52.13" rx="0" ry="0" width="17" height="26" />
-            <rect x="4.58" y="82.13" rx="0" ry="0" width="154" height="22" />
-        </ContentLoader>
-    );
-};
-
-const CurrentVulnerabilitiesItemLoader = () => {
-    return (
-        <ContentLoader height={50} width={200} speed={2} primaryColor="#f3f3f3" secondaryColor="#ecebeb">
-            <rect x="82.58" y="15.13" rx="0" ry="0" width="110.88" height="21.42" />
-            <circle cx="25" cy="25" r="25" />
-        </ContentLoader>
-    );
-};
-
 WithLoader.propTypes = {
-    loading: propTypes.bool,
-    variant: propTypes.string
+    isLoading: propTypes.bool,
+    variant: propTypes.oneOf(Object.keys(LoaderType))
 };
 
 export default WithLoader;

--- a/src/Components/PresentationalComponents/WithLoader/WithLoader.test.js
+++ b/src/Components/PresentationalComponents/WithLoader/WithLoader.test.js
@@ -9,43 +9,18 @@ describe('WithLoader component', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should render with cvePageOverviewItem variant', () => {
-        const wrapper = shallow(<WithLoader variant={'cvePageOverviewItem'} />);
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render with list variant', () => {
-        const wrapper = shallow(<WithLoader variant={'list'} />);
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render with bulletList variant', () => {
-        const wrapper = shallow(<WithLoader variant={'bulletList'} />);
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render with trendBox variant', () => {
-        const wrapper = shallow(<WithLoader variant={'trendBox'} />);
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('should render with currentVulnerabilitiesItem variant', () => {
-        const wrapper = shallow(<WithLoader variant={'currentVulnerabilitiesItem'} />);
-        expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
     it('should render with loading prop is undefined', () => {
-        const wrapper = shallow(<WithLoader loading={undefined} />);
+        const wrapper = shallow(<WithLoader isLoading={undefined} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render with loading prop is true', () => {
-        const wrapper = shallow(<WithLoader loading={true} />);
+        const wrapper = shallow(<WithLoader isLoading={true} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
     it('should render with loading prop is false', () => {
-        const wrapper = shallow(<WithLoader loading={false} />);
+        const wrapper = shallow(<WithLoader isLoading={false} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/src/Components/PresentationalComponents/WithLoader/__snapshots__/WithLoader.test.js.snap
+++ b/src/Components/PresentationalComponents/WithLoader/__snapshots__/WithLoader.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WithLoader component should render with bulletList variant 1`] = `<ReactContentLoaderBulletList />`;
-
-exports[`WithLoader component should render with currentVulnerabilitiesItem variant 1`] = `<CurrentVulnerabilitiesItemLoader />`;
-
-exports[`WithLoader component should render with cvePageOverviewItem variant 1`] = `<CVEPageOverviewItemLoader />`;
-
-exports[`WithLoader component should render with list variant 1`] = `<ReactContentLoaderListStyle />`;
-
 exports[`WithLoader component should render with loading prop is false 1`] = `""`;
 
 exports[`WithLoader component should render with loading prop is true 1`] = `
@@ -17,18 +9,6 @@ exports[`WithLoader component should render with loading prop is true 1`] = `
 />
 `;
 
-exports[`WithLoader component should render with loading prop is undefined 1`] = `
-<Skeleton
-  isDark={false}
-  size="lg"
-/>
-`;
+exports[`WithLoader component should render with loading prop is undefined 1`] = `""`;
 
-exports[`WithLoader component should render with trendBox variant 1`] = `<TrendBoxLoader />`;
-
-exports[`WithLoader component should render without props 1`] = `
-<Skeleton
-  isDark={false}
-  size="lg"
-/>
-`;
+exports[`WithLoader component should render without props 1`] = `""`;


### PR DESCRIPTION
- completely refactor `WithLoader` component to remove very old and obsolete code and make it more useful in the future, new types of loaders available:
    - **spinner**
    - **table** - table of columns * rows skeletons
    - **compactTable** - compact table of columns * rows skeletons
    - **rectangle** -  multiple rows
    - **inlineSkeleton** - one row, inline
    - **skeleton** - one row, block level (default)
- improve skeletons for CVE detail page header
### Before:
![loadingBefore](https://user-images.githubusercontent.com/8426204/130057795-dd5316aa-e0be-4a3f-9534-1c06a3b9b07c.png)

### After:
![detailLoading](https://user-images.githubusercontent.com/8426204/130057282-dda8924d-4f81-44f9-a282-285f7556775a.png)

- add skeleton table for CVSS score breakdown
### After:
![vectorSkeleton](https://user-images.githubusercontent.com/8426204/130057256-1b65a831-a171-4a8d-baa3-d9a5349ac8bc.png)

- description text align justified
### Before:
![justifyBefore](https://user-images.githubusercontent.com/8426204/130057235-c44a3bfa-fb08-4f69-bd8e-6e2bbd6fb238.png)

### After:
![justifyAfter](https://user-images.githubusercontent.com/8426204/130057239-94104eab-9cd5-4339-89ba-28fd317d4507.png)


### How to test:
1. Go to `CVEDetailsPage.js`
2. Locate line `<CVEPageContext.Provider value={cveDetails && { isLoading: cveDetails.isLoading }}>`
3. Replace `cveDetails.isLoading` with `true` to keep the loading and showing skeletons forever