### PR TITLE
chore: Add jsx-no-useless-fragment lint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -52,6 +52,7 @@ rules:
   react/style-prop-object: 2
   react/jsx-boolean-value: 2
   react/jsx-handler-names: 2
+  react/jsx-no-useless-fragment: 2
   react/sort-comp:
     [
       2,
@@ -85,7 +86,6 @@ rules:
     - error
     - 4
     - SwitchCase: 1
-      MemberExpression: 0
       ImportDeclaration: 1
       ObjectExpression: 1
   key-spacing: 2

--- a/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
+++ b/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
@@ -8,46 +8,43 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { createRHDBLink } from '../../../Helpers/CVEHelper';
 
 const AdvisoryColumn = ({ cve, advisoriesList }) => {
-    return (<Fragment>
-        {
-            advisoriesList?.length > 0
-                ? (
-                    advisoriesList.map((advisory, _i) =>
-                        <a
-                            key={_i}
-                            href={`${ADVISORY_PATH}/${advisory}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            {advisory}
-                        </a>
-                    ).reduce((prev, curr) => [prev, ', ', curr])
-                ) : (
-                    <Fragment>
-                        <FormattedMessage {...messages.notAvailable} />
-                        <Tooltip exitDelay={2000} appendTo={document.querySelector('.vulnerability')} content={
-                            <FormattedMessage
-                                {...messages.advisoryTooltip}
-                                values={
-                                    {
-                                        link: createRHDBLink(
-                                            cve,
-                                            messages.rhCVEdb,
-                                            { className: 'toolip-link--embeded' }
-                                        )
-                                    }
+    return (
+        advisoriesList?.length > 0
+            ? (
+                advisoriesList.map((advisory, _i) =>
+                    <a
+                        key={_i}
+                        href={`${ADVISORY_PATH}/${advisory}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {advisory}
+                    </a>
+                ).reduce((prev, curr) => [prev, ', ', curr])
+            ) : (
+                <Fragment>
+                    <FormattedMessage {...messages.notAvailable} />
+                    <Tooltip exitDelay={2000} appendTo={document.querySelector('.vulnerability')} content={
+                        <FormattedMessage
+                            {...messages.advisoryTooltip}
+                            values={
+                                {
+                                    link: createRHDBLink(
+                                        cve,
+                                        messages.rhCVEdb,
+                                        { className: 'toolip-link--embeded' }
+                                    )
                                 }
-                            />
-                        }>
-                            <OutlinedQuestionCircleIcon
-                                className="pf-u-ml-xs"
-                                color="var(--pf-global--Color--200)"
-                            />
-                        </Tooltip>
-                    </Fragment>
-                )
-        }
-    </Fragment>
+                            }
+                        />
+                    }>
+                        <OutlinedQuestionCircleIcon
+                            className="pf-u-ml-xs"
+                            color="var(--pf-global--Color--200)"
+                        />
+                    </Tooltip>
+                </Fragment>
+            )
     );
 };
 

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Stack,
+import {
+    Stack,
     StackItem,
     Text,
     TextContent,
@@ -46,8 +47,8 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
         dispatch(changeExposedSystemsParameters({ rule: ruleId }));
     };
 
