### PR TITLE
fix(CVE detail page): Improve responsiveness

### DIFF
--- a/src/Components/PresentationalComponents/Header/Header.js
+++ b/src/Components/PresentationalComponents/Header/Header.js
@@ -13,7 +13,7 @@ const Header = ({ title, actions, breadcrumbs, showBreadcrumb, children, actions
         <PageHeader>
             {showBreadcrumb && <Breadcrumb breadcrumbs={breadcrumbs} />}
 
-            <Split hasGutter>
+            <Split hasGutter isWrappable>
                 <SplitItem>
                     <PageHeaderTitle title={title} />
                 </SplitItem>

--- a/src/Components/PresentationalComponents/StaticPages/__snapshots__/NoAccessPage.test.js.snap
+++ b/src/Components/PresentationalComponents/StaticPages/__snapshots__/NoAccessPage.test.js.snap
@@ -207,9 +207,10 @@ exports[`NoAccessPage component Should match snapshot 1`] = `
                 >
                   <Split
                     hasGutter={true}
+                    isWrappable={true}
                   >
                     <div
-                      className="pf-l-split pf-m-gutter"
+                      className="pf-l-split pf-m-gutter pf-m-wrap"
                     >
                       <SplitItem>
                         <div

--- a/src/Components/PresentationalComponents/StaticPages/__snapshots__/UpgradePage.test.js.snap
+++ b/src/Components/PresentationalComponents/StaticPages/__snapshots__/UpgradePage.test.js.snap
@@ -207,9 +207,10 @@ exports[`UpgradePage component Should match snapshot 1`] = `
                 >
                   <Split
                     hasGutter={true}
+                    isWrappable={true}
                   >
                     <div
-                      className="pf-l-split pf-m-gutter"
+                      className="pf-l-split pf-m-gutter pf-m-wrap"
                     >
                       <SplitItem>
                         <div

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -49,9 +49,10 @@ exports[`Reports page component Should match snapshots 1`] = `
             >
               <Split
                 hasGutter={true}
+                isWrappable={true}
               >
                 <div
-                  className="pf-l-split pf-m-gutter"
+                  className="pf-l-split pf-m-gutter pf-m-wrap"
                 >
                   <SplitItem>
                     <div


### PR DESCRIPTION
This change doesn't change anything for wide enough resolutions, but fixes layout for narrow viewport devices, like portrait mobile.

## Before:
![before1](https://user-images.githubusercontent.com/8426204/130079320-4e343b40-1ac1-4cf3-bfc1-688b9475189e.png)
![before2](https://user-images.githubusercontent.com/8426204/130079324-a6d8803d-386c-4013-96e9-6ea4cf4209ca.png)

## After:
![after](https://user-images.githubusercontent.com/8426204/130079331-3fcb0753-da76-40eb-80d3-f6ae4aae9092.png)
![after2](https://user-images.githubusercontent.com/8426204/130079338-283821fa-52ed-40c0-bdd4-78cb1211c387.png)
