### PR TITLE
VULN-1581 part2: Fixing 'select all' in Systems tables

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -54,9 +54,8 @@ const SystemsExposedTable = ({
     const totalItems = useSelector(({ entities }) => entities?.total);
     const meta = useSelector(({ entities }) => entities?.meta);
     const error = useSelector(({ entities }) => entities?.error || {});
-    const selectedRows = useSelector(({ entities }) => entities?.selectedRows || {});
+    const selectedRows = useSelector(({ entities }) => entities?.selectedRows || []);
     const selectedRowsCount = useSelector(({ entities }) => entities?.selectedRowsCount ?? 0);
-    const selectedRowsRawData = useSelector(({ entities }) => entities?.selectedRowsRawData || []);
     const isLoaded = useSelector(({ entities }) => entities?.loaded || false);
 
     const parameters = useSelector(
@@ -201,7 +200,6 @@ const SystemsExposedTable = ({
                                 isAllExpanded={isAllExpanded}
                                 selectedRows={selectedRows}
                                 selectedRowsCount={selectedRowsCount}
-                                selectedRowsRawData={selectedRowsRawData}
                                 cveStatusDetails={cveStatusDetails}
                                 filterRuleValues={filterRuleValues}
                                 methods={{

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -68,7 +68,7 @@ const SystemsExposedTable = ({
 
     const apply = (params) => dispatch(changeExposedSystemsParameters(params));
 
-    const handleSelect = (payload) => dispatch(selectRows(payload));
+    const handleSelect = (payload, selecting) => dispatch(selectRows(payload, selecting));
 
     useEffect(() => apply(urlParameters), []);
 

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
@@ -12,7 +12,7 @@ import { dataShape } from '../../../Helpers/MiscHelper';
 import { useBulkSelect } from '../../../Helpers/Hooks';
 import useSearchFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import {
-    fetchAffectedSystemsIdsByCve
+    fetchAffectedSystemsByCVE
 } from '../../../Store/Actions/Actions';
 import {
     RULE_ABSENCE_OPTIONS, ANSIBLE_REMEDIATION
@@ -25,7 +25,6 @@ export const SystemsExposedTableToolbar = ({
     cveStatusDetails,
     selectedRows,
     selectedRowsCount,
-    selectedRowsRawData,
     filterRuleValues,
     expandAll,
     hasSecurityRule,
@@ -40,12 +39,12 @@ export const SystemsExposedTableToolbar = ({
     const { apply, showStatusModal, handleSelect, downloadReport, setColumnModalOpen } = methods;
     const { isLoaded, meta } = rawData;
 
-    const remediableSystems = selectedRowsRawData.filter(system => system.remediation === ANSIBLE_REMEDIATION);
+    const remediableSystems = selectedRows.filter(system => system.remediation === ANSIBLE_REMEDIATION);
 
     const kebabOptions = ['',
         ...canEditPairStatus ? [{
             label: intl.formatMessage(messages.editStatus),
-            onClick: () => showStatusModal([cveStatusDetails], selectedRowsRawData),
+            onClick: () => showStatusModal([cveStatusDetails], selectedRows),
             props: { isDisabled: !selectedRowsCount }
         }] : [],
         {
@@ -80,7 +79,8 @@ export const SystemsExposedTableToolbar = ({
         selectedRows,
         selectedRowsCount,
         handleSelect,
-        fetchResource: ops => fetchAffectedSystemsIdsByCve({ id: cveName, ...parameters, ...ops })
+        // TODO: change it back to fetchAffectedSystemsIdsByCve when the endpoint return also a remediation field
+        fetchResource: ops => fetchAffectedSystemsByCVE({ id: cveName, ...parameters, ...ops })
     });
 
     if (isAllExpanded) {
@@ -100,7 +100,7 @@ export const SystemsExposedTableToolbar = ({
             dedicatedAction={(isLoaded &&
                 <Remediation
                     manyRules
-                    isDisabled={selectedRowsRawData.length === 0}
+                    isDisabled={selectedRows.length === 0}
                     systems={remediableSystems}
                     cves={{ id: cveName, rules: filterRuleValues }}
                 />
@@ -153,7 +153,6 @@ SystemsExposedTableToolbar.propTypes = {
     isAllExpanded: propTypes.bool,
     selectedRows: propTypes.array,
     selectedRowsCount: propTypes.number,
-    selectedRowsRawData: propTypes.array,
     children: propTypes.node,
     methods: propTypes.shape({
         apply: propTypes.func,

--- a/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
@@ -389,7 +389,6 @@ beforeEach(() => {
                         doOptOut: doOptOutMock
                     }}
                     selectedRows={[]}
-                    selectedRowsRawData={[]}
                     canExport
                     canSetExcludedIncluded
                     canReadExcluded
@@ -419,12 +418,12 @@ describe('SystemsTableToolbar component', () => {
 
         expect(handleSelectMock).toHaveBeenCalledWith(
             [
-                { id: "ece17ad9-97db-4480-a486-3eb4edd6c330", selected: true },
-                { id: "84b763c8-9611-4bf0-9fb8-4f737253b994", selected: true },
-                { id: "9ad25b17-b805-437b-8fc3-074559c453b8", selected: true },
-                { id: "ae7a9d76-ccc8-44d8-b8f0-692199199f10", selected: true },
-                { id: "721d9b9f-0db5-46f4-ba71-5611d6c12887", selected: true },
-                { id: "57c715fd-c49c-4c0d-81bc-f95599cd28f8", selected: true }
+                { display_name: "hypervisor.beav", id: "ece17ad9-97db-4480-a486-3eb4edd6c330", opt_out: false, remediation: undefined, selected: true },
+                { display_name: "client01.apex.example.com", id: "84b763c8-9611-4bf0-9fb8-4f737253b994", opt_out: true, remediation: undefined, selected: true },
+                { display_name: "edge-host-1", id: "9ad25b17-b805-437b-8fc3-074559c453b8", opt_out: false, remediation: undefined,  selected: true },
+                { display_name: "rhel7-insights-client-prod.virbr0.akofink-laptop",id: "ae7a9d76-ccc8-44d8-b8f0-692199199f10", opt_out: false, remediation: undefined, selected: true },
+                { display_name: "vm-9-105.lab.eng.tlv2.redhat.com",id: "721d9b9f-0db5-46f4-ba71-5611d6c12887", opt_out: false, remediation: undefined, selected: true },
+                { display_name: "dhcp-2-44.vms.sat.rdu2.redhat.com",id: "57c715fd-c49c-4c0d-81bc-f95599cd28f8", opt_out: false, remediation: undefined, selected: true }
             ]
         );
 
@@ -441,9 +440,8 @@ describe('SystemsTableToolbar component', () => {
                             handleSelect: handleSelectMock,
                             doOptOut: doOptOutMock
                         }}
-                        selectedRows={{ "ece17ad9-97db-4480-a486-3eb4edd6c330": true }}
+                        selectedRows={[{ display_name: "hypervisor.beav", id: "ece17ad9-97db-4480-a486-3eb4edd6c330", opt_out: false, remediation: undefined, selected: true }]}
                         selectedRowsCount={1}
-                        selectedRowsRawData={[{ id: 'ece17ad9-97db-4480-a486-3eb4edd6c330', opt_out: false }]}
                         totalSelectedRows={1}
                         canExport
                         canSetExcludedIncluded
@@ -484,9 +482,8 @@ describe('SystemsTableToolbar component', () => {
                             handleSelect: handleSelectMock,
                             doOptOut: doOptOutMock
                         }}
-                        selectedRows={{ "84b763c8-9611-4bf0-9fb8-4f737253b994": true }}
+                        selectedRows={[{ display_name: "client01.apex.example.com", id: "84b763c8-9611-4bf0-9fb8-4f737253b994", opt_out: true, remediation: undefined, selected: true }]}
                         selectedRowsCount={1}
-                        selectedRowsRawData={[{ id: '84b763c8-9611-4bf0-9fb8-4f737253b994', opt_out: false }]}
                         canExport
                         canSetExcludedIncluded
                         canReadExcluded

--- a/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
@@ -424,7 +424,7 @@ describe('SystemsTableToolbar component', () => {
                 { display_name: "rhel7-insights-client-prod.virbr0.akofink-laptop",id: "ae7a9d76-ccc8-44d8-b8f0-692199199f10", opt_out: false, remediation: undefined, selected: true },
                 { display_name: "vm-9-105.lab.eng.tlv2.redhat.com",id: "721d9b9f-0db5-46f4-ba71-5611d6c12887", opt_out: false, remediation: undefined, selected: true },
                 { display_name: "dhcp-2-44.vms.sat.rdu2.redhat.com",id: "57c715fd-c49c-4c0d-81bc-f95599cd28f8", opt_out: false, remediation: undefined, selected: true }
-            ]
+            ], true
         );
 
     });

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -88,7 +88,7 @@ const SystemsPage = () => {
 
     useEffect(() => setUrlParams({ ...parameters, ...meta }), [setUrlParams, parameters, meta]);
 
-    const handleSelect = (payload) => dispatch(selectRows(payload));
+    const handleSelect = (payload, selecting) => dispatch(selectRows(payload, selecting));
 
     const onRefreshInventory = () => (
         dispatch(clearInventoryStore()),

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -54,9 +54,8 @@ const SystemsPage = () => {
     const items = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
     const totalItems = useSelector(({ entities }) => entities?.total);
     const meta = useSelector(({ entities }) => entities?.meta);
-    const selectedRows = useSelector(({ entities }) => entities?.selectedRows || {});
+    const selectedRows = useSelector(({ entities }) => entities?.selectedRows || []);
     const selectedRowsCount = useSelector(({ entities }) => entities?.selectedRowsCount ?? 0);
-    const selectedRowsRawData = useSelector(({ entities }) => entities?.selectedRowsRawData || []);
     const isLoaded = useSelector(({ entities }) => entities?.loaded || false);
 
     let parameters = useSelector(({ SystemsPageStore }) => SystemsPageStore.params, shallowEqual);
@@ -169,7 +168,6 @@ const SystemsPage = () => {
                                         rawData={{ data: items, meta: { totalItems }, isLoaded }}
                                         selectedRows={selectedRows}
                                         selectedRowsCount={selectedRowsCount}
-                                        selectedRowsRawData={selectedRowsRawData}
                                         methods={{
                                             doOptOut,
                                             apply,

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -4,7 +4,7 @@ import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { useDispatch } from 'react-redux';
 import { dataShape } from '../../../Helpers/MiscHelper';
-import { fetchSystems, fetchSystemsIds } from '../../../Store/Actions/Actions';
+import { fetchSystems } from '../../../Store/Actions/Actions';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import useSearchFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import { exportConfig, buildActiveFilters, removeFilters, isFilterInDefaultState } from '../../../Helpers/TableToolbarHelper';
@@ -23,7 +23,6 @@ import useOsVersionFilter from '../../PresentationalComponents/Filters/PrimaryTo
 const SystemsTableToolbar = ({
     selectedRows,
     selectedRowsCount,
-    selectedRowsRawData,
     intl,
     canExport,
     canSetExcludedIncluded,
@@ -52,21 +51,21 @@ const SystemsTableToolbar = ({
 
     const kebabProps = useMemo(() => {
         return {
-            selectedExcluded: selectedRowsRawData.some(({ opt_out: optOut }) => optOut === true),
-            selectedIncluded: selectedRowsRawData.some(({ opt_out: optOut }) => optOut === false)
+            selectedExcluded: selectedRows.some(({ opt_out: optOut }) => optOut === true),
+            selectedIncluded: selectedRows.some(({ opt_out: optOut }) => optOut === false)
         };
-    }, [selectedRowsRawData]);
+    }, [selectedRows]);
 
     const kebabOptions = [
         '',
         ...canSetExcludedIncluded ? [{
             label: intl.formatMessage(messages.systemKebabExcludeAnalysis, { count: selectedRowsCount }),
-            onClick: () => doOptOut(selectedRows, selectedRowsRawData?.[0].display_name, true),
+            onClick: () => doOptOut(selectedRows, selectedRows?.[0].display_name, true),
             props: { isDisabled: !selectedRowsCount || !kebabProps.selectedIncluded }
         },
         {
             label: intl.formatMessage(messages.systemKebabIncludeAnalysis, { count: selectedRowsCount }),
-            onClick: () => doOptOut(selectedRows, selectedRowsRawData?.[0].display_name, false, selectedRows),
+            onClick: () => doOptOut(selectedRows, selectedRows?.[0].display_name, false, selectedRows),
             props: { isDisabled: !selectedRowsCount || !kebabProps.selectedExcluded }
         }] : [],
         {
@@ -80,7 +79,8 @@ const SystemsTableToolbar = ({
         selectedRows,
         selectedRowsCount,
         handleSelect,
-        fetchResource: ops => fetchSystemsIds({ ...parameters, ...ops })
+        // TODO: change it back to fetchSystemsIds when the endpoint returns also a display_name
+        fetchResource: ops => fetchSystems({ ...parameters, ...ops })
     });
 
     let filterConfigItems = [
@@ -147,7 +147,6 @@ SystemsTableToolbar.propTypes = {
     parameters: propTypes.object,
     selectedRows: propTypes.array,
     selectedRowsCount: propTypes.number,
-    selectedRowsRawData: propTypes.array,
     methods: propTypes.shape({
         doOptOut: propTypes.func,
         apply: propTypes.func,

--- a/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
@@ -455,7 +455,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
           }
         }
         selectedRows={Array []}
-        selectedRowsRawData={Array []}
       >
         <SystemsTableToolbar
           canExport={true}
@@ -882,7 +881,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
             }
           }
           selectedRows={Array []}
-          selectedRowsRawData={Array []}
         >
           <PrimaryToolbar
             actionsConfig={

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -149,18 +149,19 @@ export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handle
 
     const handleSelectPage = () => {
         const { data } = rawData ?? {};
-        handleSelect(data?.map(mapSelectedRows));
+        // concat already selected rows (in case we are selecting another page)
+        handleSelect(selectedRows.concat(data?.map(mapSelectedRows)), true);
     };
 
     const handleUnselect = () => {
-        handleSelect(selectedRows.map(selectedRow => ({ ...selectedRow, selected: false })));
+        handleSelect(selectedRows.map(selectedRow => ({ ...selectedRow, selected: false })), false);
     };
 
     const handleSelectAll = async () => {
 
         let { payload } = await fetchResource({ page_size: meta.totalItems, page: 1 });
 
-        payload.then(({ data }) => handleSelect(data.map(mapSelectedRows)));
+        payload.then(({ data }) => handleSelect(data.map(mapSelectedRows)), true);
     };
 
     return {

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -128,8 +128,18 @@ export const useOptOutSystems = onRefreshInventory => {
     };
 };
 
-// Temp solution to suppoint
-const mapSelectedRows = ({ id, inventory_id: inventoryId }) => ({ id: id ? id : inventoryId, selected: true });
+// Temp solution - have an optimized endpoint for ids and these attributes
+// eslint-disable-next-line camelcase
+const mapSelectedRows = ({ id, inventory_id: inventoryId, attributes, remediation, display_name, opt_out }) =>
+    ({
+        id: id ? id : inventoryId,
+        selected: true,
+        remediation: attributes ? attributes.remediation : remediation,
+        // eslint-disable-next-line camelcase
+        display_name: attributes ? attributes.display_name : display_name,
+        // eslint-disable-next-line camelcase
+        opt_out: attributes ? attributes.opt_out : opt_out
+    });
 
 export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handleSelect, fetchResource, multiRow = false }) => {
     const intl = useIntl();
@@ -143,19 +153,7 @@ export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handle
     };
 
     const handleUnselect = () => {
-        let toSelect = [];
-        Object.keys(selectedRows).forEach((id) => {
-            toSelect.push(
-                {
-                    id,
-                    selected: false
-                }
-            );
-
-            return toSelect;
-        });
-
-        handleSelect(toSelect);
+        handleSelect(selectedRows.map(selectedRow => ({ ...selectedRow, selected: false })));
     };
 
     const handleSelectAll = async () => {

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -9,6 +9,7 @@ import { optOutSystemsAction } from '../../src/Store/Actions/Actions';
 import messages from '../Messages';
 import { NotAuthorizedNotification, ReadOnlyNotification } from './constants';
 import { useState } from 'react';
+import unionBy from 'lodash/unionBy';
 
 export const useNotification = (config) => {
     const dispatch = useDispatch();
@@ -149,8 +150,9 @@ export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handle
 
     const handleSelectPage = () => {
         const { data } = rawData ?? {};
-        // concat already selected rows (in case we are selecting another page)
-        handleSelect(selectedRows.concat(data?.map(mapSelectedRows)), true);
+        const mappedRows = data?.map(mapSelectedRows);
+        // union with already selected rows (in case we are selecting another page)
+        handleSelect(unionBy(mappedRows, selectedRows, 'id'), true);
     };
 
     const handleUnselect = () => {

--- a/src/Store/Actions/Actions.js
+++ b/src/Store/Actions/Actions.js
@@ -213,7 +213,8 @@ export const setGlobalFilter = (filters) => ({
     payload: filters
 });
 
-export const selectRows = (selected) => ({
+export const selectRows = (selected, selecting) => ({
     type: ActionTypes.SELECT_ENTITY,
-    payload: selected
+    payload: selected,
+    selecting
 });

--- a/src/Store/Reducers/InventoryEntitiesReducer.js
+++ b/src/Store/Reducers/InventoryEntitiesReducer.js
@@ -61,7 +61,7 @@ export const inventoryEntitiesReducer = (columns) => (state = initialState, acti
         case ActionTypes.LOAD_ENTITIES + '_FULFILLED':
             return modifyInventory(columns, newState, action);
         case ActionTypes.SELECT_ENTITY:
-            return selectRows(newState, action);
+            return selectRows(newState, action, action.selecting);
         case ActionTypes.EXPAND_ROW:
             return {
                 ...newState,

--- a/src/Store/Reducers/InventoryEntitiesReducer.js
+++ b/src/Store/Reducers/InventoryEntitiesReducer.js
@@ -1,6 +1,5 @@
 import { selectRows } from './reducersHelper';
 import * as ActionTypes from '../ActionTypes';
-import unionBy from 'lodash/unionBy';
 
 export const initialState = {
     columns: [],
@@ -16,9 +15,7 @@ export const initialState = {
     },
     page: 1,
     perPage: 20,
-    selectedRows: {},
-    prevLoadedRows: [],
-    selectedRowsRawData: [],
+    selectedRows: [],
     selectedRowsCount: 0
 };
 
@@ -26,7 +23,7 @@ function modifyInventory(columns, state, action) {
     let advisory = columns.find(({ key }) => key === 'advisory');
 
     if (!state.selectedRows) {
-        state.selectedRows = {};
+        state.selectedRows = [];
     }
 
     if (!state.sortBy) {
@@ -48,9 +45,8 @@ function modifyInventory(columns, state, action) {
             columns,
             rows: state.rows.map(row => ({
                 ...row,
-                selected: state.selectedRows[row.id] || false
+                selected: state.selectedRows.some(selectedRow => selectedRow.id === row.id) || false
             })),
-            prevLoadedRows: unionBy(action.payload.results, state.prevLoadedRows, 'id'),
             meta: action.payload.meta
         };
     }

--- a/src/Store/Reducers/reducersHelper.js
+++ b/src/Store/Reducers/reducersHelper.js
@@ -64,21 +64,29 @@ export const addOrRemoveItemFromObj = (targetObj, inputArr) => {
     return { ...targetObj, ...inputObj };
 };
 
-export const getNewSelectedItems = (selectedItems, currentItems) => {
-    let payload = [].concat(selectedItems).map(({ id, selected }) => ({ id, selected }));
-    return addOrRemoveItemFromObj(currentItems, payload);
-};
-
 export const selectRows = (state, action) => {
-    const selectedUpdated = getNewSelectedItems(action.payload, state.selectedRows);
-    let prevLoadedRows = [].concat(state.prevLoadedRows);
-    let selectedRowsRawData = prevLoadedRows.filter(({ id }) => selectedUpdated[id] === true);
+    let selectedRows = state.selectedRows.slice();
+    if (Array.isArray(action.payload)) {
+        // when the state and payload are the same length it means that it is a "select none" action
+        if (state.selectedRows.length && state.selectedRows.length === action.payload.length) {
+            selectedRows = [];
+        } else {
+            selectedRows = action.payload;
+        }
+    } else {
+        const selectedRow = selectedRows.find(selected => selected.id === action.payload.id);
+        if (selectedRow) {
+            selectedRows.splice(selectedRows.indexOf(selectedRow), 1);
+        } else {
+            // We need the whole object, not just id in selectedRows, so using rows in our advantage
+            selectedRows.push(state.rows.find(row => row.id === action.payload.id));
+        }
+    }
 
     return {
         ...state,
-        selectedRows: selectedUpdated,
-        selectedRowsRawData,
-        selectedRowsCount: Object.keys(selectedUpdated).length
+        selectedRows,
+        selectedRowsCount: selectedRows.length
     };
 };
 

--- a/src/Store/Reducers/reducersHelper.js
+++ b/src/Store/Reducers/reducersHelper.js
@@ -42,44 +42,20 @@ export const applyGlobalFilter = (state, { workloads, SIDs, tags }) => {
 
 export const isTimestampValid = (stateTimestamp, actionTimestamp) => actionTimestamp >= stateTimestamp;
 
-/**
- * Adds or removes item from the given (targetObj) object based on the value
- *
- * @param {Object} targetObj
- * @param {Array} inputArr
- * @returns {Object}
- */
-export const addOrRemoveItemFromObj = (targetObj, inputArr) => {
-    const inputObj = inputArr.reduce((obj, { id, selected }) => {
-        if (selected === false) {
-            delete targetObj[id];
-        } else {
-            obj[id] = selected;
-        }
-
-        return obj;
-
-    }, {});
-
-    return { ...targetObj, ...inputObj };
-};
-
-export const selectRows = (state, action) => {
+export const selectRows = (state, action, selecting = true) => {
     let selectedRows = state.selectedRows.slice();
     if (Array.isArray(action.payload)) {
-        // when the state and payload are the same length it means that it is a "select none" action
-        if (state.selectedRows.length && state.selectedRows.length === action.payload.length) {
-            selectedRows = [];
-        } else {
+        if (selecting) {
             selectedRows = action.payload;
+        } else {
+            selectedRows = [];
         }
     } else {
-        const selectedRow = selectedRows.find(selected => selected.id === action.payload.id);
-        if (selectedRow) {
-            selectedRows.splice(selectedRows.indexOf(selectedRow), 1);
-        } else {
+        if (action.payload.selected) {
             // We need the whole object, not just id in selectedRows, so using rows in our advantage
             selectedRows.push(state.rows.find(row => row.id === action.payload.id));
+        } else {
+            selectedRows.splice(selectedRows.findIndex(selected => selected.id === action.payload.id), 1);
         }
     }
 


### PR DESCRIPTION
Removing `selectedRowsRawData` and `prevLoadedRows` state fields. Also making sure that `selectedRows` is array. It was sometimes an object...
Adds 2 TODOs comments as we need an update for 2 endpoints. We don't need the whole objects, just some attributes.