-    return <Fragment>
-        {sortedRules && sortedRules.map((rule, index) => (
+    return (
+        sortedRules && sortedRules.map((rule, index) => (
             rule.summary && (
                 <Card className="card-box" key={rule.rule_id} ouiaId={'security-rule-card-' + index}>
                     <ExpandableSection toggleText={
@@ -55,7 +56,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                             <SplitItem className="pf-u-mr-xl">
                                 <TextContent>
                                     <Text component={TextVariants.h4}>
-                                        <CSAwLabel className="pf-u-mr-sm"/>
+                                        <CSAwLabel className="pf-u-mr-sm" />
                                         {rule.description}
                                     </Text>
                                 </TextContent>
@@ -121,7 +122,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                         <Tooltip
                                                             content={RISK_OF_CHANGE_TOOLTIP[rule.change_risk]}
                                                         >
-                                                            { RISK_OF_CHANGE_LABEL[rule.change_risk] }
+                                                            {RISK_OF_CHANGE_LABEL[rule.change_risk]}
                                                         </Tooltip>
                                                     </SplitItem>
                                                     <SplitItem>
@@ -130,7 +131,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                         </Label>
                                                         <Split>
                                                             <SplitItem>
-                                                                { !rule.playbook_count
+                                                                {!rule.playbook_count
                                                                     ? intl.formatMessage(messages.no)
                                                                     : (
                                                                         <Fragment>
@@ -153,13 +154,13 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                                 }
                                                             </SplitItem>
                                                             <SplitItem className="pf-u-ml-md">
-                                                                { rule.reboot_required &&
-                                                                <Text>
-                                                                    <PowerOffIcon
-                                                                        className="pf-u-mr-xs powerOffIcon"
-                                                                    />
-                                                                    {intl.formatMessage(messages.rebootRequired)}
-                                                                </Text>
+                                                                {rule.reboot_required &&
+                                                                    <Text>
+                                                                        <PowerOffIcon
+                                                                            className="pf-u-mr-xs powerOffIcon"
+                                                                        />
+                                                                        {intl.formatMessage(messages.rebootRequired)}
+                                                                    </Text>
                                                                 }
                                                             </SplitItem>
                                                         </Split>
@@ -171,26 +172,26 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
 
                                         {
                                             rule.kbase_node_id &&
-                                        <StackItem>
-                                            <TextContent>
-                                                <Text
-                                                    className="pf-u-mt-xs"
-                                                    component={TextVariants.p}
-                                                >
-                                                    <a
-                                                        className="kb-link"
-                                                        href={`${RH_KB_URL}/${rule.kbase_node_id}`}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
+                                            <StackItem>
+                                                <TextContent>
+                                                    <Text
+                                                        className="pf-u-mt-xs"
+                                                        component={TextVariants.p}
                                                     >
-                                                        {
-                                                            intl.formatMessage(messages.knowledgebaseArticle)
-                                                        }
-                                                        <ExternalLinkAltIcon className="l-sm-spacer"/>
-                                                    </a>
-                                                </Text>
-                                            </TextContent>
-                                        </StackItem>
+                                                        <a
+                                                            className="kb-link"
+                                                            href={`${RH_KB_URL}/${rule.kbase_node_id}`}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                        >
+                                                            {
+                                                                intl.formatMessage(messages.knowledgebaseArticle)
+                                                            }
+                                                            <ExternalLinkAltIcon className="l-sm-spacer" />
+                                                        </a>
+                                                    </Text>
+                                                </TextContent>
+                                            </StackItem>
                                         }
 
                                     </Stack>
@@ -204,17 +205,17 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                             {synopsis} ({intl.formatMessage(messages.current)})
                                             {
                                                 rule.associated_cves
-                                                .filter(cve => cve !== synopsis)
-                                                .map((cve, _i) =>
-                                                    <a
-                                                        className="associated-cve-link"
-                                                        key={_i}
-                                                        href={`${CVES_PATH}/${cve}`}
-                                                    >
-                                                        {cve}
-                                                    </a>
-                                                )
-                                                .reduce((prev, curr) => [prev, ', ', curr], [''])
+                                                    .filter(cve => cve !== synopsis)
+                                                    .map((cve, _i) =>
+                                                        <a
+                                                            className="associated-cve-link"
+                                                            key={_i}
+                                                            href={`${CVES_PATH}/${cve}`}
+                                                        >
+                                                            {cve}
+                                                        </a>
+                                                    )
+                                                    .reduce((prev, curr) => [prev, ', ', curr], [''])
                                             }
                                         </Text>
                                     </TextContent>
@@ -224,8 +225,8 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                     </ExpandableSection>
                 </Card>
             )
-        ))}
-    </Fragment>;
+        ))
+    );
 };
 
 CSAwRuleBox.defaultProps = {

--- a/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSidebar/__snapshots__/CVEDetailsPageSidebar.test.js.snap
@@ -1156,22 +1156,20 @@ exports[`CVEDetailsPageSidebar component should render correctly 1`] = `
                           }
                         }
                         trigger={
-                          <React.Fragment>
-                            <Label
-                              className="pf-u-mb-xs pointer"
-                              isLarge={true}
-                            >
-                              CVSS 3.0
-                               
-                               base score
-                              <OutlinedQuestionCircleIcon
-                                className="pf-u-ml-xs"
-                                color="var(--pf-global--secondary-color--100)"
-                                noVerticalAlign={false}
-                                size="sm"
-                              />
-                            </Label>
-                          </React.Fragment>
+                          <Label
+                            className="pf-u-mb-xs pointer"
+                            isLarge={true}
+                          >
+                            CVSS 3.0
+                             
+                             base score
+                            <OutlinedQuestionCircleIcon
+                              className="pf-u-ml-xs"
+                              color="var(--pf-global--secondary-color--100)"
+                              noVerticalAlign={false}
+                              size="sm"
+                            />
+                          </Label>
                         }
                         zIndex={9999}
                       >

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/__snapshots__/CVEDetailsPageSummary.test.js.snap
@@ -1369,22 +1369,20 @@ exports[`CVEDetailsPageSummary component should render with data 1`] = `
                                           }
                                         }
                                         trigger={
-                                          <React.Fragment>
-                                            <Label
-                                              className="pf-u-mb-xs pointer"
-                                              isLarge={true}
-                                            >
-                                              CVSS 3.0
-                                               
-                                               base score
-                                              <OutlinedQuestionCircleIcon
-                                                className="pf-u-ml-xs"
-                                                color="var(--pf-global--secondary-color--100)"
-                                                noVerticalAlign={false}
-                                                size="sm"
-                                              />
-                                            </Label>
-                                          </React.Fragment>
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            CVSS 3.0
+                                             
+                                             base score
+                                            <OutlinedQuestionCircleIcon
+                                              className="pf-u-ml-xs"
+                                              color="var(--pf-global--secondary-color--100)"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                            />
+                                          </Label>
                                         }
                                         zIndex={9999}
                                       >
@@ -2602,22 +2600,20 @@ exports[`CVEDetailsPageSummary component should render with enabled WithLoader 1
                                           }
                                         }
                                         trigger={
-                                          <React.Fragment>
-                                            <Label
-                                              className="pf-u-mb-xs pointer"
-                                              isLarge={true}
-                                            >
-                                              CVSS 3.0
-                                               
-                                               base score
-                                              <OutlinedQuestionCircleIcon
-                                                className="pf-u-ml-xs"
-                                                color="var(--pf-global--secondary-color--100)"
-                                                noVerticalAlign={false}
-                                                size="sm"
-                                              />
-                                            </Label>
-                                          </React.Fragment>
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            CVSS 3.0
+                                             
+                                             base score
+                                            <OutlinedQuestionCircleIcon
+                                              className="pf-u-ml-xs"
+                                              color="var(--pf-global--secondary-color--100)"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                            />
+                                          </Label>
                                         }
                                         zIndex={9999}
                                       >
@@ -3870,22 +3866,20 @@ exports[`CVEDetailsPageSummary component should render with long description 1`]
                                           }
                                         }
                                         trigger={
-                                          <React.Fragment>
-                                            <Label
-                                              className="pf-u-mb-xs pointer"
-                                              isLarge={true}
-                                            >
-                                              CVSS 3.0
-                                               
-                                               base score
-                                              <OutlinedQuestionCircleIcon
-                                                className="pf-u-ml-xs"
-                                                color="var(--pf-global--secondary-color--100)"
-                                                noVerticalAlign={false}
-                                                size="sm"
-                                              />
-                                            </Label>
-                                          </React.Fragment>
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            CVSS 3.0
+                                             
+                                             base score
+                                            <OutlinedQuestionCircleIcon
+                                              className="pf-u-ml-xs"
+                                              color="var(--pf-global--secondary-color--100)"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                            />
+                                          </Label>
                                         }
                                         zIndex={9999}
                                       >
@@ -5077,22 +5071,20 @@ exports[`CVEDetailsPageSummary component should render without data 1`] = `
                                           }
                                         }
                                         trigger={
-                                          <React.Fragment>
-                                            <Label
-                                              className="pf-u-mb-xs pointer"
-                                              isLarge={true}
-                                            >
-                                              CVSS 3.0
-                                               
-                                               base score
-                                              <OutlinedQuestionCircleIcon
-                                                className="pf-u-ml-xs"
-                                                color="var(--pf-global--secondary-color--100)"
-                                                noVerticalAlign={false}
-                                                size="sm"
-                                              />
-                                            </Label>
-                                          </React.Fragment>
+                                          <Label
+                                            className="pf-u-mb-xs pointer"
+                                            isLarge={true}
+                                          >
+                                            CVSS 3.0
+                                             
+                                             base score
+                                            <OutlinedQuestionCircleIcon
+                                              className="pf-u-ml-xs"
+                                              color="var(--pf-global--secondary-color--100)"
+                                              noVerticalAlign={false}
+                                              size="sm"
+                                            />
+                                          </Label>
                                         }
                                         zIndex={9999}
                                       >

--- a/src/Components/PresentationalComponents/CvssVector/CvssVector.js
+++ b/src/Components/PresentationalComponents/CvssVector/CvssVector.js
@@ -63,15 +63,13 @@ const CvssVector = props => {
                             </WithLoader>
                         }
                     >
-                        <React.Fragment>
-                            <Label isLarge className="pf-u-mb-xs pointer">
-                                {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
-                                <OutlinedQuestionCircleIcon
-                                    color={'var(--pf-global--secondary-color--100)'}
-                                    className="pf-u-ml-xs"
-                                />
-                            </Label>
-                        </React.Fragment>
+                        <Label isLarge className="pf-u-mb-xs pointer">
+                            {cvssVer} {intl.formatMessage(messages.cvssVectorVectorString)}
+                            <OutlinedQuestionCircleIcon
+                                color={'var(--pf-global--secondary-color--100)'}
+                                className="pf-u-ml-xs"
+                            />
+                        </Label>
                     </Popover>
 
                     <WithLoader isLoading={context.isLoading} style={{ width: '320px' }}>

--- a/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
+++ b/src/Components/PresentationalComponents/CvssVector/__snapshots__/CvssVector.test.js.snap
@@ -291,22 +291,20 @@ exports[`CvssVector Should render CVSSv3 when given both 1`] = `
               }
             }
             trigger={
-              <React.Fragment>
-                <Label
-                  className="pf-u-mb-xs pointer"
-                  isLarge={true}
-                >
-                  CVSS 3.0
-                   
-                   base score
-                  <OutlinedQuestionCircleIcon
-                    className="pf-u-ml-xs"
-                    color="var(--pf-global--secondary-color--100)"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />
-                </Label>
-              </React.Fragment>
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                CVSS 3.0
+                 
+                 base score
+                <OutlinedQuestionCircleIcon
+                  className="pf-u-ml-xs"
+                  color="var(--pf-global--secondary-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+              </Label>
             }
             zIndex={9999}
           >
@@ -668,22 +666,20 @@ exports[`CvssVector Should render with CVSSv2 1`] = `
               }
             }
             trigger={
-              <React.Fragment>
-                <Label
-                  className="pf-u-mb-xs pointer"
-                  isLarge={true}
-                >
-                  CVSS 2.0
-                   
-                   base score
-                  <OutlinedQuestionCircleIcon
-                    className="pf-u-ml-xs"
-                    color="var(--pf-global--secondary-color--100)"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />
-                </Label>
-              </React.Fragment>
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                CVSS 2.0
+                 
+                 base score
+                <OutlinedQuestionCircleIcon
+                  className="pf-u-ml-xs"
+                  color="var(--pf-global--secondary-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+              </Label>
             }
             zIndex={9999}
           >
