### PR TITLE
chore: Update FEC config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@babel/preset-flow": "^7.16.7",
         "@babel/preset-react": "^7.16.7",
         "@formatjs/cli": "^4.8.2",
-        "@redhat-cloud-services/frontend-components-config": "4.6.8",
+        "@redhat-cloud-services/frontend-components-config": "^4.6.11",
         "@rollup/plugin-commonjs": "^21.0.3",
         "@rollup/plugin-image": "^2.1.0",
         "@rollup/plugin-json": "^4.0.3",
@@ -3351,9 +3351,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.8",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.8.tgz",
-      "integrity": "sha512-6NsXYvV4vAAV1mMt8QZrjmSTBx7PD6LF4CzPxnxDbc2G8u0meA+GhLBlOJb31pfSKVQsaYsUzyFnTuj4d1V8hw==",
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.11.tgz",
+      "integrity": "sha512-EBm/kEVIk2UNMa9MQjv5a0C/tMZH+nNc+CsvNanD8EjUdTfPIYoJ0eAtEbQPJ/gIS3pc4+5+fz++GptU/YLk0A==",
       "dev": true,
       "dependencies": {
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
@@ -26668,9 +26668,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "4.6.8",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.8.tgz",
-      "integrity": "sha512-6NsXYvV4vAAV1mMt8QZrjmSTBx7PD6LF4CzPxnxDbc2G8u0meA+GhLBlOJb31pfSKVQsaYsUzyFnTuj4d1V8hw==",
+      "version": "4.6.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.11.tgz",
+      "integrity": "sha512-EBm/kEVIk2UNMa9MQjv5a0C/tMZH+nNc+CsvNanD8EjUdTfPIYoJ0eAtEbQPJ/gIS3pc4+5+fz++GptU/YLk0A==",
       "dev": true,
       "requires": {
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@babel/preset-flow": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
     "@formatjs/cli": "^4.8.2",
-    "@redhat-cloud-services/frontend-components-config": "4.6.8",
+    "@redhat-cloud-services/frontend-components-config": "^4.6.11",
     "@rollup/plugin-commonjs": "^21.0.3",
     "@rollup/plugin-image": "^2.1.0",
     "@rollup/plugin-json": "^4.0.3",


### PR DESCRIPTION
Update FEC config to version over 4.6.9 to prevent future problems when ESI tags are disabled on Akamai.