### PR TITLE
VULN-1842 VULN-2021 fix: Fix table alignment

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -84,6 +84,7 @@
         padding-top: 2px;
         padding-bottom: 0;
         padding-left: 2px;
+        height: 20px;
     
         svg {
             padding-top: 2px;

--- a/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
+++ b/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
@@ -23,7 +23,7 @@ const AdvisoryColumn = ({ cve, advisoriesList }) => {
                     >
                         {advisory}
                     </a>
-                ).reduce((prev, curr) => [prev, ', ', curr])
+                ).reduce((prev, curr, index) => [prev, ', ', <br key={index}/>, curr])
             ) : (
                 <Fragment>
                     <FormattedMessage {...messages.notAvailable} />

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classNames, expandable, sortable, cellWidth, nowrap, wrappable } from '@patternfly/react-table';
+import { classNames, expandable, sortable, nowrap, wrappable } from '@patternfly/react-table';
 import StatusColumn from '../Components/PresentationalComponents/StatusColumn/StatusColumn';
 import AdvisoryColumn from '../Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn';
 import SystemNameColumn from '../Components/PresentationalComponents/TableColumns/SystemNameColumn';
@@ -569,11 +569,12 @@ export const SYSTEMS_EXPOSED_HEADER = [
     {
         key: 'tags',
         title: intl.formatMessage(messages.systemsColumnHeaderTags),
-        props: { width: 10, isStatic: true },
+        props: { isStatic: true },
         isShown: true
     },
     {
         key: 'os',
+        dataLabel: intl.formatMessage(messages.systemsColumnHeaderOS),
         title: (
             <Tooltip content={intl.formatMessage(messages.systemsColumnHeaderOSFull)}>
                 <span>
@@ -588,7 +589,7 @@ export const SYSTEMS_EXPOSED_HEADER = [
     {
         key: 'advisory',
         title: intl.formatMessage(messages.advisory),
-        props: { width: 20, isStatic: true },
+        props: { isStatic: true },
         renderFunc: (
             value,
             _id,
@@ -612,7 +613,6 @@ export const SYSTEMS_EXPOSED_HEADER = [
         title: intl.formatMessage(messages.systemsColumnHeaderUpdated),
         transforms: [nowrap],
         cellTransforms: [nowrap],
-        props: { width: 20 },
         isShown: true
     },
     {
@@ -636,9 +636,6 @@ export const SYSTEMS_ADVISORY_COLUMN =
 {
     key: 'advisory',
     title: intl.formatMessage(messages.advisory),
-    props: {
-        width: 20
-    },
     renderFunc: (
         value,
         _id,
@@ -653,17 +650,21 @@ export const SYSTEMS_HEADER = [
         composed: ['facts.os_release', 'display_name'],
         cellTransforms: [nowrap],
         renderFunc: (item, _id, { opt_out: optOut }) => <SystemNameColumn item={item} optOut={optOut} />,
+        props: {
+            width: 40
+        },
         isShown: true,
         isUnhidable: true
     },
     {
         key: 'tags',
         title: intl.formatMessage(messages.systemsColumnHeaderTags),
-        props: { width: 10, isStatic: true },
+        props: { isStatic: true },
         isShown: true
     },
     {
         key: 'os',
+        dataLabel: intl.formatMessage(messages.systemsColumnHeaderOS),
         title: (
             <Tooltip content={intl.formatMessage(messages.systemsColumnHeaderOSFull)}>
                 <span>
@@ -672,15 +673,11 @@ export const SYSTEMS_HEADER = [
             </Tooltip>
         ),
         cellTransforms: [nowrap],
-        props: {
-            width: 10
-        },
         isShown: true
     },
     {
         key: 'cve_count',
         title: intl.formatMessage(messages.systemsColumnHeaderCveCount),
-        transforms: [cellWidth(25)],
         renderFunc: value => (value !== null ? String(value) : intl.formatMessage(messages.systemsTableExcluded)),
         isShown: true
     },
@@ -689,7 +686,9 @@ export const SYSTEMS_HEADER = [
         title: intl.formatMessage(messages.systemsColumnHeaderUpdated),
         transforms: [nowrap],
         cellTransforms: [nowrap],
-        props: { width: 20 },
+        props: {
+            width: 25
+        },
         isShown: true
     }
 ];


### PR DESCRIPTION
Fix Firefox misalignment (VULN-1842), fix columns not being layed out uniformly (VULN-2021), put each advisory on separate line.

## Before:
![systemsBefore](https://user-images.githubusercontent.com/8426204/139274696-ce0cdab4-d9ef-47e6-a955-4e3ee4ae60c9.png)

## After:
![systemsAfter](https://user-images.githubusercontent.com/8426204/139274725-522e930c-ca62-4b19-951d-07a9719fe126.png)

## Before:
![exposedBefore](https://user-images.githubusercontent.com/8426204/139274704-b7300dc4-33cb-4717-abbf-80ae6d86c9e1.png)

## After:
![exposedAfter](https://user-images.githubusercontent.com/8426204/139274741-6e010d8c-b094-41a1-8751-7ac8ea109409.png)

## Before:
### fix missing OS header when table is collapsen on small viewport.
![collapsedBefore](https://user-images.githubusercontent.com/8426204/139274709-ce2771b3-924b-46b4-81fc-be69048d0a6f.png)

## After:
![collapsedAfter](https://user-images.githubusercontent.com/8426204/139274754-d297e704-9ecd-4916-b318-1ec2997d61b0.png)