@@ -1061,22 +1057,20 @@ exports[`CvssVector Should render with CVSSv3 1`] = `
               }
             }
             trigger={
-              <React.Fragment>
-                <Label
-                  className="pf-u-mb-xs pointer"
-                  isLarge={true}
-                >
-                  CVSS 3.0
-                   
-                   base score
-                  <OutlinedQuestionCircleIcon
-                    className="pf-u-ml-xs"
-                    color="var(--pf-global--secondary-color--100)"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />
-                </Label>
-              </React.Fragment>
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                CVSS 3.0
+                 
+                 base score
+                <OutlinedQuestionCircleIcon
+                  className="pf-u-ml-xs"
+                  color="var(--pf-global--secondary-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+              </Label>
             }
             zIndex={9999}
           >
@@ -1323,22 +1317,20 @@ exports[`CvssVector Should render without parameters 1`] = `
               }
             }
             trigger={
-              <React.Fragment>
-                <Label
-                  className="pf-u-mb-xs pointer"
-                  isLarge={true}
-                >
-                  CVSS 3.0
-                   
-                   base score
-                  <OutlinedQuestionCircleIcon
-                    className="pf-u-ml-xs"
-                    color="var(--pf-global--secondary-color--100)"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />
-                </Label>
-              </React.Fragment>
+              <Label
+                className="pf-u-mb-xs pointer"
+                isLarge={true}
+              >
+                CVSS 3.0
+                 
+                 base score
+                <OutlinedQuestionCircleIcon
+                  className="pf-u-ml-xs"
+                  color="var(--pf-global--secondary-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+              </Label>
             }
             zIndex={9999}
           >

--- a/src/Components/PresentationalComponents/InsightsSystemRule/InsightsSystemRule.js
+++ b/src/Components/PresentationalComponents/InsightsSystemRule/InsightsSystemRule.js
@@ -10,26 +10,23 @@ import messages from '../../../Messages';
 
 export const InsightsSystemRule = ({ rule, cve }) => {
     return (
-        <Fragment>
-            { !rule ? <InsightsNoSystemRule cve={cve}/> :
-                <Fragment>
-                    <TextContent>
-                        <Text component={TextVariants.h3} className="pf-u-pb-lg">
-                            <Label isInline>
-                                <CSAwLabel className="pf-u-mr-sm"/>
-                            </Label>
-                            <span className="rule-name">{rule.rule.description || rule.rule.rule_id}</span>
-                        </Text>
-                    </TextContent>
+        !rule ? <InsightsNoSystemRule cve={cve} /> :
+            <Fragment>
+                <TextContent>
+                    <Text component={TextVariants.h3} className="pf-u-pb-lg">
+                        <Label isInline>
+                            <CSAwLabel className="pf-u-mr-sm" />
+                        </Label>
+                        <span className="rule-name">{rule.rule.description || rule.rule.rule_id}</span>
+                    </Text>
+                </TextContent>
 
-                    <InsightsReportCard
-                        report={rule}
-                        kbaLoading={false}
-                        kbaDetail={{ view_uri: `${RH_KB_URL}/${rule.rule.node_id}` }}
-                    />
-                </Fragment>
-            }
-        </Fragment>
+                <InsightsReportCard
+                    report={rule}
+                    kbaLoading={false}
+                    kbaDetail={{ view_uri: `${RH_KB_URL}/${rule.rule.node_id}` }}
+                />
+            </Fragment>
     );
 };
 
@@ -49,7 +46,7 @@ export const InsightsNoSystemRule = ({ cve }) => {
                 <FormattedMessage {...messages.exposedSystemNoRules} values={{ cve }} />
             </Text>
             <Text component={TextVariants.p} className="pf-u-mb-sm">
-                <FormattedMessage {...messages.exposedSystemNoRulesInfo}/>
+                <FormattedMessage {...messages.exposedSystemNoRulesInfo} />
             </Text>
             <Text
                 component={TextVariants.a}

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -93,55 +93,53 @@ const CVEDetailsPage = ({ match }) => {
     if (error?.hasError) {
         return (
             <React.Fragment>
-                <Header title={cveName}/>
+                <Header title={cveName} />
                 <ErrorHandler code={error?.errorCode} />
             </React.Fragment>
         );
     } else {
         return (
-            <React.Fragment>
-                <CVEPageContext.Provider value={cveDetails && { isLoading: cveDetails.isLoading }}>
-                    <Header
-                        title={data.celebrity_name ? cveName + ' - ' + data.celebrity_name : cveName}
-                        actions={kebabItems}
-                        actionsOuiaId={'cve-actions'}
-                        breadcrumbs={[
-                            {
-                                title: PATHS.cvesPage.title,
-                                to: PATHS.cvesPage.to,
-                                loaded: true
-                            },
-                            {
-                                title: cveName,
-                                isActive: true,
-                                loaded: true
-                            }
-                        ]}
-                        labels={[
-                            <GroupedCVELabels
-                                key="labels"
-                                hasExploit={!!details.payload.data?.attributes.known_exploit}
-                                hasRule={details.payload.data?.attributes.rules.length > 0}
-                            />
-                        ]}
-                    >
-                        <CVEDetailsPageSummary
-                            changeExposedSystemsParameters={changeExposedSystemsParameters}
-                            data={cveDetails}
+            <CVEPageContext.Provider value={cveDetails && { isLoading: cveDetails.isLoading }}>
+                <Header
+                    title={data.celebrity_name ? cveName + ' - ' + data.celebrity_name : cveName}
+                    actions={kebabItems}
+                    actionsOuiaId={'cve-actions'}
+                    breadcrumbs={[
+                        {
+                            title: PATHS.cvesPage.title,
+                            to: PATHS.cvesPage.to,
+                            loaded: true
+                        },
+                        {
+                            title: cveName,
+                            isActive: true,
+                            loaded: true
+                        }
+                    ]}
+                    labels={[
+                        <GroupedCVELabels
+                            key="labels"
+                            hasExploit={!!details.payload.data?.attributes.known_exploit}
+                            hasRule={details.payload.data?.attributes.rules.length > 0}
                         />
-                        <StatusModal />
-                        <BusinessModal />
-                    </Header>
-                    <Main>
-                        <SystemsExposedTable
-                            cve={cveName}
-                            filterRuleValues={filterRuleValues}
-                            cveStatusDetails={cveStatusDetails}
-                            methods={{ showStatusModal }}
-                        />
-                    </Main>
-                </CVEPageContext.Provider>
-            </React.Fragment>
+                    ]}
+                >
+                    <CVEDetailsPageSummary
+                        changeExposedSystemsParameters={changeExposedSystemsParameters}
+                        data={cveDetails}
+                    />
+                    <StatusModal />
+                    <BusinessModal />
+                </Header>
+                <Main>
+                    <SystemsExposedTable
+                        cve={cveName}
+                        filterRuleValues={filterRuleValues}
+                        cveStatusDetails={cveStatusDetails}
+                        methods={{ showStatusModal }}
+                    />
+                </Main>
+            </CVEPageContext.Provider>
         );
     }
 };

--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -21,7 +21,7 @@ const CVEsTableWithContext = ({ context, header }) => {
                         context.params.affecting === 'true'
                             ? messages.emptyStateYourSystemsShouldHaveCVEs
                             : messages.emptyStateThereShouldBeCVEs
-                    }/>
+                    } />
                 }
             ]
         }]);
