### PR TITLE
fix(System CVE table): Fix sorting when canSelect is false

### DIFF
--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -52,6 +52,8 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
             return ({ ...cve, isOpen: current && current.isOpen });
         }) : [];
 
+    const sortingHeader = [{ key: 'collapse' }, ...canSelect ? [{ key: 'checkbox' }] : [], ...header];
+
     return (
         !cves.isLoading ? (
             <Fragment>
@@ -65,14 +67,14 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
                     actionResolver={(!isEmpty && canEditPairStatus) &&
                         ((rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex))}
                     sortBy={!isEmpty
-                        ? createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
+                        ? createSortBy(sortingHeader, cves.meta.sort) : undefined}
                     onCollapse={!isEmpty ? (event, rowKey, isOpen) => handleOnCollapse(event, rowKey, isOpen) : undefined}
                     onSort={!isEmpty ?
                         (event, key, direction) =>
                             handleSortColumn(
                                 key,
                                 direction,
-                                [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
+                                sortingHeader,
                                 cves.meta.sort,
                                 methods.apply
                             ) : undefined


### PR DESCRIPTION
Description and screen capture of this bug is in last comment in https://issues.redhat.com/browse/VULN-2047

This bug was about sorting header not matching table header when checkboxes were not present, sorting header has to contain all columns including expand button column and checkbox column.

![1](https://user-images.githubusercontent.com/8426204/157437476-ebde4faf-d819-4a84-8b3f-3e36e8f97f6c.png)

![2](https://user-images.githubusercontent.com/8426204/157437474-a1b16723-fcb9-4ac9-b24d-afe68a8dd6e1.png)

