### PR TITLE
VULN-672 fix: Add tooltip text to 'Unknown' severity label

### DIFF
--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCves.test.js.snap
@@ -294,7 +294,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -3657,7 +3656,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                   hasTooltip={true}
                                   impact="Moderate"
                                   size="sm"
-                                  tooltipPosition="right"
                                 />
                               </span>,
                             },
@@ -3959,7 +3957,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                 hasTooltip={true}
                                 impact="Moderate"
                                 size="sm"
-                                tooltipPosition="right"
                               />
                             </span>,
                           },
@@ -7005,7 +7002,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -7166,7 +7162,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               hasTooltip={true}
                                               impact="Moderate"
                                               size="sm"
-                                              tooltipPosition="right"
                                             />
                                           </span>,
                                         },
@@ -7296,7 +7291,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -7454,7 +7448,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               hasTooltip={true}
                                               impact="Moderate"
                                               size="sm"
-                                              tooltipPosition="right"
                                             />
                                           </span>,
                                         },
@@ -7584,7 +7577,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -8254,7 +8246,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 hasTooltip={true}
                                                 impact="Moderate"
                                                 size="sm"
-                                                tooltipPosition="right"
                                               />
                                             </span>,
                                           },
@@ -8384,7 +8375,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               hasTooltip={true}
                                               impact="Moderate"
                                               size="sm"
-                                              tooltipPosition="right"
                                             />
                                           </span>,
                                         },
@@ -8566,7 +8556,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 hasTooltip={true}
                                                 impact="Moderate"
                                                 size="sm"
-                                                tooltipPosition="right"
                                               />
                                             </span>,
                                           },
@@ -8696,7 +8685,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                               hasTooltip={true}
                                               impact="Moderate"
                                               size="sm"
-                                              tooltipPosition="right"
                                             />
                                           </span>,
                                         },
@@ -8856,7 +8844,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                   hasTooltip={true}
                                                   impact="Moderate"
                                                   size="sm"
-                                                  tooltipPosition="right"
                                                 />
                                               </span>,
                                             },
@@ -8986,7 +8973,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                 hasTooltip={true}
                                                 impact="Moderate"
                                                 size="sm"
-                                                tooltipPosition="right"
                                               />
                                             </span>,
                                           },
@@ -9676,7 +9662,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         hasTooltip={true}
                                                         impact="Moderate"
                                                         size="sm"
-                                                        tooltipPosition="right"
                                                       />
                                                     </span>,
                                                   },
@@ -9806,7 +9791,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                       hasTooltip={true}
                                                       impact="Moderate"
                                                       size="sm"
-                                                      tooltipPosition="right"
                                                     />
                                                   </span>,
                                                 },
@@ -9923,7 +9907,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                           hasTooltip={true}
                                                           impact="Moderate"
                                                           size="sm"
-                                                          tooltipPosition="right"
                                                         />
                                                       </span>,
                                                     },
@@ -10053,7 +10036,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                         hasTooltip={true}
                                                         impact="Moderate"
                                                         size="sm"
-                                                        tooltipPosition="right"
                                                       />
                                                     </span>,
                                                   },
@@ -10411,7 +10393,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                 hasTooltip={true}
                                                                 impact="Moderate"
                                                                 size="sm"
-                                                                tooltipPosition="right"
                                                               >
                                                                 <span>
                                                                   <Tooltip
@@ -11178,7 +11159,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                           hasTooltip={true}
                                                                           impact="Moderate"
                                                                           size="sm"
-                                                                          tooltipPosition="right"
                                                                         />
                                                                       </span>,
                                                                     },
