### PR TITLE
fix: Disable Exec report download button when already downloading

### DIFF
--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -61,11 +61,12 @@ const DownloadExecutive = () => {
 
     return (
         <Fragment>
-            <a onClick={() => onDownloadButtonClick()}>
-                {isLoading
-                    ? intl.formatMessage(messages.loading)
-                    : intl.formatMessage(messages.executiveReportCardButton)}
-            </a>
+            {isLoading
+                ? intl.formatMessage(messages.loading)
+                : <a onClick={() => onDownloadButtonClick()}>
+                    {intl.formatMessage(messages.executiveReportCardButton)}
+                </a>
+            }
             {
                 renderPDF && <DownloadButton
                     fallback={<div />}


### PR DESCRIPTION
Moved `Loading...` text, which is shown after user clicks `Download report`, outside of `<a>` element so now user cannot initiate another download until the first download finishes.