@@ -37,50 +37,48 @@ const CVEsTableWithContext = ({ context, header }) => {
     const isEmpty = cves.data.length === 0;
 
     const rows = cves.data && cves.data
-    .map(cve => (selectedCves.includes(cve.id) && { ...cve, selected: true }) || cve)
-    .map((cve, index) => {
-        const current = index % 2 === 0 ? expandedRows.includes(cve.id) : undefined;
-        return ({ ...cve, isOpen: current });
-    });
+        .map(cve => (selectedCves.includes(cve.id) && { ...cve, selected: true }) || cve)
+        .map((cve, index) => {
+            const current = index % 2 === 0 ? expandedRows.includes(cve.id) : undefined;
+            return ({ ...cve, isOpen: current });
+        });
 
     return (
-        <Fragment>
-            {!cves.isLoading ? (
-                <Fragment>
-                    <Table
-                        canSelectAll={false}
-                        aria-label={'Vulnerability CVE table'}
-                        cells={header}
-                        rows={isEmpty ? noCves() : rows}
-                        onSelect={!isEmpty ? handleOnSelect : undefined}
-                        onCollapse={!isEmpty ?  (event, rowKey) => methods.openCves(rowKey) : undefined}
-                        actionResolver={!(cves.data.length === 0) ?
-                            (rowData, rowIndex) => cveTableRowActions(methods, rowIndex.rowIndex) : undefined}
-                        sortBy={!isEmpty ?
-                            createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
-                        onSort={!isEmpty ?
-                            (event, key, direction) =>
-                                handleSortColumn(
-                                    key,
-                                    direction,
-                                    [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
-                                    cves.meta.sort,
-                                    methods.apply
-                                ) : undefined
-                        }
-                        ouiaId={'cves-table'}
-                        isStickyHeader
-                        variant={TableVariant.compact}
-                    >
-                        <TableHeader />
-                        <TableBody />
-                    </Table>
-                    <PaginationWrapper meta={cves.meta} apply={methods.apply} />
-                </Fragment>
-            ) : (
-                <SkeletonTable colSize={7} rowSize={20} variant={TableVariant.compact}/>
-            )}
-        </Fragment>
+        !cves.isLoading ? (
+            <Fragment>
+                <Table
+                    canSelectAll={false}
+                    aria-label={'Vulnerability CVE table'}
+                    cells={header}
+                    rows={isEmpty ? noCves() : rows}
+                    onSelect={!isEmpty ? handleOnSelect : undefined}
+                    onCollapse={!isEmpty ? (event, rowKey) => methods.openCves(rowKey) : undefined}
+                    actionResolver={!(cves.data.length === 0) ?
+                        (rowData, rowIndex) => cveTableRowActions(methods, rowIndex.rowIndex) : undefined}
+                    sortBy={!isEmpty ?
+                        createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
+                    onSort={!isEmpty ?
+                        (event, key, direction) =>
+                            handleSortColumn(
+                                key,
+                                direction,
+                                [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
+                                cves.meta.sort,
+                                methods.apply
+                            ) : undefined
+                    }
+                    ouiaId={'cves-table'}
+                    isStickyHeader
+                    variant={TableVariant.compact}
+                >
+                    <TableHeader />
+                    <TableBody />
+                </Table>
+                <PaginationWrapper meta={cves.meta} apply={methods.apply} />
+            </Fragment>
+        ) : (
+            <SkeletonTable colSize={7} rowSize={20} variant={TableVariant.compact} />
+        )
     );
 
 };

--- a/src/Components/SmartComponents/Modals/BaseModal.js
+++ b/src/Components/SmartComponents/Modals/BaseModal.js
@@ -65,25 +65,23 @@ export const BaseModal = ({ items, title, onSave, onSuccessNotification, onFailu
     }, [clearNotifications]);
 
     return (
-        <React.Fragment>
-            <Modal
-                variant="small"
-                title={title}
-                isOpen={Boolean(targetItems)}
-                onClose={handleClose}
-                actions={[
-                    <Button key="save" variant="primary" ouiaId="save" onClick={handleSave}>
-                        {<FormattedMessage {...messages.save} />}
-                    </Button>,
-                    <Button key="cancel" variant="secondary" ouiaId="close" onClick={handleClose}>
-                        {<FormattedMessage {...messages.cancel} />}
-                    </Button>
-                ]}
-                ouiaId={props.ouiaId}
-            >
-                {props.children}
-            </Modal>
-        </React.Fragment>
+        <Modal
+            variant="small"
+            title={title}
+            isOpen={Boolean(targetItems)}
+            onClose={handleClose}
+            actions={[
+                <Button key="save" variant="primary" ouiaId="save" onClick={handleSave}>
+                    {<FormattedMessage {...messages.save} />}
+                </Button>,
+                <Button key="cancel" variant="secondary" ouiaId="close" onClick={handleClose}>
+                    {<FormattedMessage {...messages.cancel} />}
+                </Button>
+            ]}
+            ouiaId={props.ouiaId}
+        >
+            {props.children}
+        </Modal>
     );
 };
 

--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -34,8 +34,8 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                 })
             ]
         ])
