### PR TITLE
fix(Reports page): Clear notifs on unmount

### DIFF
--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -1,4 +1,5 @@
-import React,  { useState } from 'react';
+import React,  { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Grid, GridItem, Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { FileAltIcon } from '@patternfly/react-icons';
@@ -12,6 +13,7 @@ import DownloadCVEsReport from '../Reports/DownloadCVEsReport';
 import { constructFilterParameters, buildFilters } from '../../../Helpers/ReportsHelper';
 import { CVE_REPORT_FILTERS, DEFAULT_FILTER_DATA } from '../../../Helpers/constants';
 import styles from './Common/styles';
+import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 const ReportsPage = () => {
     const [isModalOpen, setModalOpen] = useState(false);
@@ -20,6 +22,14 @@ const ReportsPage = () => {
     const [userNotes, setUserNotes] = useState('');
     const [columnsToInclude, setColumnsToInclude] = useState(Object.keys(CVE_REPORT_FILTERS));
     const [filterData, setFilterData] = useState(DEFAULT_FILTER_DATA);
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        return () => {
+            dispatch(clearNotifications());
+        };
+    }, [dispatch]);
 
     const handleModalClose = () => {
         setReportTitle(intl.formatMessage(messages.customReportDefaultTitle));


### PR DESCRIPTION
Previously if you exported PDF, received notification and then navigated to other page the notification would still be there.