### PR TITLE
fix: Add newest RHEL versions to OS filter

### DIFF
--- a/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
@@ -1096,6 +1096,46 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                           onClick={[Function]}
                           sendRef={[Function]}
                           setViewMoreNextIndex={[Function]}
+                          value="RHEL 9.0"
+                        />
+                        <SelectOption
+                          className=""
+                          component="button"
+                          index={0}
+                          inputId=""
+                          isChecked={false}
+                          isDisabled={false}
+                          isFavorite={null}
+                          isLastOptionBeforeFooter={[Function]}
+                          isLoad={false}
+                          isLoading={false}
+                          isNoResultsOption={false}
+                          isPlaceholder={false}
+                          isSelected={false}
+                          keyHandler={[Function]}
+                          onClick={[Function]}
+                          sendRef={[Function]}
+                          setViewMoreNextIndex={[Function]}
+                          value="RHEL 8.6"
+                        />
+                        <SelectOption
+                          className=""
+                          component="button"
+                          index={0}
+                          inputId=""
+                          isChecked={false}
+                          isDisabled={false}
+                          isFavorite={null}
+                          isLastOptionBeforeFooter={[Function]}
+                          isLoad={false}
+                          isLoading={false}
+                          isNoResultsOption={false}
+                          isPlaceholder={false}
+                          isSelected={false}
+                          keyHandler={[Function]}
+                          onClick={[Function]}
+                          sendRef={[Function]}
+                          setViewMoreNextIndex={[Function]}
                           value="RHEL 8.5"
                         />
                         <SelectOption
@@ -1237,46 +1277,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                           sendRef={[Function]}
                           setViewMoreNextIndex={[Function]}
                           value="RHEL 7.8"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 7.7"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 7.6"
                         />
                       </Select>,
                     },
@@ -1852,6 +1852,46 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                               onClick={[Function]}
                                               sendRef={[Function]}
                                               setViewMoreNextIndex={[Function]}
+                                              value="RHEL 9.0"
+                                            />
+                                            <SelectOption
+                                              className=""
+                                              component="button"
+                                              index={0}
+                                              inputId=""
+                                              isChecked={false}
+                                              isDisabled={false}
+                                              isFavorite={null}
+                                              isLastOptionBeforeFooter={[Function]}
+                                              isLoad={false}
+                                              isLoading={false}
+                                              isNoResultsOption={false}
+                                              isPlaceholder={false}
+                                              isSelected={false}
+                                              keyHandler={[Function]}
+                                              onClick={[Function]}
+                                              sendRef={[Function]}
+                                              setViewMoreNextIndex={[Function]}
+                                              value="RHEL 8.6"
+                                            />
+                                            <SelectOption
+                                              className=""
+                                              component="button"
+                                              index={0}
+                                              inputId=""
+                                              isChecked={false}
+                                              isDisabled={false}
+                                              isFavorite={null}
+                                              isLastOptionBeforeFooter={[Function]}
+                                              isLoad={false}
+                                              isLoading={false}
+                                              isNoResultsOption={false}
+                                              isPlaceholder={false}
+                                              isSelected={false}
+                                              keyHandler={[Function]}
+                                              onClick={[Function]}
+                                              sendRef={[Function]}
+                                              setViewMoreNextIndex={[Function]}
                                               value="RHEL 8.5"
                                             />
                                             <SelectOption
@@ -1993,46 +2033,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                               sendRef={[Function]}
                                               setViewMoreNextIndex={[Function]}
                                               value="RHEL 7.8"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 7.7"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 7.6"
                                             />
                                           </Select>,
                                         },

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -422,6 +422,14 @@ export const RHEL_VERSIONS = [
     {
         label: 'RHEL 8.5',
         value: '8.5'
+    },
+    {
+        label: 'RHEL 8.6',
+        value: '8.6'
+    },
+    {
+        label: 'RHEL 9.0',
+        value: '9.0'
     }
 ];
 


### PR DESCRIPTION
Add new options to OS filter
- RHEL 8.6
- RHEL 9.0