### PR TITLE
VULN-2165 chore: Use federated modules for Remediation button

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -97,15 +97,6 @@ const fecTransformImports = (env) => [
                     NotificationMapper[importName] || importName
                 }.js`,
             preventFullImport: true
-        },
-        '@redhat-cloud-services/frontend-components-remediations': {
-            transform: (importName) => `@redhat-cloud-services/frontend-components-remediations/${
-                env
-            }/${
-                importName === 'RemediationButton' ? 'RemediationButton.js' : 'index.js'
-            }`,
-            preventFullImport: false,
-            skipDefaultConversion: false
         }
     },
     'frontend-components'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@redhat-cloud-services/frontend-components-inventory-insights": "3.2.3",
         "@redhat-cloud-services/frontend-components-notifications": "3.2.4",
         "@redhat-cloud-services/frontend-components-pdf-generator": "2.6.7",
-        "@redhat-cloud-services/frontend-components-remediations": "3.2.7",
         "@redhat-cloud-services/frontend-components-translations": "3.2.3",
         "@redhat-cloud-services/frontend-components-utilities": "3.2.6",
         "@redhat-cloud-services/vulnerabilities-client": "^1.0.104",
@@ -2119,42 +2118,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-      "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.21",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
       "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
       "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.15.tgz",
-      "integrity": "sha512-nnRbkK+nz4ZL1l1lUbztL8qrEUGQKF/NU38itLnzLm8QLEacFS5qGOxxp/0DSIehhX99tNroNtudtjdOvzruAQ==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/icu-skeleton-parser": "1.3.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.2.tgz",
-      "integrity": "sha512-ChKmnVCE/LbJzedRgA/EeL5+tfjx/6ZWunqNiEC5BtqHnnwmLN/oPuCPb8b3NhuGiwTqp+LkaS70tga5kXRHxg==",
-      "dev": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.0",
         "tslib": "^2.1.0"
       }
     },
@@ -2230,15 +2198,6 @@
       "version": "0.2.22",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
       "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.21.tgz",
-      "integrity": "sha512-JTJeLiNwexN4Gy0cMxoUPvJbKhXdnSuo5jPrDafEZpnDWlJ5VDYta8zUVVozO/pwzEmFVHEUpgiEDj+39L4oMg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -25693,42 +25652,11 @@
         }
       }
     },
-    "@formatjs/ecma402-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-      "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
-      "dev": true,
-      "requires": {
-        "@formatjs/intl-localematcher": "0.2.21",
-        "tslib": "^2.1.0"
-      }
-    },
     "@formatjs/fast-memoize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
       "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
       "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "@formatjs/icu-messageformat-parser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.15.tgz",
-      "integrity": "sha512-nnRbkK+nz4ZL1l1lUbztL8qrEUGQKF/NU38itLnzLm8QLEacFS5qGOxxp/0DSIehhX99tNroNtudtjdOvzruAQ==",
-      "dev": true,
-      "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/icu-skeleton-parser": "1.3.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@formatjs/icu-skeleton-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.2.tgz",
-      "integrity": "sha512-ChKmnVCE/LbJzedRgA/EeL5+tfjx/6ZWunqNiEC5BtqHnnwmLN/oPuCPb8b3NhuGiwTqp+LkaS70tga5kXRHxg==",
-      "dev": true,
-      "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
         "tslib": "^2.1.0"
       }
     },
@@ -25840,15 +25768,6 @@
             "tslib": "^2.1.0"
           }
         }
-      }
-    },
-    "@formatjs/intl-localematcher": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.21.tgz",
-      "integrity": "sha512-JTJeLiNwexN4Gy0cMxoUPvJbKhXdnSuo5jPrDafEZpnDWlJ5VDYta8zUVVozO/pwzEmFVHEUpgiEDj+39L4oMg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.1.0"
       }
     },
     "@formatjs/ts-transformer": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@redhat-cloud-services/frontend-components-inventory-insights": "3.2.3",
     "@redhat-cloud-services/frontend-components-notifications": "3.2.4",
     "@redhat-cloud-services/frontend-components-pdf-generator": "2.6.7",
-    "@redhat-cloud-services/frontend-components-remediations": "3.2.7",
     "@redhat-cloud-services/frontend-components-translations": "3.2.3",
     "@redhat-cloud-services/frontend-components-utilities": "3.2.6",
     "@redhat-cloud-services/vulnerabilities-client": "^1.0.104",

--- a/src/Components/SmartComponents/Remediation/Remediation.js
+++ b/src/Components/SmartComponents/Remediation/Remediation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import routerParams from '@redhat-cloud-services/frontend-components-utilities/RouterParams';
 import { connect } from 'react-redux';
 import messages from '../../../Messages';
@@ -9,6 +8,7 @@ import { FormattedMessage } from 'react-intl';
 import { mergeObjectPropertyBy } from '../../../Helpers/MiscHelper';
 import { Spinner } from '@patternfly/react-core';
 import { spinnerSize } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
 const Remediation = ({ cves, systems, manyRules, addNotification: dispatchNotification, isDisabled }) => {
     const baseIssueTemplate = (cve, system) => ({
@@ -57,14 +57,16 @@ const Remediation = ({ cves, systems, manyRules, addNotification: dispatchNotifi
     };
 
     return (
-        <RemediationButton
+        <AsyncComponent
+            appName="remediations"
+            module="./RemediationButton"
             fallback={<Spinner size={spinnerSize.lg} />}
             isDisabled={isDisabled}
             dataProvider={() => remediationProvider(cves, systems, manyRules)}
             onRemediationCreated={result => dispatchNotification(result.getNotification())}
         >
             <FormattedMessage {...messages.remediateLabel} />
-        </RemediationButton>
+        </AsyncComponent>
     );
 };
 


### PR DESCRIPTION
This PR should not change any functionality, it will just make Remediation button mirror the version of Remediations from current environment as opposed to version of the imported package.