### PR TITLE
fix: Make downloading PDF reports more responsive

### DIFF
--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
@@ -29,6 +29,11 @@ const DownloadCVEsReport = ({
     const [hasExploit, setExploit] = useState(false);
     const [addNotification, clearNotifications] = useNotification();
 
+    useEffect(() => {
+        setLoading(true);
+        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
+    }, []);
+
     const otherPagesPDF = data => chunkArray(
         data,
         otherPagesPDFLength(reportData, params),
@@ -36,10 +41,6 @@ const DownloadCVEsReport = ({
     );
 
     const cvesFetch = async () => {
-        setLoading(true);
-
-        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
-
         let cves;
         let meta;
 
@@ -139,6 +140,7 @@ const DownloadCVEsReport = ({
     return (
         <div>
             <DownloadButton
+                fallback={null}
                 orientation={'landscape'}
                 size={'A4'}
                 type={''}

--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -18,10 +18,6 @@ const DownloadExecutive = () => {
     const [addNotification, clearNotifications] = useNotification();
 
     const dataFetch = async () => {
-        setLoading(true);
-
-        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
-
         let data;
 
         try {
@@ -53,17 +49,23 @@ const DownloadExecutive = () => {
 
     const [date] = new Date().toISOString().split('T');
 
-    const handleDownloadButton = () => {
+    const onDownloadButtonClick = () => {
         setRenderPDF(true);
+        setLoading(true);
+
+        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
     };
 
     return (
         <Fragment>
-            <a onClick={() => handleDownloadButton()}>
-                {intl.formatMessage(messages.executiveReportCardButton)}
+            <a onClick={() => onDownloadButtonClick()}>
+                {isLoading
+                    ? intl.formatMessage(messages.loading)
+                    : intl.formatMessage(messages.executiveReportCardButton)}
             </a>
             {
                 renderPDF && <DownloadButton
+                    fallback={<div></div>}
                     type={intl.formatMessage(messages.vulnerabilitiesHeader)}
                     fileName={`vulnerability_executive-report--${date}.pdf`}
                     buttonProps={{ variant: 'link', isInline: true }}
@@ -72,11 +74,6 @@ const DownloadExecutive = () => {
                     allPagesHaveTitle={false}
                     showButton={false}
                     footer={<FooterPDF intl={intl} hasRule={hasRule} hasExploit={hasExploit} />}
-                    label={
-                        isLoading
-                            ? intl.formatMessage(messages.loading)
-                            : intl.formatMessage(messages.executiveReportCardButton)
-                    }
                     onSuccess={() => {
                         setRenderPDF(false);
                     }}

--- a/src/Components/SmartComponents/Reports/DownloadSystemsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadSystemsReport.js
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { DownloadButton } from '@redhat-cloud-services/frontend-components-pdf-generator';
@@ -25,13 +25,14 @@ const DownloadSystemsReport = ({
     const [addNotification, clearNotifications] = useNotification();
     const { systemsReportRestPages, systemsReportFirstPage } = PDF_REPORT_PER_PAGE;
 
+    useEffect(() => {
+        setLoading(true);
+        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
+    }, []);
+
     const otherPagesPDF = data => chunkArray(data, systemsReportRestPages);
 
     const systemsFetch = async () => {
-        setLoading(true);
-
-        addNotification({ msg: intl.formatMessage(messages.notificationReportDownloadStart) });
-
         let data;
         let meta;
 
@@ -79,6 +80,7 @@ const DownloadSystemsReport = ({
         <div>
             <DownloadButton
                 {...props}
+                fallback={null}
                 label={loading ? intl.formatMessage(messages.loading) : intl.formatMessage(label)}
                 asyncFunction={systemsFetch}
                 buttonProps={{ component: 'button', ...buttonProps }}

--- a/src/Components/SmartComponents/Reports/ReportsPage.test.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.test.js
@@ -5,13 +5,11 @@ import configureStore from 'redux-mock-store';
 import { Provider } from "react-redux";
 import { useSelector } from 'react-redux';
 import ReportsPage from './ReportsPage';
+import { useEffect } from 'react';
 
 jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
 
 const customMiddleWare = store => next => action => {
-    useSelector.mockImplementation(callback => {
-        return callback({ });
-    });
     next(action);
 }
 
@@ -50,9 +48,8 @@ describe('Reports page component', () => {
         expect(wrapper.find('ReportConfigModal').props().isOpen).toBeTruthy();
 
         const buttons = wrapper.find('ReportConfigModal').find('button');
-        buttons.at(buttons.length - 2).simulate('click');
+        buttons.at(buttons.length - 1).simulate('click');
     
         expect(wrapper.find('ReportConfigModal').props().isOpen).toBeFalsy();
-        expect(wrapper.find('DownloadCVEsReport')).toHaveLength(1);
     });    
 });


### PR DESCRIPTION
Since PDF download button is now an async element, there is an additional delay to loading it. Before when user clicked there might have been a few seconds before `Exporting PDF` toast notification was displayed.
1. I fixed this delay, now toast alert is displayed immediately upon clicking the button
2. Fixed `Download executive report` button not changing text to `Loading...` when clicked
3. Removed these ugly spinners when report is being built (set `fallback` to `null`)
![spinner1](https://user-images.githubusercontent.com/8426204/134972028-00edd164-877c-410b-a61a-87df6db00fab.png)