-        .then(updateRef)
-        .catch(error => { throw error; }); // propagate error to BaseModal
+            .then(updateRef)
+            .catch(error => { throw error; }); // propagate error to BaseModal
     };
 
     function getDefaultStatus() {
@@ -92,12 +92,10 @@ export const CveStatusModal = ({ cves, updateRef, intl }) => {
                     <Tooltip
                         content={intl.formatMessage(messages.cveStatusModalInfoTooltip)}
                     >
-                        <React.Fragment>
-                            <OutlinedQuestionCircleIcon
-                                className="pf-u-ml-xs"
-                                color="var(--pf-global--Color--200)"
-                            />
-                        </React.Fragment>
+                        <OutlinedQuestionCircleIcon
+                            className="pf-u-ml-xs"
+                            color="var(--pf-global--Color--200)"
+                        />
                     </Tooltip>
                 </StackItem>
                 <StackItem>

--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
@@ -451,79 +451,77 @@ User notes
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-23969
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-23969
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [
@@ -560,79 +558,77 @@ User notes
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-20250
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-20250
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [
@@ -669,79 +665,77 @@ User notes
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-1998
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-1998
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [
@@ -1774,79 +1768,77 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-23969
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-23969
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [
@@ -1951,79 +1943,77 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-20250
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-20250
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [
@@ -2128,79 +2118,77 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   </TEXT>,
                 ],
                 Array [
-                  <React.Fragment>
-                    <VIEW
-                      style={
-                        Array [
-                          Object {
-                            "fontSize": 8,
-                            "paddingBottom": 2,
-                            "paddingTop": 2,
-                            "textAlign": "left",
-                          },
-                          Object {
-                            "width": "72px",
-                          },
-                        ]
-                      }
-                    >
-                      <VIEW>
-                        <TEXT>
-                          <LINK
-                            src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                            style={
-                              Object {
-                                "color": "#0066CC",
-                                "textDecoration": "none",
-                              }
+                  <VIEW
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 8,
+                          "paddingBottom": 2,
+                          "paddingTop": 2,
+                          "textAlign": "left",
+                        },
+                        Object {
+                          "width": "72px",
+                        },
+                      ]
+                    }
+                  >
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                          style={
+                            Object {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
                             }
-                          >
-                            CVE-2021-1998
-                          </LINK>
-                        </TEXT>
-                      </VIEW>
-                      <CVElabels
-                        hasExploit={false}
-                        hasRule={false}
-                        intl={
-                          Object {
-                            "defaultFormats": Object {},
-                            "defaultLocale": "en",
-                            "defaultRichTextElements": undefined,
-                            "formatDate": [Function],
-                            "formatDateTimeRange": [Function],
-                            "formatDateToParts": [Function],
-                            "formatDisplayName": [Function],
-                            "formatList": [Function],
-                            "formatListToParts": [Function],
-                            "formatMessage": [Function],
-                            "formatNumber": [Function],
-                            "formatNumberToParts": [Function],
-                            "formatPlural": [Function],
-                            "formatRelativeTime": [Function],
-                            "formatTime": [Function],
-                            "formatTimeToParts": [Function],
-                            "formats": Object {},
-                            "formatters": Object {
-                              "getDateTimeFormat": [Function],
-                              "getDisplayNames": [Function],
-                              "getListFormat": [Function],
-                              "getMessageFormat": [Function],
-                              "getNumberFormat": [Function],
-                              "getPluralRules": [Function],
-                              "getRelativeTimeFormat": [Function],
-                            },
-                            "locale": "en",
-                            "messages": Object {},
-                            "onError": [Function],
-                            "textComponent": Symbol(react.fragment),
-                            "timeZone": undefined,
                           }
-                        }
-                        isSmall={true}
-                      />
+                        >
+                          CVE-2021-1998
+                        </LINK>
+                      </TEXT>
                     </VIEW>
-                  </React.Fragment>,
+                    <CVElabels
+                      hasExploit={false}
+                      hasRule={false}
+                      intl={
+                        Object {
+                          "defaultFormats": Object {},
+                          "defaultLocale": "en",
+                          "defaultRichTextElements": undefined,
+                          "formatDate": [Function],
+                          "formatDateTimeRange": [Function],
+                          "formatDateToParts": [Function],
+                          "formatDisplayName": [Function],
+                          "formatList": [Function],
+                          "formatListToParts": [Function],
+                          "formatMessage": [Function],
+                          "formatNumber": [Function],
+                          "formatNumberToParts": [Function],
+                          "formatPlural": [Function],
+                          "formatRelativeTime": [Function],
+                          "formatTime": [Function],
+                          "formatTimeToParts": [Function],
+                          "formats": Object {},
+                          "formatters": Object {
+                            "getDateTimeFormat": [Function],
+                            "getDisplayNames": [Function],
+                            "getListFormat": [Function],
+                            "getMessageFormat": [Function],
+                            "getNumberFormat": [Function],
+                            "getPluralRules": [Function],
+                            "getRelativeTimeFormat": [Function],
+                          },
+                          "locale": "en",
+                          "messages": Object {},
+                          "onError": [Function],
+                          "textComponent": Symbol(react.fragment),
+                          "timeZone": undefined,
+                        }
+                      }
+                      isSmall={true}
+                    />
+                  </VIEW>,
                   <TEXT
                     style={
                       Array [

--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
@@ -604,79 +604,77 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-23969
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-23969
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [
@@ -730,79 +728,77 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-20250
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-20250
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [
@@ -856,79 +852,77 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-1998
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-1998
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [
@@ -1817,79 +1811,77 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-23969
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-23969
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [
@@ -1994,79 +1986,77 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-20250
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-20250
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [
@@ -2171,79 +2161,77 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 </TEXT>,
               ],
               Array [
-                <React.Fragment>
-                  <VIEW
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 8,
-                          "paddingBottom": 2,
-                          "paddingTop": 2,
-                          "textAlign": "left",
-                        },
-                        Object {
-                          "width": "72px",
-                        },
-                      ]
-                    }
-                  >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                          style={
-                            Object {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                <VIEW
+                  style={
+                    Array [
+                      Object {
+                        "fontSize": 8,
+                        "paddingBottom": 2,
+                        "paddingTop": 2,
+                        "textAlign": "left",
+                      },
+                      Object {
+                        "width": "72px",
+                      },
+                    ]
+                  }
+                >
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          Object {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-1998
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
-                    <CVElabels
-                      hasExploit={false}
-                      hasRule={false}
-                      intl={
-                        Object {
-                          "defaultFormats": Object {},
-                          "defaultLocale": "en",
-                          "defaultRichTextElements": undefined,
-                          "formatDate": [Function],
-                          "formatDateTimeRange": [Function],
-                          "formatDateToParts": [Function],
-                          "formatDisplayName": [Function],
-                          "formatList": [Function],
-                          "formatListToParts": [Function],
-                          "formatMessage": [Function],
-                          "formatNumber": [Function],
-                          "formatNumberToParts": [Function],
-                          "formatPlural": [Function],
-                          "formatRelativeTime": [Function],
-                          "formatTime": [Function],
-                          "formatTimeToParts": [Function],
-                          "formats": Object {},
-                          "formatters": Object {
-                            "getDateTimeFormat": [Function],
-                            "getDisplayNames": [Function],
-                            "getListFormat": [Function],
-                            "getMessageFormat": [Function],
-                            "getNumberFormat": [Function],
-                            "getPluralRules": [Function],
-                            "getRelativeTimeFormat": [Function],
-                          },
-                          "locale": "en",
-                          "messages": Object {},
-                          "onError": [Function],
-                          "textComponent": Symbol(react.fragment),
-                          "timeZone": undefined,
                         }
-                      }
-                      isSmall={true}
-                    />
+                      >
+                        CVE-2021-1998
+                      </LINK>
+                    </TEXT>
                   </VIEW>
-                </React.Fragment>,
+                  <CVElabels
+                    hasExploit={false}
+                    hasRule={false}
+                    intl={
+                      Object {
+                        "defaultFormats": Object {},
+                        "defaultLocale": "en",
+                        "defaultRichTextElements": undefined,
+                        "formatDate": [Function],
+                        "formatDateTimeRange": [Function],
+                        "formatDateToParts": [Function],
+                        "formatDisplayName": [Function],
+                        "formatList": [Function],
+                        "formatListToParts": [Function],
+                        "formatMessage": [Function],
+                        "formatNumber": [Function],
+                        "formatNumberToParts": [Function],
+                        "formatPlural": [Function],
+                        "formatRelativeTime": [Function],
+                        "formatTime": [Function],
+                        "formatTimeToParts": [Function],
+                        "formats": Object {},
+                        "formatters": Object {
+                          "getDateTimeFormat": [Function],
+                          "getDisplayNames": [Function],
+                          "getListFormat": [Function],
+                          "getMessageFormat": [Function],
+                          "getNumberFormat": [Function],
+                          "getPluralRules": [Function],
+                          "getRelativeTimeFormat": [Function],
+                        },
+                        "locale": "en",
+                        "messages": Object {},
+                        "onError": [Function],
+                        "textComponent": Symbol(react.fragment),
+                        "timeZone": undefined,
+                      }
+                    }
+                    isSmall={true}
+                  />
+                </VIEW>,
                 <TEXT
                   style={
                     Array [

--- a/src/Components/SmartComponents/Reports/Common/tablePage.js
+++ b/src/Components/SmartComponents/Reports/Common/tablePage.js
@@ -86,28 +86,26 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
     const cveRows = [
         ...data.map(({ attributes: cve }) => {
             const synopsisCell = (
-                <Fragment>
-                    <View style={[styles.bodyCell, styles.cveCell]}>
-                        <View>
-                            <Text>
-                                <Link
-                                    style={styles.link}
-                                    src={`${CVES_PATH}/${cve.synopsis}`}
-                                >
-                                    {cve.synopsis}
-                                </Link>
-                            </Text>
-                        </View>
-                        <CVElabels hasExploit={hasExploit(cve)} hasRule={hasRules(cve)} intl={intl} isSmall />
+                <View style={[styles.bodyCell, styles.cveCell]}>
+                    <View>
+                        <Text>
+                            <Link
+                                style={styles.link}
+                                src={`${CVES_PATH}/${cve.synopsis}`}
+                            >
+                                {cve.synopsis}
+                            </Link>
+                        </Text>
                     </View>
-                </Fragment>
+                    <CVElabels hasExploit={hasExploit(cve)} hasRule={hasRules(cve)} intl={intl} isSmall />
+                </View>
             );
 
             const publishDateCell = (
                 (!header || header.includes('publish_date')) &&
-                    <Text key={cve.public_date} style={[styles.bodyCell, styles.cveCell]}>
-                        { processDate(cve.public_date) }
-                    </Text>
+                <Text key={cve.public_date} style={[styles.bodyCell, styles.cveCell]}>
+                    {processDate(cve.public_date)}
+                </Text>
             );
 
             return [
@@ -122,9 +120,10 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
         ...data.map(({ attributes: system }) => {
             return [
                 columnBuilder({ value: system.display_name, style: [styles.bodyCell, styles.systemNameCell] }),
-                columnBuilder({ value: system.opt_out
-                    ? intl.formatMessage(messages.systemsTableExcluded)
-                    : system.cve_count, style: [styles.bodyCell, styles.systemCell]
+                columnBuilder({
+                    value: system.opt_out
+                        ? intl.formatMessage(messages.systemsTableExcluded)
+                        : system.cve_count, style: [styles.bodyCell, styles.systemCell]
                 }),
                 columnBuilder({ value: formatDate(system.updated, true), style: [styles.bodyCell, styles.systemCell] })
             ];
@@ -146,7 +145,7 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
                 ... (type === 'cves') ? cveRows : systemRows
             ]}
         />
-        { data.length === 0 && <Text>{intl.formatMessage(messages.customReportNoCves)}</Text> }
+        {data.length === 0 && <Text>{intl.formatMessage(messages.customReportNoCves)}</Text>}
     </Fragment>;
 };
 

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -33,7 +33,7 @@ const SystemCvesTableWithContext = ({ context, header, entity }) => {
     };
 
     const handleOnCollapse = (event, rowKey, isOpen) => {
-        const { cves, methods,  isAllExpanded } = context;
+        const { cves, methods, isAllExpanded } = context;
         const cveName = cves.data[rowKey] && cves.data[rowKey].id;
         methods.openCves(isOpen, [cveName], isAllExpanded);
     };
@@ -47,55 +47,52 @@ const SystemCvesTableWithContext = ({ context, header, entity }) => {
     const isEmpty = !cves.data || cves.data.length === 0;
 
     const rows = !isEmpty ? cves.data
-    .map(cve => (selectedCves.includes(cve.id) && { ...cve, selected: true }) || cve)
-    .map((cve, index) => {
-        const current = index % 2 === 0 ? expandedRows.find(opened => opened.id === cve.id) || false : { isOpen: undefined };
-        return ({ ...cve, isOpen: current && current.isOpen });
-    }) : [];
+        .map(cve => (selectedCves.includes(cve.id) && { ...cve, selected: true }) || cve)
+        .map((cve, index) => {
+            const current = index % 2 === 0 ? expandedRows.find(opened => opened.id === cve.id) || false : { isOpen: undefined };
+            return ({ ...cve, isOpen: current && current.isOpen });
+        }) : [];
 
     return (
-        <Fragment>
-            {!cves.isLoading ? (
-                <Fragment>
-                    <Table
-                        isStickyHeader
-                        canSelectAll={false}
-                        aria-label={'Vulnerability CVE table'}
-                        cells={header}
-                        rows={isEmpty ? noCves() : rows}
-                        onSelect={!isEmpty ? handleOnSelect : undefined}
-                        actionResolver={ (!isEmpty && canEditStatus) &&
-                            ((rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex))}
-                        sortBy={!isEmpty
-                            ? createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
-                        onCollapse={!isEmpty ? (event, rowKey, isOpen) => handleOnCollapse(event, rowKey, isOpen) : undefined}
-                        onSort={!isEmpty ?
-                            (event, key, direction) =>
-                                handleSortColumn(
-                                    key,
-                                    direction,
-                                    [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
-                                    cves.meta.sort,
-                                    methods.apply
-                                ) : undefined
-                        }
-                        gridBreakPoint={'grid-lg'}
-                        ouiaId={'cves-table'}
-                        variant={TableVariant.compact}
-                    >
-                        <Fragment>
-                            <TableHeader />
-                            <TableBody />
-                        </Fragment>
-                    </Table>
-                    <PaginationWrapper meta={cves.meta} apply={methods.apply} />
-                </Fragment>
-            ) : (
-                <SkeletonTable colSize={6} rowSize={20} variant={TableVariant.compact}/>
-            )}
-        </Fragment>
+        !cves.isLoading ? (
+            <Fragment>
+                <Table
+                    isStickyHeader
+                    canSelectAll={false}
+                    aria-label={'Vulnerability CVE table'}
+                    cells={header}
+                    rows={isEmpty ? noCves() : rows}
+                    onSelect={!isEmpty ? handleOnSelect : undefined}
+                    actionResolver={(!isEmpty && canEditStatus) &&
+                        ((rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex))}
+                    sortBy={!isEmpty
+                        ? createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
+                    onCollapse={!isEmpty ? (event, rowKey, isOpen) => handleOnCollapse(event, rowKey, isOpen) : undefined}
+                    onSort={!isEmpty ?
+                        (event, key, direction) =>
+                            handleSortColumn(
+                                key,
+                                direction,
+                                [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
+                                cves.meta.sort,
+                                methods.apply
+                            ) : undefined
+                    }
+                    gridBreakPoint={'grid-lg'}
+                    ouiaId={'cves-table'}
+                    variant={TableVariant.compact}
+                >
+                    <Fragment>
+                        <TableHeader />
+                        <TableBody />
+                    </Fragment>
+                </Table>
+                <PaginationWrapper meta={cves.meta} apply={methods.apply} />
+            </Fragment>
+        ) : (
+            <SkeletonTable colSize={6} rowSize={20} variant={TableVariant.compact} />
+        )
     );
-
 };
 
 SystemCvesTableWithContext.propTypes = {

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -35,7 +35,7 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
     const { filter, advisory } = parameters;
     const selectedCvesCount = canRemediate && ((selectedCves && selectedCves.length) || 0);
 
-    const selectOptions  = useMemo(() => selectAllCheckbox({
+    const selectOptions = useMemo(() => selectAllCheckbox({
         selectedItems: selectedCves,
         selectorHandler: methods.selectCves,
         items: cves,
@@ -51,12 +51,12 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
                     [...selectedCves].map(item => ({
                         id: item,
                         ...cves.data.filter(cve => item === cve.id)
-                        .map(item => ({
-                            status_id: item.status_id,
-                            cve_status_id: item.cve_status_id,
-                            justification: item.status_justification,
-                            cve_justification: item.cve_status_justification
-                        }))[0]
+                            .map(item => ({
+                                status_id: item.status_id,
+                                cve_status_id: item.cve_status_id,
+                                justification: item.status_justification,
+                                cve_justification: item.cve_status_justification
+                            }))[0]
                     })), []
                 ),
                 props: { isDisabled: !selectedCvesCount }
@@ -66,61 +66,58 @@ const SystemCveToolbarWithContext = ({ entity, intl, context }) => {
     const selectedCvesData = selectedCves.flatMap(item => cves.data.filter(cve => item === cve.id));
 
     return (
-        <React.Fragment>
-            <PrimaryToolbar
-                pagination={{
-                    itemCount: cves.meta.total_items || 0,
-                    page: cves.meta.page || 1,
-                    perPage: cves.meta.page_size || 1,
-                    ouiaId: 'pagination-top',
-                    onSetPage: (_event, page) => handleChangePage(_event, page, methods.apply),
-                    onPerPageSelect: (_event, perPage) => handleSetPageSize(_event, perPage, methods.apply)
-                }}
-                dedicatedAction={(canRemediate && entity && <Remediation systems={entity} cves={selectedCvesData} />)}
-                actionsConfig={{
-                    actions,
-                    kebabToggleProps: { isDisabled: !selectedCvesCount },
-                    dropdownProps: { ouiaId: 'toolbar-actions' }
-                } }
-                bulkSelect={{
-                    count: selectedCvesCount,
-                    items: selectOptions.items,
-                    isDisabled: cves.meta.total_items === 0 && selectedCvesCount === 0,
-                    checked: Boolean(selectedCvesCount),
-                    ouiaId: 'bulk-select',
-                    onSelect: ()=> selectOptions.handleOnCheckboxChange()
-                }}
-                filterConfig={{
-                    items: [
-                        useSearchFilter('filter', messages.cve, messages.searchFilterByCveID, filter, methods.apply),
-                        securityRuleFilter(methods.apply, parameters),
-                        knownExploitFilter(methods.apply, parameters),
-                        impactFilter(methods.apply, parameters),
-                        useCvssBaseScoreFilter(methods.apply, parameters),
-                        businessRiskFilter(methods.apply, parameters),
-                        publishDateFilter(methods.apply, parameters),
-                        statusFilter(methods.apply, parameters),
-                        useSearchFilter('advisory', messages.advisory, messages.search, advisory, methods.apply)
-                    ]
-                }}
-                activeFiltersConfig={{
-                    filters: buildActiveFilters(parameters),
-                    onDelete: (_, chips) => removeFilters(chips, methods.apply),
-                    deleteTitle: intl.formatMessage(messages.resetFilters)
-                }}
-                exportConfig = {{
-                    isDisabled: cves.meta.total_items === 0,
-                    ouiaId: 'export',
-                    ...exportConfig(methods)
-                }}
-                expandAll = {{
-                    isAllExpanded,
-                    onClick: onExpandAllClick
-                }}
-            />
-        </React.Fragment>
+        <PrimaryToolbar
+            pagination={{
+                itemCount: cves.meta.total_items || 0,
+                page: cves.meta.page || 1,
+                perPage: cves.meta.page_size || 1,
+                ouiaId: 'pagination-top',
+                onSetPage: (_event, page) => handleChangePage(_event, page, methods.apply),
+                onPerPageSelect: (_event, perPage) => handleSetPageSize(_event, perPage, methods.apply)
+            }}
+            dedicatedAction={(canRemediate && entity && <Remediation systems={entity} cves={selectedCvesData} />)}
+            actionsConfig={{
+                actions,
+                kebabToggleProps: { isDisabled: !selectedCvesCount },
+                dropdownProps: { ouiaId: 'toolbar-actions' }
+            }}
+            bulkSelect={{
+                count: selectedCvesCount,
+                items: selectOptions.items,
+                isDisabled: cves.meta.total_items === 0 && selectedCvesCount === 0,
+                checked: Boolean(selectedCvesCount),
+                ouiaId: 'bulk-select',
+                onSelect: () => selectOptions.handleOnCheckboxChange()
+            }}
+            filterConfig={{
+                items: [
+                    useSearchFilter('filter', messages.cve, messages.searchFilterByCveID, filter, methods.apply),
+                    securityRuleFilter(methods.apply, parameters),
+                    knownExploitFilter(methods.apply, parameters),
+                    impactFilter(methods.apply, parameters),
+                    useCvssBaseScoreFilter(methods.apply, parameters),
+                    businessRiskFilter(methods.apply, parameters),
+                    publishDateFilter(methods.apply, parameters),
+                    statusFilter(methods.apply, parameters),
+                    useSearchFilter('advisory', messages.advisory, messages.search, advisory, methods.apply)
+                ]
+            }}
+            activeFiltersConfig={{
+                filters: buildActiveFilters(parameters),
+                onDelete: (_, chips) => removeFilters(chips, methods.apply),
+                deleteTitle: intl.formatMessage(messages.resetFilters)
+            }}
+            exportConfig={{
+                isDisabled: cves.meta.total_items === 0,
+                ouiaId: 'export',
+                ...exportConfig(methods)
+            }}
+            expandAll={{
+                isAllExpanded,
+                onClick: onExpandAllClick
+            }}
+        />
     );
-
 };
 
 SystemCveToolbarWithContext.defaultProps = {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -209,110 +209,108 @@ const SystemsExposedTable = (props) => {
     const advisoryFilter = useSearchFilter('advisory', messages.advisory, messages.search, parameters.advisory, apply);
 
     return (
-        <React.Fragment>
-            <Stack hasGutter>
-                <StackItem>
-                    <TextContent>
-                        <Text component={TextVariants.h2}>
-                            {props.intl.formatMessage(messages.affectsSystems)}
-                        </Text>
-                    </TextContent>
-                </StackItem>
-                <StackItem>
-                    {error?.hasError
-                        ? <ErrorHandler code={error?.errorCode} />
-                        : <InventoryTable
-                            disableDefaultColumns
-                            onLoad={({ mergeWithEntities, mergeWithDetail }) => {
-                                ReducerRegistry.register({
-                                    ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER)),
-                                    ...mergeWithDetail()
-                                });
+        <Stack hasGutter>
+            <StackItem>
+                <TextContent>
+                    <Text component={TextVariants.h2}>
+                        {props.intl.formatMessage(messages.affectsSystems)}
+                    </Text>
+                </TextContent>
+            </StackItem>
+            <StackItem>
+                {error?.hasError
+                    ? <ErrorHandler code={error?.errorCode} />
+                    : <InventoryTable
+                        disableDefaultColumns
+                        onLoad={({ mergeWithEntities, mergeWithDetail }) => {
+                            ReducerRegistry.register({
+                                ...mergeWithEntities(inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER)),
+                                ...mergeWithDetail()
+                            });
+                        }}
+                        tableProps={{
+                            isStickyHeader: true,
+                            canSelectAll: false,
+                            onSort: (items.data.length > 0) && onSort,
+                            sortBy: (items.data.length > 0) && sortBy(),
+                            actionResolver: (rowData, rowIndex) => (
+                                items.data.length > 0 &&
+                                systemExposedTableRowActions(
+                                    showStatusModal,
+                                    props.cveStatusDetails,
+                                    rowIndex.rowIndex
+                                )
+                            ),
+                            variant: TableVariant.compact
+                        }}
+                        showTags
+                        key={'inventory'}
+                        expandable
+                        ref={inventory}
+                        items={items.data}
+                        page={metadata && metadata.page || 1}
+                        perPage={metadata && metadata.page_size || 20}
+                        total={metadata && metadata.total_items || 0}
+                        isLoaded={!isLoading}
+                        onRefresh={inventoryRefresh}
+                        hasCheckbox={items && items.length !== 0}
+                        showActions={items && items.length !== 0}
+                        onExpandClick={(_e, _i, isOpen, { id }) => dispatch(expandRow(id, isOpen))}
+                        noSystemsTable={<EmptyStateNoSystems />}
+                    >
+                        <PrimaryToolbar
+                            className="vuln-systems-primary-toolbar"
+                            exportConfig={{
+                                isDisabled: items.meta.total_items === 0,
+                                ouiaId: 'export',
+                                ...exportConfig({ downloadReport })
                             }}
-                            tableProps={{
-                                isStickyHeader: true,
-                                canSelectAll: false,
-                                onSort: (items.data.length > 0) && onSort,
-                                sortBy: (items.data.length > 0) && sortBy(),
-                                actionResolver: (rowData, rowIndex) => (
-                                    items.data.length > 0 &&
-                                    systemExposedTableRowActions(
-                                        showStatusModal,
-                                        props.cveStatusDetails,
-                                        rowIndex.rowIndex
-                                    )
-                                ),
-                                variant: TableVariant.compact
+                            dedicatedAction={(!isLoading &&
+                                <Remediation
+                                    manyRules
+                                    systems={selectedHostsData}
+                                    cves={{ id: props.cve, rules: props.filterRuleValues }}
+                                />
+                            )}
+                            actionsConfig={{
+                                actions: kebabOptions,
+                                kebabToggleProps: { isDisabled: !selectedHosts || selectedHosts.length === 0 },
+                                dropdownProps: { ouiaId: 'toolbar-actions' }
                             }}
-                            showTags
-                            key={'inventory'}
-                            expandable
-                            ref={inventory}
-                            items={items.data}
-                            page={metadata && metadata.page || 1}
-                            perPage={metadata && metadata.page_size || 20}
-                            total={metadata && metadata.total_items || 0}
-                            isLoaded={!isLoading}
-                            onRefresh={inventoryRefresh}
-                            hasCheckbox={items && items.length !== 0}
-                            showActions={items && items.length !== 0}
-                            onExpandClick={(_e, _i, isOpen, { id }) => dispatch(expandRow(id, isOpen))}
-                            noSystemsTable={<EmptyStateNoSystems />}
-                        >
-                            <PrimaryToolbar
-                                className="vuln-systems-primary-toolbar"
-                                exportConfig={{
-                                    isDisabled: items.meta.total_items === 0,
-                                    ouiaId: 'export',
-                                    ...exportConfig({ downloadReport })
-                                }}
-                                dedicatedAction={(!isLoading &&
-                                    <Remediation
-                                        manyRules
-                                        systems={selectedHostsData}
-                                        cves={{ id: props.cve, rules: props.filterRuleValues }}
-                                    />
-                                )}
-                                actionsConfig={{
-                                    actions: kebabOptions,
-                                    kebabToggleProps: { isDisabled: !selectedHosts || selectedHosts.length === 0 },
-                                    dropdownProps: { ouiaId: 'toolbar-actions' }
-                                }}
-                                activeFiltersConfig={{
-                                    filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
-                                    onDelete: (_, chips) => removeFilters(chips, apply),
-                                    deleteTitle: props.intl.formatMessage(messages.resetFilters)
-                                }}
-                                bulkSelect={selectOptions && {
-                                    count: selectedHosts && selectedHosts.length,
-                                    items: selectOptions.items,
-                                    isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
-                                    checked: Boolean(selectedHosts && selectedHosts.length),
-                                    ouiaId: 'bulk-select',
-                                    onSelect: () => selectOptions.handleOnCheckboxChange()
-                                }}
-                                filterConfig={{
-                                    items: [
-                                        searchFilter,
-                                        securityRuleFilter(
-                                            apply,
-                                            parameters,
-                                            props.filterRuleValues,
-                                            {
-                                                isDynamic: true,
-                                                dropdownItems: RULE_ABSENSE_OPTIONS
-                                            }
-                                        ),
-                                        statusFilter(apply, parameters),
-                                        advisoryFilter
-                                    ]
-                                }}
-                            />
-                            {StatusModal && <StatusModal />}
-                        </InventoryTable>}
-                </StackItem>
-            </Stack>
-        </React.Fragment>
+                            activeFiltersConfig={{
+                                filters: buildActiveFilters({ ...parameters }, props.filterRuleValues),
+                                onDelete: (_, chips) => removeFilters(chips, apply),
+                                deleteTitle: props.intl.formatMessage(messages.resetFilters)
+                            }}
+                            bulkSelect={selectOptions && {
+                                count: selectedHosts && selectedHosts.length,
+                                items: selectOptions.items,
+                                isDisabled: items.meta.total_items === 0 && (!selectedHosts || selectedHosts.length === 0),
+                                checked: Boolean(selectedHosts && selectedHosts.length),
+                                ouiaId: 'bulk-select',
+                                onSelect: () => selectOptions.handleOnCheckboxChange()
+                            }}
+                            filterConfig={{
+                                items: [
+                                    searchFilter,
+                                    securityRuleFilter(
+                                        apply,
+                                        parameters,
+                                        props.filterRuleValues,
+                                        {
+                                            isDynamic: true,
+                                            dropdownItems: RULE_ABSENSE_OPTIONS
+                                        }
+                                    ),
+                                    statusFilter(apply, parameters),
+                                    advisoryFilter
+                                ]
+                            }}
+                        />
+                        {StatusModal && <StatusModal />}
+                    </InventoryTable>}
+            </StackItem>
+        </Stack>
     );
 };
 

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -80,68 +80,66 @@ const SystemsPage = () => {
         <Fragment>
             <Header title={intl.formatMessage(messages.vulnerabilitySystemsHeader)} showBreadcrumb={false} />
             <Main>
-                <Fragment>
-                    {hasError
-                        ? <ErrorHandler code={errorCode} />
-                        : (
-                            <InventoryTable
-                                disableDefaultColumns
-                                onLoad={({ mergeWithEntities }) => {
-                                    ReducerRegistry.register({
-                                        ...mergeWithEntities(
-                                            inventoryEntitiesReducer(SYSTEMS_HEADER),
-                                            {
-                                                page: Number(parameters.page || 1),
-                                                perPage: Number(parameters.page_size || 20),
-                                                ...(parameters.sort && {
-                                                    sortBy: {
-                                                        key: parameters.sort.replace(/^-/, ''),
-                                                        direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
-                                                    }
-                                                })
-                                            }
-                                        )
-                                    });
+                {hasError
+                    ? <ErrorHandler code={errorCode} />
+                    : (
+                        <InventoryTable
+                            disableDefaultColumns
+                            onLoad={({ mergeWithEntities }) => {
+                                ReducerRegistry.register({
+                                    ...mergeWithEntities(
+                                        inventoryEntitiesReducer(SYSTEMS_HEADER),
+                                        {
+                                            page: Number(parameters.page || 1),
+                                            perPage: Number(parameters.page_size || 20),
+                                            ...(parameters.sort && {
+                                                sortBy: {
+                                                    key: parameters.sort.replace(/^-/, ''),
+                                                    direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
+                                                }
+                                            })
+                                        }
+                                    )
+                                });
+                            }}
+                            tableProps={{
+                                isStickyHeader: true,
+                                canSelectAll: false,
+                                actionResolver: systems?.length > 0
+                                    && ((rowData) => systemTableRowActions(rowData, doOptOut)),
+                                variant: TableVariant.compact
+                            }}
+                            showTagModal
+                            isFullView
+                            ref={inventoryRef}
+                            autoRefresh
+                            customFilters={{
+                                vulnerabilityParams: {
+                                    ...parameters
+                                }
+                            }}
+                            hasCheckbox={systems?.length !== 0}
+                            columnCounter={columnCounter}
+                            columns={(defaultColumns) => createColumns(defaultColumns)}
+                            getEntities={getEntities}
+                            hideFilters={{ all: true }}
+                            noSystemsTable={<EmptyStateNoSystems />}
+                        >
+                            <SystemsTableToolbar
+                                parameters={parameters}
+                                systems={{ data: systems, meta: { total_items: totalItems } }}
+                                selectedRows={selectedRows}
+                                selectedRowsCount={selectedRowsCount}
+                                selectedRowsRawData={selectedRowsRawData}
+                                methods={{
+                                    doOptOut,
+                                    apply,
+                                    handleSelect
                                 }}
-                                tableProps={{
-                                    isStickyHeader: true,
-                                    canSelectAll: false,
-                                    actionResolver: systems?.length > 0
-                                        && ((rowData) => systemTableRowActions(rowData, doOptOut)),
-                                    variant: TableVariant.compact
-                                }}
-                                showTagModal
-                                isFullView
-                                ref={inventoryRef}
-                                autoRefresh
-                                customFilters={{
-                                    vulnerabilityParams: {
-                                        ...parameters
-                                    }
-                                }}
-                                hasCheckbox={systems?.length !== 0}
-                                columnCounter={columnCounter}
-                                columns={(defaultColumns) => createColumns(defaultColumns)}
-                                getEntities={getEntities}
-                                hideFilters={{ all: true }}
-                                noSystemsTable={<EmptyStateNoSystems />}
-                            >
-                                <SystemsTableToolbar
-                                    parameters={parameters}
-                                    systems={{ data: systems, meta: { total_items: totalItems } }}
-                                    selectedRows={selectedRows}
-                                    selectedRowsCount={selectedRowsCount}
-                                    selectedRowsRawData={selectedRowsRawData}
-                                    methods={{
-                                        doOptOut,
-                                        apply,
-                                        handleSelect
-                                    }}
-                                    actions
-                                />
-                            </InventoryTable>
-                        )}
-                </Fragment>
+                                actions
+                            />
+                        </InventoryTable>
+                    )}
             </Main>
         </Fragment>
     );

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -85,24 +85,26 @@ export const useOptOutSystems = onRefreshInventory => {
         const count = Object.keys(affectedRows).length;
 
         dispatch(optOutSystemsAction(Object.keys(affectedRows), isIncluded))
-        .then(() => {
-            isIncluded ?
-                addSuccessNotification({
-                    msg: intl.formatMessage(messages.notificationExcludeSuccess, { count, systemName }) })
-                : addSuccessNotification({
-                    msg: intl.formatMessage(messages.notificationIncludeSuccessTitle, { count, systemName }),
-                    description: intl.formatMessage(messages.notificationIncludeSuccessBody)
-                });
-        }).catch(() => {
-            isIncluded ?
-                addFailureNotification({
-                    msg: intl.formatMessage(messages.notificationExcludeFailureTitle, { count, systemName }),
-                    description: intl.formatMessage(messages.notificationExcludeFailureBody, { count }) })
-                : addFailureNotification({
-                    msg: intl.formatMessage(messages.notificationIncludeFailureTitle, { count, systemName }),
-                    description: intl.formatMessage(messages.notificationIncludeFailureBody, { count })
-                });
-        }).finally(onRefreshInventory);
+            .then(() => {
+                isIncluded ?
+                    addSuccessNotification({
+                        msg: intl.formatMessage(messages.notificationExcludeSuccess, { count, systemName })
+                    })
+                    : addSuccessNotification({
+                        msg: intl.formatMessage(messages.notificationIncludeSuccessTitle, { count, systemName }),
+                        description: intl.formatMessage(messages.notificationIncludeSuccessBody)
+                    });
+            }).catch(() => {
+                isIncluded ?
+                    addFailureNotification({
+                        msg: intl.formatMessage(messages.notificationExcludeFailureTitle, { count, systemName }),
+                        description: intl.formatMessage(messages.notificationExcludeFailureBody, { count })
+                    })
+                    : addFailureNotification({
+                        msg: intl.formatMessage(messages.notificationIncludeFailureTitle, { count, systemName }),
+                        description: intl.formatMessage(messages.notificationIncludeFailureBody, { count })
+                    });
+            }).finally(onRefreshInventory);
     };
 };
 


### PR DESCRIPTION
Added `react/jsx-no-useless-fragment: 2` rule, which shows error when you are wrapping only 1 child in `React.Fragment`, which makes components returns a bit cleaner.

Also removed `Indent > MemberExpression: 0` (this makes this rule by default 1), so now when chaining functions on more lines they have to be indented.

### OLD:
```
something(...)
.then(...)
.catch(...)
```

### NEW:
```
something(...)
    .then(...)
    .catch(...)
```