### PR TITLE
VULN-1883 fix: Do not expand security rule box when clicking filter by systems exposed

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -65,7 +65,10 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                     <TextContent>
                                         <Text
                                             id="filter-affected-systems"
-                                            onClick={() => handleExposedSystemFilter(rule.rule_id)}
+                                            onClick={event => {
+                                                handleExposedSystemFilter(rule.rule_id);
+                                                event.stopPropagation();
+                                            }}
                                             component={TextVariants.small}
                                         >
                                             <Link


### PR DESCRIPTION
Do not bubble up the click event to the card header so it does not expand when `Filter by X systems` is clicked.