### PR TITLE
Enable code coverage for Cypress tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -118,7 +118,8 @@ module.exports = {
         '@babel/plugin-proposal-nullish-coalescing-operator',
         '@babel/plugin-proposal-optional-chaining',
         'lodash',
-        'transform-class-properties'
+        'transform-class-properties',
+        'babel-plugin-istanbul'
     ],
     env: {
         cjs: {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "build:components:js": "BABEL_ENV=cjs rollup -c ./config/rollup.config.js --format=cjs --environment NODE_ENV:production,FORMAT:cjs",
     "build:components:esm": "BABEL_ENV=esm rollup -c ./config/rollup.config.js --environment NODE_ENV:production,FORMAT:esm",
     "build:components:umd": "rollup -c ./config/rollup.config.js --format=umd --environment NODE_ENV:production,FORMAT:umd",
-    "test:ct": "cypress run-ct",
+    "test:ct": "cypress run-ct && npx nyc report",
     "test:openct": "cypress open-ct",
     "test:jest": "jest --silent --no-cache --passWithNoTests --env=jsdom",
     "test": "npm run test:jest",
@@ -221,9 +221,10 @@
     "access": "public"
   },
   "nyc": {
+    "all": true,
     "report-dir": "cypress-coverage",
     "include": [
-      "src/Components"
+      "src/**/*.js"
     ],
     "exclude": [
       "src/**/*.spec.ct.js",


### PR DESCRIPTION
Running `npm run test:ct` should show code coverage information at the end and should generate HTML report accessible at
`vulnerability-ui/cypress-coverage/lcov-report/index.html`.