### PR TITLE
VULN-1925 fix: Make status change twice as fast

### DIFF
--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -20,13 +20,20 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
     }, [setSelectProps]);
 
     const handleSave = () => {
-        return setCveStatus({
-            status_id: parseInt(statusId),
-            cve: cveList.map(item => item.id),
-            status_text: justification
-        })
-        .then(() => (!checkboxState && cvesWithExposedSystems.length > 0)
-            ? setSystemCveStatus({ cve: cvesWithExposedSystems }) : true)
+        return Promise.all([
+            setCveStatus({
+                cve: cveList.map(item => item.id),
+                status_id: parseInt(statusId),
+                status_text: justification
+            }),
+            ...[(!checkboxState && cvesWithExposedSystems.length > 0) &&
+                setSystemCveStatus({
+                    cve: cvesWithExposedSystems,
+                    status_id: parseInt(statusId),
+                    status_text: justification
+                })
+            ]
+        ])
         .then(updateRef)
         .catch(error => { throw error; }); // propagate error to BaseModal
     };


### PR DESCRIPTION
Previously we sent `setCveStatus` waited for it to resolve and then we sent `setSystemCveStatus` and then we showed the success notification, so we waited for 2 requests to resolve. But if we supply `status_id` and `status_text` to `setSystemCveStatus` we can send these two requests simultaneously and we only need to wait for half the time.