### PR TITLE
VULN-2030 fix(CVEs pages): Retain sorting and filtering after status/BR change

### DIFF
--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -99,7 +99,7 @@ export const CVEs = () => {
                 cves={cvesList}
                 updateRef={() => {
                     dispatch(clearCVEsStore());
-                    updateRef(goToFirstPage ? { ...meta, page: 1 } : meta, apply);
+                    updateRef(goToFirstPage ? { ...meta, page: 1 } : meta, parameters, apply);
                 }}
             />
         );
@@ -112,7 +112,7 @@ export const CVEs = () => {
                 cves={cvesList}
                 updateRef={() => {
                     dispatch(clearCVEsStore());
-                    updateRef(goToFirstPage ? { ...meta, page: 1 } : meta, apply);
+                    updateRef(goToFirstPage ? { ...meta, page: 1 } : meta, parameters, apply);
                 }}
             />
         );

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -141,7 +141,7 @@ export const SystemCVEs = ({ entity, intl, allowedCveActions, showHeaderLabel, s
                 cveList={cveList}
                 updateRef={() => {
                     dispatch(clearSystemCvesStore());
-                    updateRef(goToFirstPage ? { ...cves.meta, page: 1 } : cves.meta, apply);
+                    updateRef(goToFirstPage ? { ...cves.meta, page: 1 } : cves.meta, parameters, apply);
                 }}
 
                 inventoryList={[{ id: entity.id, display_name: entity.display_name }]}

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -166,13 +166,14 @@ export const useUrlParams = (allowedParams) => {
     return [urlParams, setUrlParams];
 };
 
-export const updateRef = (meta, apply) => {
+// TODO: Refactor
+export const updateRef = (meta, params, apply) => {
     const pages = parseInt(meta.pages);
     const page = parseInt(meta.page);
     const cvesCount = parseInt(meta.cvesCount);
     const goTo = (pages === page && page > 1 && cvesCount === 1) ? (pages - 1) : page;
 
-    apply({ page: goTo });
+    apply({ ...params, page: goTo });
 };
 
 export const mountWithIntl = (Component) => {

--- a/src/Helpers/MiscHelper.test.js
+++ b/src/Helpers/MiscHelper.test.js
@@ -190,7 +190,7 @@ describe('MiscHelper', () => {
         const testMeta = { page: 10, pages: 10, cvesCount: 10 };
         const testFunc = jest.fn();
 
-        updateRef(testMeta, testFunc);
+        updateRef(testMeta, testParameters, testFunc);
         
         expect(testFunc).toHaveBeenCalledWith(testParameters);
     });
@@ -199,7 +199,7 @@ describe('MiscHelper', () => {
         const testMeta = { page: 10, pages: 10, cvesCount: 1 };
         const testFunc = jest.fn();
 
-        updateRef(testMeta, testFunc);
+        updateRef(testMeta, {}, testFunc);
         
         expect(testFunc).toHaveBeenCalledWith({ page: 9 });
     });


### PR DESCRIPTION
## After:
![updateref](https://user-images.githubusercontent.com/8426204/140028598-023d31db-9a69-4cb2-bd94-f237dd06b6eb.gif)
