### PR TITLE
chore: Add script to detect unused translation keys

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 **/*.test.js
+scripts/*

--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
     "nightly": "npm run travis:verify",
     "translations": "npm-run-all translations:*",
     "translations:extract": "npx formatjs extract ./src/*.js --out-file ./build/messages/src/Messages.json",
-    "translations:compile": "npx formatjs compile ./build/messages/src/Messages.json --out-file ./locales/en.json"
+    "translations:compile": "npx formatjs compile ./build/messages/src/Messages.json --out-file ./locales/en.json",
+    "translations:unused": "node ./scripts/unused.mjs"
   },
   "release": {
     "analyzeCommits": {

--- a/scripts/unused.mjs
+++ b/scripts/unused.mjs
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import { exec } from 'child_process';
+
+try {
+    const messagesFile = fs.readFileSync('./src/Messages.js', 'utf8')
+    let messagesFileLines = messagesFile.split('\n');
+
+    const startLine = messagesFileLines.indexOf('export default defineMessages({');
+    const endLine = messagesFileLines.indexOf('});');
+
+    messagesFileLines = messagesFileLines.slice(startLine, endLine + 1);
+    messagesFileLines[0] = "({"
+    messagesFileLines[messagesFileLines.length - 1] = "})"
+    messagesFileLines = messagesFileLines.join(' ');
+
+    const messages = eval(messagesFileLines)
+
+    Object.keys(messages).forEach(key => {
+        exec(`grep --include=*.js --exclude=*.test.js -rnw 'src' -e 'messages.${key}'`, error => {
+            error && console.log(`\x1b[31mUnused message key: ${key}\x1b[0m`);
+        });
+    });
+} catch (err) {
+    console.error(err)
+}


### PR DESCRIPTION
We often update appearance of our app which means some translation keys get removed from the code, but still remain in the `messages.js` file. This script searches whole 'src/' directory to find keys which are unused. Script is ran using `npm run translations:unused` and is run when using `npm run translations`. It uses `eval()` but this script is dev only, so this shouldn't pose any danger.

![unused](https://user-images.githubusercontent.com/8426204/131125612-269e6465-c2e3-43a7-bf0b-0764db873dff.png)
