### PR TITLE
VULN-1903 fix: Correctly refresh previously loaded rows

### DIFF
--- a/src/Store/Reducers/CVEsStore.js
+++ b/src/Store/Reducers/CVEsStore.js
@@ -50,7 +50,7 @@ export const CVEsStore = (state = initialState, action) => {
                         payload: action.payload,
                         isLoading: false
                     },
-                    prevLoadedRows: unionBy(state.prevLoadedRows, action.payload.data, 'id'),
+                    prevLoadedRows: unionBy(action.payload.data, state.prevLoadedRows, 'id'),
                     ...state.isAllExpanded && { expandedRows: action.payload.data.map(({ id }) => id) }
                 };
 

--- a/src/Store/Reducers/InventoryEntitiesReducer.js
+++ b/src/Store/Reducers/InventoryEntitiesReducer.js
@@ -51,7 +51,7 @@ function modifyInventory(columns, state, action) {
                 ...row,
                 selected: state.selectedRows[row.id] === true
             })),
-            prevLoadedRows: unionBy(state.prevLoadedRows, action.payload.results, 'id')
+            prevLoadedRows: unionBy(action.payload.results, state.prevLoadedRows, 'id')
         };
     }
 


### PR DESCRIPTION
From [unionBy documentation](https://lodash.com/docs/4.17.15#unionBy):
> Result values are chosen from the first array in which the value occurs.

So if an item is contained in both previously loaded rows and new data, we should prioritize the new attributes; otherwise we'd use the old attributes for overlapping items.