### PR TITLE
fix: Remove duplicate expand all button

### DIFF
--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -42,6 +42,7 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
         !cves.isLoading ? (
             <Fragment>
                 <Table
+                    canCollapseAll={false}
                     canSelectAll={false}
                     aria-label="Vulnerability CVE table"
                     cells={header}

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -4188,7 +4188,7 @@ exports[`CVEs Should render without props 1`] = `
                       actionResolver={[Function]}
                       aria-label="Vulnerability CVE table"
                       borders={true}
-                      canCollapseAll={true}
+                      canCollapseAll={false}
                       canSelectAll={false}
                       canSortFavorites={true}
                       cells={
@@ -4403,7 +4403,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4427,7 +4427,6 @@ exports[`CVEs Should render without props 1`] = `
                                 "formatters": Array [],
                                 "label": "",
                                 "transforms": Array [
-                                  [Function],
                                   [Function],
                                   [Function],
                                 ],
@@ -4456,7 +4455,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4511,7 +4510,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4567,7 +4566,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4624,7 +4623,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4679,7 +4678,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4734,7 +4733,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4789,7 +4788,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4844,7 +4843,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -4898,7 +4897,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "allRowsExpanded": false,
                                 "allRowsSelected": false,
                                 "areActionsDisabled": undefined,
-                                "canCollapseAll": true,
+                                "canCollapseAll": false,
                                 "canSelectAll": false,
                                 "canSortFavorites": true,
                                 "collapseAllAriaLabel": "",
@@ -5022,7 +5021,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5046,7 +5045,6 @@ exports[`CVEs Should render without props 1`] = `
                                               "formatters": Array [],
                                               "label": "",
                                               "transforms": Array [
-                                                [Function],
                                                 [Function],
                                                 [Function],
                                               ],
@@ -5075,7 +5073,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5130,7 +5128,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5186,7 +5184,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5243,7 +5241,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5298,7 +5296,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5353,7 +5351,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5408,7 +5406,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5463,7 +5461,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5517,7 +5515,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -5626,7 +5624,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5650,7 +5648,6 @@ exports[`CVEs Should render without props 1`] = `
                                                       "formatters": Array [],
                                                       "label": "",
                                                       "transforms": Array [
-                                                        [Function],
                                                         [Function],
                                                         [Function],
                                                       ],
@@ -5679,7 +5676,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5734,7 +5731,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5790,7 +5787,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5847,7 +5844,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5902,7 +5899,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -5957,7 +5954,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -6012,7 +6009,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -6067,7 +6064,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -6121,7 +6118,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "allRowsExpanded": false,
                                                       "allRowsSelected": false,
                                                       "areActionsDisabled": undefined,
-                                                      "canCollapseAll": true,
+                                                      "canCollapseAll": false,
                                                       "canSelectAll": false,
                                                       "canSortFavorites": true,
                                                       "collapseAllAriaLabel": "",
@@ -6172,15 +6169,13 @@ exports[`CVEs Should render without props 1`] = `
                                                     hidden={false}
                                                   >
                                                     <HeaderCell
-                                                      className="pf-c-table__toggle"
                                                       data-key={0}
                                                       data-label=""
-                                                      isVisible={true}
                                                       key="0-header"
                                                       scope=""
                                                     >
                                                       <Th
-                                                        className="pf-c-table__toggle"
+                                                        className=""
                                                         component="th"
                                                         data-key={0}
                                                         data-label=""
@@ -6190,7 +6185,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         tooltip=""
                                                       >
                                                         <ThBase
-                                                          className="pf-c-table__toggle"
+                                                          className=""
                                                           component="th"
                                                           data-key={0}
                                                           data-label=""
@@ -6201,86 +6196,12 @@ exports[`CVEs Should render without props 1`] = `
                                                           tooltip=""
                                                         >
                                                           <th
-                                                            className="pf-c-table__toggle"
+                                                            className=""
                                                             data-key={0}
                                                             data-label=""
                                                             onMouseEnter={[Function]}
-                                                            scope=""
-                                                          >
-                                                            <CollapseColumn
-                                                              aria-label="Expand all rows"
-                                                              aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                              id="expandable-toggle-1"
-                                                              isOpen={false}
-                                                              onToggle={[Function]}
-                                                            >
-                                                              <Button
-                                                                aria-expanded={false}
-                                                                aria-label="Expand all rows"
-                                                                aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                                className=""
-                                                                id="expandable-toggle-1"
-                                                                onClick={[Function]}
-                                                                variant="plain"
-                                                              >
-                                                                <ButtonBase
-                                                                  aria-expanded={false}
-                                                                  aria-label="Expand all rows"
-                                                                  aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                                  className=""
-                                                                  id="expandable-toggle-1"
-                                                                  innerRef={null}
-                                                                  onClick={[Function]}
-                                                                  variant="plain"
-                                                                >
-                                                                  <button
-                                                                    aria-disabled={false}
-                                                                    aria-expanded={false}
-                                                                    aria-label="Expand all rows"
-                                                                    aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                                    className="pf-c-button pf-m-plain"
-                                                                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                                                    data-ouia-component-type="PF4/Button"
-                                                                    data-ouia-safe={true}
-                                                                    disabled={false}
-                                                                    id="expandable-toggle-1"
-                                                                    onClick={[Function]}
-                                                                    role={null}
-                                                                    type="button"
-                                                                  >
-                                                                    <div
-                                                                      className="pf-c-table__toggle-icon"
-                                                                    >
-                                                                      <AngleDownIcon
-                                                                        color="currentColor"
-                                                                        noVerticalAlign={false}
-                                                                        size="sm"
-                                                                      >
-                                                                        <svg
-                                                                          aria-hidden={true}
-                                                                          aria-labelledby={null}
-                                                                          fill="currentColor"
-                                                                          height="1em"
-                                                                          role="img"
-                                                                          style={
-                                                                            Object {
-                                                                              "verticalAlign": "-0.125em",
-                                                                            }
-                                                                          }
-                                                                          viewBox="0 0 320 512"
-                                                                          width="1em"
-                                                                        >
-                                                                          <path
-                                                                            d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                                                          />
-                                                                        </svg>
-                                                                      </AngleDownIcon>
-                                                                    </div>
-                                                                  </button>
-                                                                </ButtonBase>
-                                                              </Button>
-                                                            </CollapseColumn>
-                                                          </th>
+                                                            scope={null}
+                                                          />
                                                         </ThBase>
                                                       </Th>
                                                     </HeaderCell>
@@ -7059,7 +6980,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7083,7 +7004,6 @@ exports[`CVEs Should render without props 1`] = `
                                           "formatters": Array [],
                                           "label": "",
                                           "transforms": Array [
-                                            [Function],
                                             [Function],
                                             [Function],
                                           ],
@@ -7112,7 +7032,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7167,7 +7087,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7223,7 +7143,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7280,7 +7200,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7335,7 +7255,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7390,7 +7310,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7445,7 +7365,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7500,7 +7420,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -7554,7 +7474,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "allRowsExpanded": false,
                                           "allRowsSelected": false,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -8110,7 +8030,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8134,7 +8054,6 @@ exports[`CVEs Should render without props 1`] = `
                                               "formatters": Array [],
                                               "label": "",
                                               "transforms": Array [
-                                                [Function],
                                                 [Function],
                                                 [Function],
                                               ],
@@ -8163,7 +8082,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8218,7 +8137,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8274,7 +8193,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8331,7 +8250,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8386,7 +8305,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8441,7 +8360,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8496,7 +8415,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8551,7 +8470,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -8605,7 +8524,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "allRowsExpanded": false,
                                               "allRowsSelected": false,
                                               "areActionsDisabled": undefined,
-                                              "canCollapseAll": true,
+                                              "canCollapseAll": false,
                                               "canSelectAll": false,
                                               "canSortFavorites": true,
                                               "collapseAllAriaLabel": "",
@@ -9307,7 +9226,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9331,7 +9250,6 @@ exports[`CVEs Should render without props 1`] = `
                                                         "formatters": Array [],
                                                         "label": "",
                                                         "transforms": Array [
-                                                          [Function],
                                                           [Function],
                                                           [Function],
                                                         ],
@@ -9360,7 +9278,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9415,7 +9333,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9471,7 +9389,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9528,7 +9446,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9583,7 +9501,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9638,7 +9556,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9693,7 +9611,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9748,7 +9666,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -9802,7 +9720,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -10271,7 +10189,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                         aria-label="Details"
                                                                         aria-labelledby="simple-node0 expandable-toggle0"
                                                                         className="pf-c-button pf-m-plain"
-                                                                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                                                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
                                                                         data-ouia-component-type="PF4/Button"
                                                                         data-ouia-safe={true}
                                                                         disabled={false}
@@ -10870,7 +10788,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                           "allRowsExpanded": false,
                                                                           "allRowsSelected": false,
                                                                           "areActionsDisabled": undefined,
-                                                                          "canCollapseAll": true,
+                                                                          "canCollapseAll": false,
                                                                           "canSelectAll": false,
                                                                           "canSortFavorites": true,
                                                                           "collapseAllAriaLabel": "",
@@ -11348,7 +11266,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11372,7 +11290,6 @@ exports[`CVEs Should render without props 1`] = `
                                                         "formatters": Array [],
                                                         "label": "",
                                                         "transforms": Array [
-                                                          [Function],
                                                           [Function],
                                                           [Function],
                                                         ],
@@ -11401,7 +11318,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11456,7 +11373,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11512,7 +11429,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11569,7 +11486,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11624,7 +11541,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11679,7 +11596,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11734,7 +11651,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11789,7 +11706,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -11843,7 +11760,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "allRowsExpanded": false,
                                                         "allRowsSelected": false,
                                                         "areActionsDisabled": undefined,
-                                                        "canCollapseAll": true,
+                                                        "canCollapseAll": false,
                                                         "canSelectAll": false,
                                                         "canSortFavorites": true,
                                                         "collapseAllAriaLabel": "",
@@ -12821,7 +12738,7 @@ exports[`CVEs Should render without props 1`] = `
                                       aria-label="Go to first page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="first"
-                                      data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-4"
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -12881,7 +12798,7 @@ exports[`CVEs Should render without props 1`] = `
                                       aria-label="Go to previous page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="previous"
-                                      data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-5"
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -12963,7 +12880,7 @@ exports[`CVEs Should render without props 1`] = `
                                       aria-label="Go to next page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="next"
-                                      data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-6"
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -13023,7 +12940,7 @@ exports[`CVEs Should render without props 1`] = `
                                       aria-label="Go to last page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="last"
-                                      data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-7"
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -301,7 +301,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
           actionResolver={[Function]}
           aria-label="Vulnerability CVE table"
           borders={true}
-          canCollapseAll={true}
+          canCollapseAll={false}
           canSelectAll={false}
           canSortFavorites={true}
           cells={
@@ -515,7 +515,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -539,7 +539,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "formatters": Array [],
                     "label": "",
                     "transforms": Array [
-                      [Function],
                       [Function],
                       [Function],
                     ],
@@ -568,7 +567,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -623,7 +622,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -679,7 +678,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -736,7 +735,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -791,7 +790,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -846,7 +845,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -901,7 +900,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -956,7 +955,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -1010,7 +1009,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                     "allRowsExpanded": true,
                     "allRowsSelected": true,
                     "areActionsDisabled": undefined,
-                    "canCollapseAll": true,
+                    "canCollapseAll": false,
                     "canSelectAll": false,
                     "canSortFavorites": true,
                     "collapseAllAriaLabel": "",
@@ -1134,7 +1133,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1158,7 +1157,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "formatters": Array [],
                                   "label": "",
                                   "transforms": Array [
-                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -1187,7 +1185,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1242,7 +1240,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1298,7 +1296,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1355,7 +1353,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1410,7 +1408,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1465,7 +1463,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1520,7 +1518,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1575,7 +1573,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1629,7 +1627,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -1738,7 +1736,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -1762,7 +1760,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "formatters": Array [],
                                           "label": "",
                                           "transforms": Array [
-                                            [Function],
                                             [Function],
                                             [Function],
                                           ],
@@ -1791,7 +1788,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -1846,7 +1843,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -1902,7 +1899,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -1959,7 +1956,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2014,7 +2011,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2069,7 +2066,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2124,7 +2121,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2179,7 +2176,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2233,7 +2230,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "allRowsExpanded": true,
                                           "allRowsSelected": true,
                                           "areActionsDisabled": undefined,
-                                          "canCollapseAll": true,
+                                          "canCollapseAll": false,
                                           "canSelectAll": false,
                                           "canSortFavorites": true,
                                           "collapseAllAriaLabel": "",
@@ -2284,15 +2281,13 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                         hidden={false}
                                       >
                                         <HeaderCell
-                                          className="pf-c-table__toggle"
                                           data-key={0}
                                           data-label=""
-                                          isVisible={true}
                                           key="0-header"
                                           scope=""
                                         >
                                           <Th
-                                            className="pf-c-table__toggle"
+                                            className=""
                                             component="th"
                                             data-key={0}
                                             data-label=""
@@ -2302,7 +2297,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             tooltip=""
                                           >
                                             <ThBase
-                                              className="pf-c-table__toggle"
+                                              className=""
                                               component="th"
                                               data-key={0}
                                               data-label=""
@@ -2313,86 +2308,12 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                               tooltip=""
                                             >
                                               <th
-                                                className="pf-c-table__toggle"
+                                                className=""
                                                 data-key={0}
                                                 data-label=""
                                                 onMouseEnter={[Function]}
-                                                scope=""
-                                              >
-                                                <CollapseColumn
-                                                  aria-label="Expand all rows"
-                                                  aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                  id="expandable-toggle-1"
-                                                  isOpen={true}
-                                                  onToggle={[Function]}
-                                                >
-                                                  <Button
-                                                    aria-expanded={true}
-                                                    aria-label="Expand all rows"
-                                                    aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                    className="pf-m-expanded"
-                                                    id="expandable-toggle-1"
-                                                    onClick={[Function]}
-                                                    variant="plain"
-                                                  >
-                                                    <ButtonBase
-                                                      aria-expanded={true}
-                                                      aria-label="Expand all rows"
-                                                      aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                      className="pf-m-expanded"
-                                                      id="expandable-toggle-1"
-                                                      innerRef={null}
-                                                      onClick={[Function]}
-                                                      variant="plain"
-                                                    >
-                                                      <button
-                                                        aria-disabled={false}
-                                                        aria-expanded={true}
-                                                        aria-label="Expand all rows"
-                                                        aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                        className="pf-c-button pf-m-plain pf-m-expanded"
-                                                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                                        data-ouia-component-type="PF4/Button"
-                                                        data-ouia-safe={true}
-                                                        disabled={false}
-                                                        id="expandable-toggle-1"
-                                                        onClick={[Function]}
-                                                        role={null}
-                                                        type="button"
-                                                      >
-                                                        <div
-                                                          className="pf-c-table__toggle-icon"
-                                                        >
-                                                          <AngleDownIcon
-                                                            color="currentColor"
-                                                            noVerticalAlign={false}
-                                                            size="sm"
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              aria-labelledby={null}
-                                                              fill="currentColor"
-                                                              height="1em"
-                                                              role="img"
-                                                              style={
-                                                                Object {
-                                                                  "verticalAlign": "-0.125em",
-                                                                }
-                                                              }
-                                                              viewBox="0 0 320 512"
-                                                              width="1em"
-                                                            >
-                                                              <path
-                                                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                                              />
-                                                            </svg>
-                                                          </AngleDownIcon>
-                                                        </div>
-                                                      </button>
-                                                    </ButtonBase>
-                                                  </Button>
-                                                </CollapseColumn>
-                                              </th>
+                                                scope={null}
+                                              />
                                             </ThBase>
                                           </Th>
                                         </HeaderCell>
@@ -3171,7 +3092,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3195,7 +3116,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "formatters": Array [],
                               "label": "",
                               "transforms": Array [
-                                [Function],
                                 [Function],
                                 [Function],
                               ],
@@ -3224,7 +3144,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3279,7 +3199,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3335,7 +3255,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3392,7 +3312,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3447,7 +3367,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3502,7 +3422,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3557,7 +3477,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3612,7 +3532,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -3666,7 +3586,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                               "allRowsExpanded": true,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4217,7 +4137,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4241,7 +4161,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "formatters": Array [],
                                   "label": "",
                                   "transforms": Array [
-                                    [Function],
                                     [Function],
                                     [Function],
                                   ],
@@ -4270,7 +4189,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4325,7 +4244,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4381,7 +4300,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4438,7 +4357,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4493,7 +4412,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4548,7 +4467,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4603,7 +4522,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4658,7 +4577,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -4712,7 +4631,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                   "allRowsExpanded": true,
                                   "allRowsSelected": true,
                                   "areActionsDisabled": undefined,
-                                  "canCollapseAll": true,
+                                  "canCollapseAll": false,
                                   "canSelectAll": false,
                                   "canSortFavorites": true,
                                   "collapseAllAriaLabel": "",
@@ -5408,7 +5327,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5432,7 +5351,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "formatters": Array [],
                                             "label": "",
                                             "transforms": Array [
-                                              [Function],
                                               [Function],
                                               [Function],
                                             ],
@@ -5461,7 +5379,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5516,7 +5434,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5572,7 +5490,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5629,7 +5547,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5684,7 +5602,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5739,7 +5657,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5794,7 +5712,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5849,7 +5767,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -5903,7 +5821,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -6368,7 +6286,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                             aria-label="Details"
                                                             aria-labelledby="simple-node0 expandable-toggle0"
                                                             className="pf-c-button pf-m-plain pf-m-expanded"
-                                                            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                                            data-ouia-component-id="OUIA-Generated-Button-plain-1"
                                                             data-ouia-component-type="PF4/Button"
                                                             data-ouia-safe={true}
                                                             disabled={false}
@@ -6966,7 +6884,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                               "allRowsExpanded": true,
                                                               "allRowsSelected": true,
                                                               "areActionsDisabled": undefined,
-                                                              "canCollapseAll": true,
+                                                              "canCollapseAll": false,
                                                               "canSelectAll": false,
                                                               "canSortFavorites": true,
                                                               "collapseAllAriaLabel": "",
@@ -7442,7 +7360,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7466,7 +7384,6 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "formatters": Array [],
                                             "label": "",
                                             "transforms": Array [
-                                              [Function],
                                               [Function],
                                               [Function],
                                             ],
@@ -7495,7 +7412,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7550,7 +7467,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7606,7 +7523,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7663,7 +7580,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7718,7 +7635,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7773,7 +7690,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7828,7 +7745,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7883,7 +7800,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -7937,7 +7854,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             "allRowsExpanded": true,
                                             "allRowsSelected": true,
                                             "areActionsDisabled": undefined,
-                                            "canCollapseAll": true,
+                                            "canCollapseAll": false,
                                             "canSelectAll": false,
                                             "canSortFavorites": true,
                                             "collapseAllAriaLabel": "",
@@ -8915,7 +8832,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                           aria-label="Go to first page"
                           className="pf-c-button pf-m-plain pf-m-disabled"
                           data-action="first"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe={true}
                           disabled={true}
@@ -8975,7 +8892,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                           aria-label="Go to previous page"
                           className="pf-c-button pf-m-plain pf-m-disabled"
                           data-action="previous"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe={true}
                           disabled={true}
@@ -9057,7 +8974,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                           aria-label="Go to next page"
                           className="pf-c-button pf-m-plain pf-m-disabled"
                           data-action="next"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe={true}
                           disabled={true}
@@ -9117,7 +9034,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                           aria-label="Go to last page"
                           className="pf-c-button pf-m-plain pf-m-disabled"
                           data-action="last"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
                           data-ouia-component-type="PF4/Button"
                           data-ouia-safe={true}
                           disabled={true}

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -57,6 +57,7 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
             <Fragment>
                 <Table
                     isStickyHeader
+                    canCollapseAll={false}
                     canSelectAll={false}
                     aria-label="Vulnerability CVE table"
                     cells={header}

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -335,7 +335,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
     <Table
       aria-label="Vulnerability CVE table"
       borders={true}
-      canCollapseAll={true}
+      canCollapseAll={false}
       canSelectAll={false}
       canSortFavorites={true}
       cells={
@@ -602,7 +602,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -626,7 +626,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "formatters": Array [],
                 "label": "",
                 "transforms": Array [
-                  [Function],
                   [Function],
                   [Function],
                 ],
@@ -655,7 +654,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -710,7 +709,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -765,7 +764,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -821,7 +820,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -877,7 +876,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -932,7 +931,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -985,7 +984,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -1040,7 +1039,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -1095,7 +1094,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "allRowsExpanded": false,
                 "allRowsSelected": true,
                 "areActionsDisabled": undefined,
-                "canCollapseAll": true,
+                "canCollapseAll": false,
                 "canSelectAll": false,
                 "canSortFavorites": true,
                 "collapseAllAriaLabel": "",
@@ -1219,7 +1218,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1243,7 +1242,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "formatters": Array [],
                               "label": "",
                               "transforms": Array [
-                                [Function],
                                 [Function],
                                 [Function],
                               ],
@@ -1272,7 +1270,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1327,7 +1325,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1382,7 +1380,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1438,7 +1436,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1494,7 +1492,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1549,7 +1547,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1602,7 +1600,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1657,7 +1655,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1712,7 +1710,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -1821,7 +1819,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -1845,7 +1843,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "formatters": Array [],
                                       "label": "",
                                       "transforms": Array [
-                                        [Function],
                                         [Function],
                                         [Function],
                                       ],
@@ -1874,7 +1871,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -1929,7 +1926,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -1984,7 +1981,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2040,7 +2037,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2096,7 +2093,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2151,7 +2148,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2204,7 +2201,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2259,7 +2256,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2314,7 +2311,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "allRowsExpanded": false,
                                       "allRowsSelected": true,
                                       "areActionsDisabled": undefined,
-                                      "canCollapseAll": true,
+                                      "canCollapseAll": false,
                                       "canSelectAll": false,
                                       "canSortFavorites": true,
                                       "collapseAllAriaLabel": "",
@@ -2365,15 +2362,13 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                     hidden={false}
                                   >
                                     <HeaderCell
-                                      className="pf-c-table__toggle"
                                       data-key={0}
                                       data-label=""
-                                      isVisible={true}
                                       key="0-header"
                                       scope=""
                                     >
                                       <Th
-                                        className="pf-c-table__toggle"
+                                        className=""
                                         component="th"
                                         data-key={0}
                                         data-label=""
@@ -2383,7 +2378,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         tooltip=""
                                       >
                                         <ThBase
-                                          className="pf-c-table__toggle"
+                                          className=""
                                           component="th"
                                           data-key={0}
                                           data-label=""
@@ -2394,86 +2389,12 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                           tooltip=""
                                         >
                                           <th
-                                            className="pf-c-table__toggle"
+                                            className=""
                                             data-key={0}
                                             data-label=""
                                             onMouseEnter={[Function]}
-                                            scope=""
-                                          >
-                                            <CollapseColumn
-                                              aria-label="Expand all rows"
-                                              aria-labelledby="simple-node-1 expandable-toggle-1"
-                                              id="expandable-toggle-1"
-                                              isOpen={false}
-                                              onToggle={[Function]}
-                                            >
-                                              <Button
-                                                aria-expanded={false}
-                                                aria-label="Expand all rows"
-                                                aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                className=""
-                                                id="expandable-toggle-1"
-                                                onClick={[Function]}
-                                                variant="plain"
-                                              >
-                                                <ButtonBase
-                                                  aria-expanded={false}
-                                                  aria-label="Expand all rows"
-                                                  aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                  className=""
-                                                  id="expandable-toggle-1"
-                                                  innerRef={null}
-                                                  onClick={[Function]}
-                                                  variant="plain"
-                                                >
-                                                  <button
-                                                    aria-disabled={false}
-                                                    aria-expanded={false}
-                                                    aria-label="Expand all rows"
-                                                    aria-labelledby="simple-node-1 expandable-toggle-1"
-                                                    className="pf-c-button pf-m-plain"
-                                                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                                    data-ouia-component-type="PF4/Button"
-                                                    data-ouia-safe={true}
-                                                    disabled={false}
-                                                    id="expandable-toggle-1"
-                                                    onClick={[Function]}
-                                                    role={null}
-                                                    type="button"
-                                                  >
-                                                    <div
-                                                      className="pf-c-table__toggle-icon"
-                                                    >
-                                                      <AngleDownIcon
-                                                        color="currentColor"
-                                                        noVerticalAlign={false}
-                                                        size="sm"
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          aria-labelledby={null}
-                                                          fill="currentColor"
-                                                          height="1em"
-                                                          role="img"
-                                                          style={
-                                                            Object {
-                                                              "verticalAlign": "-0.125em",
-                                                            }
-                                                          }
-                                                          viewBox="0 0 320 512"
-                                                          width="1em"
-                                                        >
-                                                          <path
-                                                            d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                                                          />
-                                                        </svg>
-                                                      </AngleDownIcon>
-                                                    </div>
-                                                  </button>
-                                                </ButtonBase>
-                                              </Button>
-                                            </CollapseColumn>
-                                          </th>
+                                            scope={null}
+                                          />
                                         </ThBase>
                                       </Th>
                                     </HeaderCell>
@@ -3253,7 +3174,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3277,7 +3198,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "formatters": Array [],
                           "label": "",
                           "transforms": Array [
-                            [Function],
                             [Function],
                             [Function],
                           ],
@@ -3306,7 +3226,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3361,7 +3281,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3416,7 +3336,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3472,7 +3392,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3528,7 +3448,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3583,7 +3503,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3636,7 +3556,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3691,7 +3611,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -3746,7 +3666,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                           "allRowsExpanded": false,
                           "allRowsSelected": true,
                           "areActionsDisabled": undefined,
-                          "canCollapseAll": true,
+                          "canCollapseAll": false,
                           "canSelectAll": false,
                           "canSortFavorites": true,
                           "collapseAllAriaLabel": "",
@@ -4550,7 +4470,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4574,7 +4494,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "formatters": Array [],
                               "label": "",
                               "transforms": Array [
-                                [Function],
                                 [Function],
                                 [Function],
                               ],
@@ -4603,7 +4522,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4658,7 +4577,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4713,7 +4632,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4769,7 +4688,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4825,7 +4744,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4880,7 +4799,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4933,7 +4852,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -4988,7 +4907,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -5043,7 +4962,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "allRowsExpanded": false,
                               "allRowsSelected": true,
                               "areActionsDisabled": undefined,
-                              "canCollapseAll": true,
+                              "canCollapseAll": false,
                               "canSelectAll": false,
                               "canSortFavorites": true,
                               "collapseAllAriaLabel": "",
@@ -6042,7 +5961,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6066,7 +5985,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "formatters": Array [],
                                         "label": "",
                                         "transforms": Array [
-                                          [Function],
                                           [Function],
                                           [Function],
                                         ],
@@ -6095,7 +6013,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6150,7 +6068,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6205,7 +6123,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6261,7 +6179,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6317,7 +6235,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6372,7 +6290,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6425,7 +6343,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6480,7 +6398,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -6535,7 +6453,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -7166,7 +7084,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                         aria-label="Details"
                                                         aria-labelledby="simple-node0 expandable-toggle0"
                                                         className="pf-c-button pf-m-plain"
-                                                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
                                                         data-ouia-component-type="PF4/Button"
                                                         data-ouia-safe={true}
                                                         disabled={false}
@@ -8378,7 +8296,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8402,7 +8320,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "formatters": Array [],
                                         "label": "",
                                         "transforms": Array [
-                                          [Function],
                                           [Function],
                                           [Function],
                                         ],
@@ -8431,7 +8348,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8486,7 +8403,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8541,7 +8458,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8597,7 +8514,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8653,7 +8570,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8708,7 +8625,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8761,7 +8678,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8816,7 +8733,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -8871,7 +8788,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "allRowsExpanded": false,
                                         "allRowsSelected": true,
                                         "areActionsDisabled": undefined,
-                                        "canCollapseAll": true,
+                                        "canCollapseAll": false,
                                         "canSelectAll": false,
                                         "canSortFavorites": true,
                                         "collapseAllAriaLabel": "",
@@ -10079,7 +9996,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       aria-label="Go to first page"
                       className="pf-c-button pf-m-plain pf-m-disabled"
                       data-action="first"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-2"
                       data-ouia-component-type="PF4/Button"
                       data-ouia-safe={true}
                       disabled={true}
@@ -10139,7 +10056,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       aria-label="Go to previous page"
                       className="pf-c-button pf-m-plain pf-m-disabled"
                       data-action="previous"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-3"
                       data-ouia-component-type="PF4/Button"
                       data-ouia-safe={true}
                       disabled={true}
@@ -10221,7 +10138,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       aria-label="Go to next page"
                       className="pf-c-button pf-m-plain pf-m-disabled"
                       data-action="next"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-4"
                       data-ouia-component-type="PF4/Button"
                       data-ouia-safe={true}
                       disabled={true}
@@ -10281,7 +10198,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                       aria-label="Go to last page"
                       className="pf-c-button pf-m-plain pf-m-disabled"
                       data-action="last"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-5"
                       data-ouia-component-type="PF4/Button"
                       data-ouia-safe={true}
                       disabled={true}


### PR DESCRIPTION
New version of patternfly table introduced `canCollapseAll` which adds expand all in table header which is true by default. But we already use expand all in table toolbar. This fix applies to CVE list table /cves and System CVEs table /systems/{system_id}.

## Before fix:
![before](https://user-images.githubusercontent.com/8426204/157434818-a0e4e964-286e-4484-b691-5a2c05b65f3a.png)


## After fix:
![after](https://user-images.githubusercontent.com/8426204/157434806-f0fe0e73-3478-4baf-b617-f19e2e0d8026.png)
