### PR TITLE
Allow HTML formatting inside Dashbar

### DIFF
--- a/src/Components/SmartComponents/Dashbar/Dashbar.js
+++ b/src/Components/SmartComponents/Dashbar/Dashbar.js
@@ -3,7 +3,7 @@ import { Card, Grid, GridItem, StackItem, Stack, Alert, CardBody, Text } from '@
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { SecurityIcon } from '@patternfly/react-icons';
 import { impactList, CVES_DEFAULT_FILTERS } from '../../../Helpers/constants';
-import { constructFilterParameters } from '../../../Helpers/MiscHelper';
+import { constructFilterParameters, sanitizeLinks } from '../../../Helpers/MiscHelper';
 import { useDispatch, useSelector } from 'react-redux';
 import { changeCveListParameters } from '../../../Store/Actions/Actions';
 import { FormattedMessage } from 'react-intl';
@@ -13,6 +13,7 @@ import { buildActiveFilters, removeFilters } from '../../../Helpers/TableToolbar
 import { getAnnouncement, getDashbar } from '../../../Helpers/APIHelper';
 import WithLoader, { LoaderType } from '../../PresentationalComponents/WithLoader/WithLoader';
 import { useIntl } from 'react-intl';
+import sanitizeHtml from 'sanitize-html';
 
 const DashbarItem = ({ title, count, impact, onLinkClick, hasIcon }) => {
     return (
@@ -89,6 +90,8 @@ const Dashbar = () => {
         }
     }, [parameters]);
 
+    const insertSanitizedHtml = text => ({ __html: sanitizeHtml(text) });
+
     return (
         <Main style={{ paddingBottom: 0 }}>
             <Stack hasGutter>
@@ -155,7 +158,10 @@ const Dashbar = () => {
                             variant="warning"
                             isInline
                             title={intl.formatMessage(messages.dashbarAnnouncementTitle)}
-                        >{announcement.message}
+                        >
+                            <span dangerouslySetInnerHTML={
+                                insertSanitizedHtml(sanitizeLinks(announcement.message))
+                            } />
                         </Alert>
                     </StackItem>
                 )}

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -253,3 +253,7 @@ export const dissectTag = tagString => {
         value
     };
 };
+
+export const sanitizeLinks = html => {
+    return html.replace('<a ', '<a target="_blank" rel="noopener noreferrer" ');
+};


### PR DESCRIPTION
Interpret text inside announcement as HTML, allowing us to format the content - for example adding links or bold text.

To test:
1. Check whether Announcement message is correctly parsing HTML data
![announcement](https://user-images.githubusercontent.com/8426204/165073270-b514dd38-4746-4123-8bf0-48ce96023245.png)