@@ -11308,7 +11288,6 @@ exports[`SystemCves Should match snapshots 1`] = `
                                                                         hasTooltip={true}
                                                                         impact="Moderate"
                                                                         size="sm"
-                                                                        tooltipPosition="right"
                                                                       />
                                                                     </span>,
                                                                   },

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -107,7 +107,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       hasTooltip={true}
                       impact="Moderate"
                       size="sm"
-                      tooltipPosition="right"
                     />
                   </span>,
                 },
@@ -412,7 +411,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                     hasTooltip={true}
                     impact="Moderate"
                     size="sm"
-                    tooltipPosition="right"
                   />
                 </span>,
               },
@@ -3224,7 +3222,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 hasTooltip={true}
                                 impact="Moderate"
                                 size="sm"
-                                tooltipPosition="right"
                               />
                             </span>,
                           },
@@ -3379,7 +3376,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   hasTooltip={true}
                                   impact="Moderate"
                                   size="sm"
-                                  tooltipPosition="right"
                                 />
                               </span>,
                             },
@@ -3505,7 +3501,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 hasTooltip={true}
                                 impact="Moderate"
                                 size="sm"
-                                tooltipPosition="right"
                               />
                             </span>,
                           },
@@ -3663,7 +3658,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   hasTooltip={true}
                                   impact="Moderate"
                                   size="sm"
-                                  tooltipPosition="right"
                                 />
                               </span>,
                             },
@@ -3789,7 +3783,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 hasTooltip={true}
                                 impact="Moderate"
                                 size="sm"
-                                tooltipPosition="right"
                               />
                             </span>,
                           },
@@ -4410,7 +4403,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     hasTooltip={true}
                                     impact="Moderate"
                                     size="sm"
-                                    tooltipPosition="right"
                                   />
                                 </span>,
                               },
@@ -4536,7 +4528,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   hasTooltip={true}
                                   impact="Moderate"
                                   size="sm"
-                                  tooltipPosition="right"
                                 />
                               </span>,
                             },
@@ -4718,7 +4709,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     hasTooltip={true}
                                     impact="Moderate"
                                     size="sm"
-                                    tooltipPosition="right"
                                   />
                                 </span>,
                               },
@@ -4844,7 +4834,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   hasTooltip={true}
                                   impact="Moderate"
                                   size="sm"
-                                  tooltipPosition="right"
                                 />
                               </span>,
                             },
@@ -5004,7 +4993,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       hasTooltip={true}
                                       impact="Moderate"
                                       size="sm"
-                                      tooltipPosition="right"
                                     />
                                   </span>,
                                 },
@@ -5130,7 +5118,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     hasTooltip={true}
                                     impact="Moderate"
                                     size="sm"
-                                    tooltipPosition="right"
                                   />
                                 </span>,
                               },
@@ -5771,7 +5758,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -5897,7 +5883,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                           hasTooltip={true}
                                           impact="Moderate"
                                           size="sm"
-                                          tooltipPosition="right"
                                         />
                                       </span>,
                                     },
@@ -6006,7 +5991,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                               hasTooltip={true}
                                               impact="Moderate"
                                               size="sm"
-                                              tooltipPosition="right"
                                             />
                                           </span>,
                                         },
@@ -6132,7 +6116,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                             hasTooltip={true}
                                             impact="Moderate"
                                             size="sm"
-                                            tooltipPosition="right"
                                           />
                                         </span>,
                                       },
@@ -6653,7 +6636,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                     hasTooltip={true}
                                                     impact="Moderate"
                                                     size="sm"
-                                                    tooltipPosition="right"
                                                   >
                                                     <span>
                                                       <Tooltip

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -88,7 +88,6 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                         hasTooltip={true}
                         impact="Moderate"
                         size="sm"
-                        tooltipPosition="right"
                       />
                     </span>,
                   },

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -53,8 +53,7 @@ export function createCveListByAccount(cveList) {
                         {
                             title: (
                                 <span key={row.id}>
-                                    <Shield impact={row.attributes.impact} hasLabel
-                                        hasTooltip={row.attributes.impact !== 'None'} />
+                                    <Shield impact={row.attributes.impact} hasLabel />
                                 </span>
                             )
                         },
@@ -165,8 +164,7 @@ export function createCveListBySystem(systemId, cveList) {
                             {
                                 title: (
                                     <span key={row.id}>
-                                        <Shield impact={row.attributes.impact} tooltipPosition={'right'} hasLabel
-                                            hasTooltip={row.attributes.impact !== 'None'} />
+                                        <Shield impact={row.attributes.impact} hasLabel />
                                     </span>
                                 )
                             },

--- a/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
+++ b/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
@@ -301,7 +301,6 @@ Object {
               hasTooltip={true}
               impact="Important"
               size="sm"
-              tooltipPosition="right"
             />
           </span>,
         },


### PR DESCRIPTION
### Before:
![tooltip2](https://user-images.githubusercontent.com/8426204/130216570-fd2c3215-ec17-46a7-ad82-bbd8293b6e5c.png)

### After:
![unknown](https://user-images.githubusercontent.com/8426204/130216572-21fbdad2-b489-4ddd-aee3-ffad53b2b1f6.png)
