### PR TITLE
VULN-2391: OS filter displays only relevant values obtained from API (1/2)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -223,7 +223,7 @@
   "options.any": "Any",
   "osFilterLabel": "Operating system",
   "osFilterLabel.reports": "Applies to OS",
-  "osFilterPlaceholder": "Filter by OS",
+  "osFilterPlaceholder": "Filter by operating system",
   "ovalPopoverBody": "The Vulnerability service identifies CVEs with errata that may affect your Insights-connected RHEL systems",
   "ovalPopoverHeader": "About CVEs in Red Hat Insights",
   "pageTitleSuffix": "Vulnerability | Red Hat Insights",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.23",
         "@redhat-cloud-services/vulnerabilities-client": "^1.0.111",
+        "@scalprum/react-core": "^0.1.9",
         "axios": "^0.27.2",
         "babel-plugin-istanbul": "^6.1.1",
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
     "@redhat-cloud-services/frontend-components-utilities": "^3.2.23",
     "@redhat-cloud-services/vulnerabilities-client": "^1.0.111",
+    "@scalprum/react-core": "^0.1.9",
     "axios": "^0.27.2",
     "babel-plugin-istanbul": "^6.1.1",
     "classnames": "^2.2.5",

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter.js
@@ -1,69 +1,42 @@
-import React from 'react';
-import { RHEL_VERSIONS } from '../../../../Helpers/constants';
-import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
-import { Select, SelectOption } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
+import { useLoadModule } from '@scalprum/react-core';
 import { intl } from '../../../../Utilities/IntlProvider';
 import messages from '../../../../Messages';
 
-const useOsVersionFilter = (filterValue, apply) => {
-    const [isOpen, setOpen] = React.useState(false);
-    const [numOptions, setNumOptions] = React.useState(10);
-    const versionFromNewestToOldest = RHEL_VERSIONS.slice().reverse();
+const useOsVersionFilter = (appliedVersions, apply) => {
+    /* operatingSystems are obtained from the Inventory store */
+    const operatingSystems = useSelector(({ entities }) => entities?.operatingSystems) || [];
+    const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
+        appName: 'inventory',
+        scope: 'inventory',
+        module: './OsFilterHelpers'
+    });
 
-    let selectedVersionsArray = filterValue ? filterValue.split(',') : [];
-
-    const onOptionSelect = (_, changedLabel) => {
-        const changedValue = RHEL_VERSIONS.find(version => version.label === changedLabel).value;
-        let newValue;
-
-        if (selectedVersionsArray.includes(changedValue)) {
-            newValue = selectedVersionsArray;
-            newValue.splice(newValue.indexOf(changedValue), 1);
-        }
-        else {
-            newValue = [...selectedVersionsArray, changedValue];
-        }
-
-        apply({ rhel_version: newValue.join(','), page: 1 });
-    };
-
-    const onToggle = (isOpen) => {
-        setOpen(isOpen);
-    };
-
-    const onViewMoreClick = () => {
-        setNumOptions(versionFromNewestToOldest.length);
-    };
-
-    return {
-        type: conditionalFilterType.custom,
-        label: intl.formatMessage(messages.osFilterLabel),
-        filterValues: {
-            children: (
-                <Select
-                    variant="checkbox"
-                    onToggle={onToggle}
-                    onSelect={onOptionSelect}
-                    selections={selectedVersionsArray.map(item => RHEL_VERSIONS.find(version => version.value === item).label)}
-                    isOpen={isOpen}
-                    aria-label="os-version-filter"
-                    placeholderText={intl.formatMessage(messages.osFilterPlaceholder)}
-                    {...(numOptions < versionFromNewestToOldest.length
-                        && { loadingVariant: { text: intl.formatMessage(messages.viewMore), onClick: onViewMoreClick } })}
-                    style={{ maxHeight: '420px', overflow: 'auto' }}
-                >
-                    {versionFromNewestToOldest.slice(0, numOptions).map((option, index) => (
-                        <SelectOption
-                            isDisabled={option.disabled}
-                            key={index}
-                            value={option.label}
-                            description={option?.description}
-                        />
-                    ))}
-                </Select>
+    return buildOSFilterConfig
+        ? [
+            buildOSFilterConfig(
+                {
+                    label: intl.formatMessage(messages.osFilterLabel),
+                    type: 'checkbox',
+                    id: 'rhel_version',
+                    value: toGroupSelectionValue(
+                        appliedVersions
+                            ? appliedVersions.split(',')
+                            : []
+                    ),
+                    onChange: (event, value) => {
+                    /* `versions` must be of type string, e.g., "8.9,9.0" */
+                        const versions = Object.values(value)
+                            .flatMap((versions) => Object.keys(versions))
+                            .toString();
+                        apply({ rhel_version: versions, page: 1 });
+                    },
+                    placeholder: intl.formatMessage(messages.osFilterPlaceholder)
+                },
+                operatingSystems
             )
-        }
-    };
+        ]
+        : [];
 };
 
 export default useOsVersionFilter;

--- a/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/__mocks__/OsVersionFilter.js
+++ b/src/Components/PresentationalComponents/Filters/PrimaryToolbarFilters/__mocks__/OsVersionFilter.js
@@ -1,0 +1,63 @@
+export default () => [
+    {
+        label: 'Operating System',
+        type: 'group',
+        id: 'rhel_version',
+        value: 'os-filter',
+        placeholder: 'Filter by operating system',
+        filterValues: {
+            selected: {},
+            groups: [
+                {
+                    groupSelectable: true,
+                    noFilter: true,
+                    label: 'RHEL 9',
+                    value: '9.0',
+                    items: [
+                        {
+                            label: 'RHEL 9.0',
+                            value: '9.0',
+                            type: 'checkbox'
+                        }
+                    ]
+                },
+                {
+                    groupSelectable: true,
+                    noFilter: true,
+                    label: 'RHEL 8',
+                    value: '8.0',
+                    items: [
+                        {
+                            label: 'RHEL 8.6',
+                            value: '8.6',
+                            type: 'checkbox'
+                        },
+                        {
+                            label: 'RHEL 8.5',
+                            value: '8.5',
+                            type: 'checkbox'
+                        },
+                        {
+                            label: 'RHEL 8.0',
+                            value: '8.0',
+                            type: 'checkbox'
+                        }
+                    ]
+                },
+                {
+                    groupSelectable: true,
+                    noFilter: true,
+                    label: 'RHEL 6',
+                    value: '6.0',
+                    items: [
+                        {
+                            label: 'RHEL 6.7',
+                            value: '6.7',
+                            type: 'checkbox'
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+];

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -129,6 +129,7 @@ const SystemsExposedTable = ({
             .map(column => ({ ...inventoryColumns.find(({ key }) => column.key === key), ...column }));
     };
 
+    // TODO: let InventoryTable render its own toolbar instead of using custom one
     return (
         <Stack hasGutter>
             <StackItem>

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
@@ -69,6 +69,7 @@ export const SystemsExposedTableToolbar = ({
         apply
     );
 
+    // TODO: use dynamic OS versions
     const osVersionFilter = useOsVersionFilter(
         parameters.rhel_version,
         apply

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
@@ -69,7 +69,6 @@ export const SystemsExposedTableToolbar = ({
         apply
     );
 
-    // TODO: use dynamic OS versions
     const osVersionFilter = useOsVersionFilter(
         parameters.rhel_version,
         apply
@@ -130,7 +129,7 @@ export const SystemsExposedTableToolbar = ({
                     ),
                     statusFilter(apply, parameters),
                     advisoryFilter,
-                    osVersionFilter,
+                    ...osVersionFilter,
                     remediationFilter(apply, parameters)
                 ]
             }}

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.test.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.test.js
@@ -1,0 +1,68 @@
+import { Provider } from "react-redux";
+import { BrowserRouter as Router } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { mountWithIntl } from "../../../Helpers/MiscHelper";
+import { SystemsExposedTableToolbar } from "./SystemsExposedTableToolbar";
+import useOsVersionFilter from "../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter";
+import toJson from "enzyme-to-json";
+import { systems } from "../../../Helpers/fixtures";
+
+const mockStore = configureStore([(store) => (next) => (action) => {}]);
+
+let store = mockStore({});
+
+const applyMock = jest.fn();
+const handleSelectMock = jest.fn();
+const doOptOutMock = jest.fn();
+
+jest.mock(
+  "../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter"
+);
+
+let wrapper;
+
+describe("SystemsExpostedTableToolbar component", () => {
+  beforeEach(() => {
+    wrapper = mountWithIntl(
+      <Provider store={store}>
+        <Router>
+          <SystemsExposedTableToolbar
+            methods={{
+              apply: applyMock,
+              handleSelect: handleSelectMock,
+              doOptOut: doOptOutMock,
+            }}
+            selectedRows={[]}
+            canExport
+            parameters={{
+              excluded: "false",
+              page: 1,
+              page_size: 20,
+              sort: "-updated",
+            }}
+            rawData={{ data: systems.data, meta: { totalItems: 10 } }}
+          />
+        </Router>
+      </Provider>
+    );
+  });
+
+  it("Renders toolbar", () => {
+    expect(
+      wrapper.find({
+        ouiaId: "PrimaryToolbar",
+      })
+    ).toHaveLength(1);
+  });
+
+  it("Toolbar matches snapshot", () => {
+    expect(toJson(wrapper.find('Toolbar'))).toMatchSnapshot();
+  });
+
+  it("The default filter is set by name", () => {
+    const container = wrapper.find('button[data-ouia-component-id="ConditionalFilter"]');
+    expect(container).toHaveLength(1);
+    expect(container.text()).toBe('Name');
+  })
+});

--- a/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemsExposedTable/__snapshots__/SystemsExposedTableToolbar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SystemsTableToolbar component Should match snapshot 1`] = `
+exports[`SystemsExpostedTableToolbar component Toolbar matches snapshot 1`] = `
 <Toolbar
   className="vuln-systems-primary-toolbar ins-c-primary-toolbar"
   id="ins-primary-data-toolbar"
@@ -466,22 +466,67 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                             "filterValues": Object {
                               "items": Array [
                                 Object {
-                                  "label": "Included systems",
+                                  "label": "Does not have security rule",
                                   "value": "false",
-                                },
-                                Object {
-                                  "label": "Excluded systems",
-                                  "value": "true",
                                 },
                               ],
                               "onChange": [Function],
-                              "value": Array [
-                                "false",
-                              ],
+                              "value": Array [],
                             },
-                            "label": "systems included in vulnerability analysis",
+                            "key": "security_rule",
+                            "label": "security rules",
                             "type": "checkbox",
-                            "urlParam": "excluded",
+                          },
+                          Object {
+                            "filterValues": Object {
+                              "items": Array [
+                                Object {
+                                  "label": "Not reviewed",
+                                  "value": "0",
+                                },
+                                Object {
+                                  "label": "In review",
+                                  "value": "1",
+                                },
+                                Object {
+                                  "label": "On-hold",
+                                  "value": "2",
+                                },
+                                Object {
+                                  "label": "Scheduled for patch",
+                                  "value": "3",
+                                },
+                                Object {
+                                  "label": "Resolved",
+                                  "value": "4",
+                                },
+                                Object {
+                                  "label": "No action - risk accepted",
+                                  "value": "5",
+                                },
+                                Object {
+                                  "label": "Resolved via mitigation",
+                                  "value": "6",
+                                },
+                              ],
+                              "onChange": [Function],
+                              "value": Array [],
+                            },
+                            "key": "status",
+                            "label": "status",
+                            "type": "checkbox",
+                          },
+                          Object {
+                            "filterValues": Object {
+                              "aria-label": "search-field",
+                              "id": "search-advisory",
+                              "onChange": [Function],
+                              "placeholder": "Filter by advisory",
+                              "value": undefined,
+                            },
+                            "key": "advisory",
+                            "label": "Advisory",
+                            "type": "text",
                           },
                           Object {
                             "filterValues": Object {
@@ -544,6 +589,30 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                             "type": "group",
                             "value": "os-filter",
                           },
+                          Object {
+                            "filterValues": Object {
+                              "items": Array [
+                                Object {
+                                  "label": "Ansible playbook",
+                                  "value": "2",
+                                },
+                                Object {
+                                  "label": "Manual",
+                                  "value": "1",
+                                },
+                                Object {
+                                  "label": "Not available",
+                                  "value": "0",
+                                },
+                              ],
+                              "onChange": [Function],
+                              "value": Array [],
+                            },
+                            "key": "remediation",
+                            "label": "remediation",
+                            "type": "checkbox",
+                            "urlParam": "remediation",
+                          },
                         ]
                       }
                     >
@@ -573,9 +642,25 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                       component="button"
                                       isHovered={false}
                                       onClick={[Function]}
-                                      ouiaId="systems included in vulnerability analysis"
+                                      ouiaId="security rules"
                                     >
-                                      Systems included in vulnerability analysis
+                                      Security rules
+                                    </DropdownItem>,
+                                    <DropdownItem
+                                      component="button"
+                                      isHovered={false}
+                                      onClick={[Function]}
+                                      ouiaId="status"
+                                    >
+                                      Status
+                                    </DropdownItem>,
+                                    <DropdownItem
+                                      component="button"
+                                      isHovered={false}
+                                      onClick={[Function]}
+                                      ouiaId="Advisory"
+                                    >
+                                      Advisory
                                     </DropdownItem>,
                                     <DropdownItem
                                       component="button"
@@ -584,6 +669,14 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                       ouiaId="Operating System"
                                     >
                                       Operating System
+                                    </DropdownItem>,
+                                    <DropdownItem
+                                      component="button"
+                                      isHovered={false}
+                                      onClick={[Function]}
+                                      ouiaId="remediation"
+                                    >
+                                      Remediation
                                     </DropdownItem>,
                                   ]
                                 }
@@ -629,9 +722,25 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                         component="button"
                                         isHovered={false}
                                         onClick={[Function]}
-                                        ouiaId="systems included in vulnerability analysis"
+                                        ouiaId="security rules"
                                       >
-                                        Systems included in vulnerability analysis
+                                        Security rules
+                                      </DropdownItem>,
+                                      <DropdownItem
+                                        component="button"
+                                        isHovered={false}
+                                        onClick={[Function]}
+                                        ouiaId="status"
+                                      >
+                                        Status
+                                      </DropdownItem>,
+                                      <DropdownItem
+                                        component="button"
+                                        isHovered={false}
+                                        onClick={[Function]}
+                                        ouiaId="Advisory"
+                                      >
+                                        Advisory
                                       </DropdownItem>,
                                       <DropdownItem
                                         component="button"
@@ -640,6 +749,14 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                         ouiaId="Operating System"
                                       >
                                         Operating System
+                                      </DropdownItem>,
+                                      <DropdownItem
+                                        component="button"
+                                        isHovered={false}
+                                        onClick={[Function]}
+                                        ouiaId="remediation"
+                                      >
+                                        Remediation
                                       </DropdownItem>,
                                     ]
                                   }
@@ -1031,20 +1148,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
               Array [
                 "",
                 Object {
-                  "label": "Exclude systems from vulnerability analysis",
-                  "onClick": [Function],
-                  "props": Object {
-                    "isDisabled": true,
-                  },
-                },
-                Object {
-                  "label": "Include systems in vulnerability analysis",
-                  "onClick": [Function],
-                  "props": Object {
-                    "isDisabled": true,
-                  },
-                },
-                Object {
                   "label": "Manage columns",
                   "onClick": [Function],
                 },
@@ -1057,21 +1160,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
             }
             exportConfig={
               Object {
-                "extraItems": Array [
-                  <li>
-                    <button
-                      className="pf-c-dropdown__menu-item"
-                      id="kebab-item-download-pdf"
-                      onClick={[Function]}
-                    >
-                      <Memo(MemoizedFormattedMessage)
-                        defaultMessage="Export as PDF"
-                        description="Kebab item"
-                        id="kebab.exportAsPDF"
-                      />
-                    </button>
-                  </li>,
-                ],
                 "isDisabled": false,
                 "onSelect": [Function],
                 "ouiaId": "export",
@@ -1086,23 +1174,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                 className="pf-c-toolbar__item pf-m-spacer-sm"
               >
                 <DownloadButton
-                  extraItems={
-                    Array [
-                      <li>
-                        <button
-                          className="pf-c-dropdown__menu-item"
-                          id="kebab-item-download-pdf"
-                          onClick={[Function]}
-                        >
-                          <Memo(MemoizedFormattedMessage)
-                            defaultMessage="Export as PDF"
-                            description="Kebab item"
-                            id="kebab.exportAsPDF"
-                          />
-                        </button>
-                      </li>,
-                    ]
-                  }
                   isDisabled={false}
                   onSelect={[Function]}
                   ouiaId="export"
@@ -1126,19 +1197,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                         >
                           Export to JSON
                         </DropdownItem>,
-                        <li>
-                          <button
-                            className="pf-c-dropdown__menu-item"
-                            id="kebab-item-download-pdf"
-                            onClick={[Function]}
-                          >
-                            <Memo(MemoizedFormattedMessage)
-                              defaultMessage="Export as PDF"
-                              description="Kebab item"
-                              id="kebab.exportAsPDF"
-                            />
-                          </button>
-                        </li>,
                       ]
                     }
                     isOpen={false}
@@ -1183,19 +1241,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                           >
                             Export to JSON
                           </DropdownItem>,
-                          <li>
-                            <button
-                              className="pf-c-dropdown__menu-item"
-                              id="kebab-item-download-pdf"
-                              onClick={[Function]}
-                            >
-                              <Memo(MemoizedFormattedMessage)
-                                defaultMessage="Export as PDF"
-                                description="Kebab item"
-                                id="kebab.exportAsPDF"
-                              />
-                            </button>
-                          </li>,
                         ]
                       }
                       isFlipEnabled={false}
@@ -1402,20 +1447,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                     Array [
                       <DropdownItem
                         component="button"
-                        isDisabled={true}
-                        onClick={[Function]}
-                      >
-                        Exclude systems from vulnerability analysis
-                      </DropdownItem>,
-                      <DropdownItem
-                        component="button"
-                        isDisabled={true}
-                        onClick={[Function]}
-                      >
-                        Include systems in vulnerability analysis
-                      </DropdownItem>,
-                      <DropdownItem
-                        component="button"
                         onClick={[Function]}
                       >
                         Manage columns
@@ -1438,20 +1469,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                     direction="down"
                     dropdownItems={
                       Array [
-                        <DropdownItem
-                          component="button"
-                          isDisabled={true}
-                          onClick={[Function]}
-                        >
-                          Exclude systems from vulnerability analysis
-                        </DropdownItem>,
-                        <DropdownItem
-                          component="button"
-                          isDisabled={true}
-                          onClick={[Function]}
-                        >
-                          Include systems in vulnerability analysis
-                        </DropdownItem>,
                         <DropdownItem
                           component="button"
                           onClick={[Function]}
@@ -1693,7 +1710,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                   ]
                 }
                 onDelete={[Function]}
-                showDeleteButton={false}
               >
                 <span
                   className="ins-c-chip-filters"
@@ -1833,6 +1849,33 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                       </div>
                     </GenerateId>
                   </ChipGroup>
+                  <Button
+                    onClick={[Function]}
+                    ouiaId="ClearFilters"
+                    variant="link"
+                  >
+                    <ButtonBase
+                      innerRef={null}
+                      onClick={[Function]}
+                      ouiaId="ClearFilters"
+                      variant="link"
+                    >
+                      <button
+                        aria-disabled={false}
+                        aria-label={null}
+                        className="pf-c-button pf-m-link"
+                        data-ouia-component-id="ClearFilters"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        onClick={[Function]}
+                        role={null}
+                        type="button"
+                      >
+                        Reset filters
+                      </button>
+                    </ButtonBase>
+                  </Button>
                 </span>
               </FilterChips>
             </div>

--- a/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemTableToolbar.test.js
@@ -5,6 +5,8 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { intl } from '../../../Utilities/IntlProvider';
+import useOsVersionFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
+import { systems } from '../../../Helpers/fixtures';
 
 const mockStore = configureStore([store => next => action => { }]);
 let store = mockStore({});
@@ -13,367 +15,7 @@ const applyMock = jest.fn();
 const handleSelectMock = jest.fn();
 const doOptOutMock = jest.fn();
 
-const systems = {
-    "data": [
-        {
-            "attributes": {
-                "culled_timestamp": "2021-08-03T11:30:29.213465+00:00",
-                "cve_count": 1,
-                "display_name": "hypervisor.beav",
-                "insights_id": "59b3f21a-161e-4037-8c08-86cad1dee1af",
-                "inventory_id": "ece17ad9-97db-4480-a486-3eb4edd6c330",
-                "last_evaluation": "2021-07-12T17:48:56.770640+00:00",
-                "last_upload": "2021-07-19T06:30:29.437396+00:00",
-                "opt_out": false,
-                "os": "RHEL 8.4",
-                "rules_evaluation": "2021-07-19T06:30:31.226597+00:00",
-                "stale_timestamp": "2021-07-20T11:30:29.213465+00:00",
-                "stale_warning_timestamp": "2021-07-27T11:30:29.213465+00:00",
-                "tags": [],
-                "updated": "2021-07-19T06:30:29.309802+00:00"
-            },
-            "id": "ece17ad9-97db-4480-a486-3eb4edd6c330",
-            "type": "system",
-            "culled_timestamp": "2021-08-03T11:30:29.213465+00:00",
-            "cve_count": 1,
-            "display_name": "hypervisor.beav",
-            "insights_id": "59b3f21a-161e-4037-8c08-86cad1dee1af",
-            "inventory_id": "ece17ad9-97db-4480-a486-3eb4edd6c330",
-            "last_evaluation": "2021-07-12T17:48:56.770640+00:00",
-            "last_upload": "2021-07-19T06:30:29.437396+00:00",
-            "opt_out": false,
-            "os": "RHEL 8.4",
-            "rules_evaluation": "2021-07-19T06:30:31.226597+00:00",
-            "stale_timestamp": "2021-07-20T11:30:29.213465+00:00",
-            "stale_warning_timestamp": "2021-07-27T11:30:29.213465+00:00",
-            "tags": [],
-            "updated": "2021-07-19T06:30:29.309802+00:00",
-            "selected": false
-        },
-        {
-            "attributes": {
-                "culled_timestamp": "2021-08-03T08:47:57.589677+00:00",
-                "cve_count": 312,
-                "display_name": "client01.apex.example.com",
-                "insights_id": "d0828ef3-54b2-4f96-b2fa-0b8b207f59be",
-                "inventory_id": "84b763c8-9611-4bf0-9fb8-4f737253b994",
-                "last_evaluation": "2021-07-15T13:21:03.229677+00:00",
-                "last_upload": "2021-07-19T03:47:57.944472+00:00",
-                "opt_out": true,
-                "os": "RHEL 7.7",
-                "rules_evaluation": "2021-07-19T03:48:02.730175+00:00",
-                "stale_timestamp": "2021-07-20T08:47:57.589677+00:00",
-                "stale_warning_timestamp": "2021-07-27T08:47:57.589677+00:00",
-                "tags": [],
-                "updated": "2021-07-19T03:47:57.719803+00:00"
-            },
-            "id": "84b763c8-9611-4bf0-9fb8-4f737253b994",
-            "type": "system",
-            "culled_timestamp": "2021-08-03T08:47:57.589677+00:00",
-            "cve_count": 312,
-            "display_name": "client01.apex.example.com",
-            "insights_id": "d0828ef3-54b2-4f96-b2fa-0b8b207f59be",
-            "inventory_id": "84b763c8-9611-4bf0-9fb8-4f737253b994",
-            "last_evaluation": "2021-07-15T13:21:03.229677+00:00",
-            "last_upload": "2021-07-19T03:47:57.944472+00:00",
-            "opt_out": true,
-            "os": "RHEL 7.7",
-            "rules_evaluation": "2021-07-19T03:48:02.730175+00:00",
-            "stale_timestamp": "2021-07-20T08:47:57.589677+00:00",
-            "stale_warning_timestamp": "2021-07-27T08:47:57.589677+00:00",
-            "tags": [],
-            "updated": "2021-07-19T03:47:57.719803+00:00",
-            "selected": false
-        },
-        {
-            "attributes": {
-                "culled_timestamp": "2021-07-28T19:54:01.447925+00:00",
-                "cve_count": 26,
-                "display_name": "edge-host-1",
-                "insights_id": "1681bf3f-aed5-43e7-af58-323fc1c823ec",
-                "inventory_id": "9ad25b17-b805-437b-8fc3-074559c453b8",
-                "last_evaluation": "2021-07-13T14:50:39.561196+00:00",
-                "last_upload": "2021-07-13T14:54:01.669222+00:00",
-                "opt_out": false,
-                "os": "RHEL 8.4",
-                "rules_evaluation": null,
-                "stale_timestamp": "2021-07-14T19:54:01.447925+00:00",
-                "stale_warning_timestamp": "2021-07-21T19:54:01.447925+00:00",
-                "tags": [],
-                "updated": "2021-07-19T00:16:35.573546+00:00"
-            },
-            "id": "9ad25b17-b805-437b-8fc3-074559c453b8",
-            "type": "system",
-            "culled_timestamp": "2021-07-28T19:54:01.447925+00:00",
-            "cve_count": 26,
-            "display_name": "edge-host-1",
-            "insights_id": "1681bf3f-aed5-43e7-af58-323fc1c823ec",
-            "inventory_id": "9ad25b17-b805-437b-8fc3-074559c453b8",
-            "last_evaluation": "2021-07-13T14:50:39.561196+00:00",
-            "last_upload": "2021-07-13T14:54:01.669222+00:00",
-            "opt_out": false,
-            "os": "RHEL 8.4",
-            "rules_evaluation": null,
-            "stale_timestamp": "2021-07-14T19:54:01.447925+00:00",
-            "stale_warning_timestamp": "2021-07-21T19:54:01.447925+00:00",
-            "tags": [],
-            "updated": "2021-07-19T00:16:35.573546+00:00",
-            "selected": false
-        },
-        {
-            "attributes": {
-                "culled_timestamp": "2021-07-29T22:11:39.837980+00:00",
-                "cve_count": 75,
-                "display_name": "rhel7-insights-client-prod.virbr0.akofink-laptop",
-                "insights_id": "256c458f-bdc0-4603-95a3-4031bced2309",
-                "inventory_id": "ae7a9d76-ccc8-44d8-b8f0-692199199f10",
-                "last_evaluation": "2021-07-15T13:22:48.155894+00:00",
-                "last_upload": "2021-07-14T17:11:40.174162+00:00",
-                "opt_out": false,
-                "os": "RHEL 7.9",
-                "rules_evaluation": "2021-07-14T17:11:42.407959+00:00",
-                "stale_timestamp": "2021-07-15T22:11:39.837980+00:00",
-                "stale_warning_timestamp": "2021-07-22T22:11:39.837980+00:00",
-                "tags": [],
-                "updated": "2021-07-17T00:27:34.357294+00:00"
-            },
-            "id": "ae7a9d76-ccc8-44d8-b8f0-692199199f10",
-            "type": "system",
-            "culled_timestamp": "2021-07-29T22:11:39.837980+00:00",
-            "cve_count": 75,
-            "display_name": "rhel7-insights-client-prod.virbr0.akofink-laptop",
-            "insights_id": "256c458f-bdc0-4603-95a3-4031bced2309",
-            "inventory_id": "ae7a9d76-ccc8-44d8-b8f0-692199199f10",
-            "last_evaluation": "2021-07-15T13:22:48.155894+00:00",
-            "last_upload": "2021-07-14T17:11:40.174162+00:00",
-            "opt_out": false,
-            "os": "RHEL 7.9",
-            "rules_evaluation": "2021-07-14T17:11:42.407959+00:00",
-            "stale_timestamp": "2021-07-15T22:11:39.837980+00:00",
-            "stale_warning_timestamp": "2021-07-22T22:11:39.837980+00:00",
-            "tags": [],
-            "updated": "2021-07-17T00:27:34.357294+00:00",
-            "selected": false
-        },
-        {
-            "attributes": {
-                "culled_timestamp": "2021-07-30T11:36:36.331980+00:00",
-                "cve_count": 230,
-                "display_name": "vm-9-105.lab.eng.tlv2.redhat.com",
-                "insights_id": "2f6e5414-514d-4641-a075-1a5eb1effcf9",
-                "inventory_id": "721d9b9f-0db5-46f4-ba71-5611d6c12887",
-                "last_evaluation": "2021-07-15T13:25:27.030126+00:00",
-                "last_upload": "2021-07-15T06:36:36.414039+00:00",
-                "opt_out": false,
-                "os": "RHEL 7.2",
-                "rules_evaluation": "2021-07-15T06:36:45.513187+00:00",
-                "stale_timestamp": "2021-07-16T11:36:36.331980+00:00",
-                "stale_warning_timestamp": "2021-07-23T11:36:36.331980+00:00",
-                "tags": [
-                    {
-                        "key": "location",
-                        "namespace": "satellite",
-                        "value": "Default Location"
-                    },
-                    {
-                        "key": "content_view",
-                        "namespace": "satellite",
-                        "value": "Default Organization View"
-                    },
-                    {
-                        "key": "organization",
-                        "namespace": "satellite",
-                        "value": "Default Organization"
-                    },
-                    {
-                        "key": "activation_key",
-                        "namespace": "satellite",
-                        "value": "ak1"
-                    },
-                    {
-                        "key": "organization_id",
-                        "namespace": "satellite",
-                        "value": "1"
-                    },
-                    {
-                        "key": "lifecycle_environment",
-                        "namespace": "satellite",
-                        "value": "Library"
-                    },
-                    {
-                        "key": "satellite_instance_id",
-                        "namespace": "satellite",
-                        "value": "7f4a0df3-7bba-4d5c-ad19-78c08fb0feea"
-                    }
-                ],
-                "updated": "2021-07-15T06:36:36.369265+00:00"
-            },
-            "id": "721d9b9f-0db5-46f4-ba71-5611d6c12887",
-            "type": "system",
-            "culled_timestamp": "2021-07-30T11:36:36.331980+00:00",
-            "cve_count": 230,
-            "display_name": "vm-9-105.lab.eng.tlv2.redhat.com",
-            "insights_id": "2f6e5414-514d-4641-a075-1a5eb1effcf9",
-            "inventory_id": "721d9b9f-0db5-46f4-ba71-5611d6c12887",
-            "last_evaluation": "2021-07-15T13:25:27.030126+00:00",
-            "last_upload": "2021-07-15T06:36:36.414039+00:00",
-            "opt_out": false,
-            "os": "RHEL 7.2",
-            "rules_evaluation": "2021-07-15T06:36:45.513187+00:00",
-            "stale_timestamp": "2021-07-16T11:36:36.331980+00:00",
-            "stale_warning_timestamp": "2021-07-23T11:36:36.331980+00:00",
-            "tags": [
-                {
-                    "key": "location",
-                    "namespace": "satellite",
-                    "value": "Default Location"
-                },
-                {
-                    "key": "content_view",
-                    "namespace": "satellite",
-                    "value": "Default Organization View"
-                },
-                {
-                    "key": "organization",
-                    "namespace": "satellite",
-                    "value": "Default Organization"
-                },
-                {
-                    "key": "activation_key",
-                    "namespace": "satellite",
-                    "value": "ak1"
-                },
-                {
-                    "key": "organization_id",
-                    "namespace": "satellite",
-                    "value": "1"
-                },
-                {
-                    "key": "lifecycle_environment",
-                    "namespace": "satellite",
-                    "value": "Library"
-                },
-                {
-                    "key": "satellite_instance_id",
-                    "namespace": "satellite",
-                    "value": "7f4a0df3-7bba-4d5c-ad19-78c08fb0feea"
-                }
-            ],
-            "updated": "2021-07-15T06:36:36.369265+00:00",
-            "selected": false
-        },
-        {
-            "attributes": {
-                "culled_timestamp": "2021-07-30T10:43:32.150325+00:00",
-                "cve_count": 7,
-                "display_name": "dhcp-2-44.vms.sat.rdu2.redhat.com",
-                "insights_id": "8e7e7f2d-5976-4ee6-8980-93a9be31fd23",
-                "inventory_id": "57c715fd-c49c-4c0d-81bc-f95599cd28f8",
-                "last_evaluation": "2021-07-15T13:26:41.499289+00:00",
-                "last_upload": "2021-07-15T05:43:32.222723+00:00",
-                "opt_out": false,
-                "os": "RHEL 7.9",
-                "rules_evaluation": "2021-07-15T05:43:33.156583+00:00",
-                "stale_timestamp": "2021-07-16T10:43:32.150325+00:00",
-                "stale_warning_timestamp": "2021-07-23T10:43:32.150325+00:00",
-                "tags": [
-                    {
-                        "key": "location",
-                        "namespace": "satellite",
-                        "value": "Default Location"
-                    },
-                    {
-                        "key": "content_view",
-                        "namespace": "satellite",
-                        "value": "Default Organization View"
-                    },
-                    {
-                        "key": "organization",
-                        "namespace": "satellite",
-                        "value": "Default Organization"
-                    },
-                    {
-                        "key": "activation_key",
-                        "namespace": "satellite",
-                        "value": "testak"
-                    },
-                    {
-                        "key": "organization_id",
-                        "namespace": "satellite",
-                        "value": "1"
-                    },
-                    {
-                        "key": "lifecycle_environment",
-                        "namespace": "satellite",
-                        "value": "Library"
-                    },
-                    {
-                        "key": "satellite_instance_id",
-                        "namespace": "satellite",
-                        "value": "86a737d0-73d3-5e3a-b43e-b5fa0883ed27"
-                    }
-                ],
-                "updated": "2021-07-15T05:43:32.183233+00:00"
-            },
-            "id": "57c715fd-c49c-4c0d-81bc-f95599cd28f8",
-            "type": "system",
-            "culled_timestamp": "2021-07-30T10:43:32.150325+00:00",
-            "cve_count": 7,
-            "display_name": "dhcp-2-44.vms.sat.rdu2.redhat.com",
-            "insights_id": "8e7e7f2d-5976-4ee6-8980-93a9be31fd23",
-            "inventory_id": "57c715fd-c49c-4c0d-81bc-f95599cd28f8",
-            "last_evaluation": "2021-07-15T13:26:41.499289+00:00",
-            "last_upload": "2021-07-15T05:43:32.222723+00:00",
-            "opt_out": false,
-            "os": "RHEL 7.9",
-            "rules_evaluation": "2021-07-15T05:43:33.156583+00:00",
-            "stale_timestamp": "2021-07-16T10:43:32.150325+00:00",
-            "stale_warning_timestamp": "2021-07-23T10:43:32.150325+00:00",
-            "tags": [
-                {
-                    "key": "location",
-                    "namespace": "satellite",
-                    "value": "Default Location"
-                },
-                {
-                    "key": "content_view",
-                    "namespace": "satellite",
-                    "value": "Default Organization View"
-                },
-                {
-                    "key": "organization",
-                    "namespace": "satellite",
-                    "value": "Default Organization"
-                },
-                {
-                    "key": "activation_key",
-                    "namespace": "satellite",
-                    "value": "testak"
-                },
-                {
-                    "key": "organization_id",
-                    "namespace": "satellite",
-                    "value": "1"
-                },
-                {
-                    "key": "lifecycle_environment",
-                    "namespace": "satellite",
-                    "value": "Library"
-                },
-                {
-                    "key": "satellite_instance_id",
-                    "namespace": "satellite",
-                    "value": "86a737d0-73d3-5e3a-b43e-b5fa0883ed27"
-                }
-            ],
-            "updated": "2021-07-15T05:43:32.183233+00:00",
-            "selected": false
-        }
-    ],
-    "meta": {
-        "total_items": 2
-    }
-}
+jest.mock('../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter')
 
 let wrapper;
 
@@ -406,8 +48,16 @@ beforeEach(() => {
 });
 
 describe('SystemsTableToolbar component', () => {
+    it("Renders toolbar", () => {
+        expect(
+          wrapper.find({
+            ouiaId: "PrimaryToolbar",
+          })
+        ).toHaveLength(1);
+      });
+
     it('Should match snapshot', () => {
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(toJson(wrapper.find('Toolbar'))).toMatchSnapshot();
     });
 
     it('Select all systems', () => {
@@ -512,4 +162,9 @@ describe('SystemsTableToolbar component', () => {
         expect(doOptOutMock).toHaveBeenCalled();
     })
 
+    it("The default filter is set by name", () => {
+        const container = wrapper.find('button[data-ouia-component-id="ConditionalFilter"]');
+        expect(container).toHaveLength(1);
+        expect(container.text()).toBe('Name');
+      })
 });

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -101,6 +101,7 @@ const SystemsPage = () => {
     const [columnCounter, setColumnCount] = useState(0);
     useEffect(() => setColumnCount(columnCounter + 1), [columns]);
 
+    // TODO: let InventoryTable render its own toolbar instead of using custom one
     return (
         isLoading ? <Spinner centered/> :
             canReadVulnerabilityResults ? <Fragment>

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -2,7 +2,7 @@ import React, { Fragment, useState, useMemo } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { dataShape } from '../../../Helpers/MiscHelper';
 import { fetchSystems } from '../../../Store/Actions/Actions';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
@@ -18,7 +18,7 @@ import {
     addNotification,
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import useOsVersionFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
+import { useLoadModule } from '@scalprum/react-core';
 
 const SystemsTableToolbar = ({
     selectedRows,
@@ -34,6 +34,13 @@ const SystemsTableToolbar = ({
     const [exportPDF, setExportPDF] = useState(false);
     const { apply, handleSelect, doOptOut, setColumnModalOpen } = methods;
     const dispatch = useDispatch();
+    /* operatingSystems are obtained from the Inventory store */
+    const operatingSystems = useSelector(({ entities }) => entities?.operatingSystems) || [];
+    const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
+        appName: 'inventory',
+        scope: 'inventory',
+        module: './OsFilterHelpers'
+    });
 
     const downloadReport = format => {
         let params = { ...parameters };
@@ -83,7 +90,7 @@ const SystemsTableToolbar = ({
         fetchResource: ops => fetchSystems({ ...parameters, ...ops })
     });
 
-    let filterConfigItems = [
+    const filterConfigItems = [
         useSearchFilter(
             'filter',
             messages.systemsSearchName,
@@ -91,11 +98,31 @@ const SystemsTableToolbar = ({
             parameters.filter,
             apply
         ),
-        ...canReadExcluded ? [excludedFilter(apply, parameters)] : [],
-        useOsVersionFilter(
-            parameters.rhel_version,
-            apply
-        )
+        ...(canReadExcluded ? [excludedFilter(apply, parameters)] : []),
+        ...(buildOSFilterConfig
+            ? [
+                buildOSFilterConfig(
+                    {
+                        label: intl.formatMessage(messages.osFilterLabel),
+                        type: 'checkbox',
+                        id: 'rhel_version',
+                        value: toGroupSelectionValue(
+                            parameters.rhel_version
+                                ? parameters.rhel_version.split(',')
+                                : []
+                        ),
+                        onChange: (event, value) => {
+                            /* `versions` must be of type string, e.g., "8.9,9.0" */
+                            const versions = Object.values(value)
+                                .flatMap((versions) => Object.keys(versions))
+                                .toString();
+                            apply({ rhel_version: versions, page: 1 });
+                        }
+                    },
+                    operatingSystems
+                )
+            ]
+            : [])
     ];
 
     return <Fragment>
@@ -111,7 +138,7 @@ const SystemsTableToolbar = ({
             }}
             activeFiltersConfig={{
                 filters: buildActiveFilters(parameters),
-                onDelete: (_, chips, reset) => removeFilters(chips, methods.apply, reset, SYSTEMS_DEFAULT_FILTERS),
+                onDelete: (_, chips, reset) => removeFilters(chips, apply, reset, SYSTEMS_DEFAULT_FILTERS),
                 deleteTitle: intl.formatMessage(messages.resetFilters),
                 showDeleteButton: !isFilterInDefaultState(
                     parameters,

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -2,7 +2,7 @@ import React, { Fragment, useState, useMemo } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { dataShape } from '../../../Helpers/MiscHelper';
 import { fetchSystems } from '../../../Store/Actions/Actions';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
@@ -18,7 +18,7 @@ import {
     addNotification,
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { useLoadModule } from '@scalprum/react-core';
+import useOsVersionFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
 
 const SystemsTableToolbar = ({
     selectedRows,
@@ -34,13 +34,6 @@ const SystemsTableToolbar = ({
     const [exportPDF, setExportPDF] = useState(false);
     const { apply, handleSelect, doOptOut, setColumnModalOpen } = methods;
     const dispatch = useDispatch();
-    /* operatingSystems are obtained from the Inventory store */
-    const operatingSystems = useSelector(({ entities }) => entities?.operatingSystems) || [];
-    const [{ toGroupSelectionValue, buildOSFilterConfig } = {}] = useLoadModule({
-        appName: 'inventory',
-        scope: 'inventory',
-        module: './OsFilterHelpers'
-    });
 
     const downloadReport = format => {
         let params = { ...parameters };
@@ -90,6 +83,11 @@ const SystemsTableToolbar = ({
         fetchResource: ops => fetchSystems({ ...parameters, ...ops })
     });
 
+    const osVersionFilter = useOsVersionFilter(
+        parameters.rhel_version,
+        apply
+    );
+
     const filterConfigItems = [
         useSearchFilter(
             'filter',
@@ -99,30 +97,7 @@ const SystemsTableToolbar = ({
             apply
         ),
         ...(canReadExcluded ? [excludedFilter(apply, parameters)] : []),
-        ...(buildOSFilterConfig
-            ? [
-                buildOSFilterConfig(
-                    {
-                        label: intl.formatMessage(messages.osFilterLabel),
-                        type: 'checkbox',
-                        id: 'rhel_version',
-                        value: toGroupSelectionValue(
-                            parameters.rhel_version
-                                ? parameters.rhel_version.split(',')
-                                : []
-                        ),
-                        onChange: (event, value) => {
-                            /* `versions` must be of type string, e.g., "8.9,9.0" */
-                            const versions = Object.values(value)
-                                .flatMap((versions) => Object.keys(versions))
-                                .toString();
-                            apply({ rhel_version: versions, page: 1 });
-                        }
-                    },
-                    operatingSystems
-                )
-            ]
-            : [])
+        ...osVersionFilter
     ];
 
     return <Fragment>

--- a/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemsPage/__snapshots__/SystemTableToolbar.test.js.snap
@@ -1019,276 +1019,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                     "type": "checkbox",
                     "urlParam": "excluded",
                   },
-                  Object {
-                    "filterValues": Object {
-                      "children": <Select
-                        aria-describedby=""
-                        aria-invalid={false}
-                        aria-label="os-version-filter"
-                        aria-labelledby=""
-                        chipGroupComponent={null}
-                        className=""
-                        clearSelectionsAriaLabel="Clear all"
-                        createText="Create"
-                        customBadgeText={null}
-                        customContent={null}
-                        direction="down"
-                        favorites={Array []}
-                        favoritesLabel="Favorites"
-                        hasInlineFilter={false}
-                        hasPlaceholderStyle={false}
-                        inlineFilterPlaceholderText={null}
-                        inputAutoComplete="off"
-                        inputIdPrefix=""
-                        isCreatable={false}
-                        isCreateSelectOptionObject={false}
-                        isDisabled={false}
-                        isFlipEnabled={false}
-                        isGrouped={false}
-                        isInputFilterPersisted={false}
-                        isInputValuePersisted={false}
-                        isOpen={false}
-                        isPlain={false}
-                        loadingVariant={
-                          Object {
-                            "onClick": [Function],
-                            "text": "View more",
-                          }
-                        }
-                        menuAppendTo="inline"
-                        noResultsFoundText="No results found"
-                        onClear={[Function]}
-                        onCreateOption={[Function]}
-                        onFilter={null}
-                        onSelect={[Function]}
-                        onToggle={[Function]}
-                        onTypeaheadInputChanged={null}
-                        ouiaSafe={true}
-                        placeholderText="Filter by OS"
-                        position="left"
-                        removeSelectionAriaLabel="Remove"
-                        selections={Array []}
-                        shouldResetOnSelect={true}
-                        style={
-                          Object {
-                            "maxHeight": "420px",
-                            "overflow": "auto",
-                          }
-                        }
-                        toggleAriaLabel="Options menu"
-                        toggleIcon={null}
-                        toggleId={null}
-                        typeAheadAriaDescribedby=""
-                        typeAheadAriaLabel=""
-                        validated="default"
-                        variant="checkbox"
-                        width=""
-                      >
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 9.0"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.6"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.5"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.4"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.3"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.2"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.1"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 8.0"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 7.9"
-                        />
-                        <SelectOption
-                          className=""
-                          component="button"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isLastOptionBeforeFooter={[Function]}
-                          isLoad={false}
-                          isLoading={false}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          setViewMoreNextIndex={[Function]}
-                          value="RHEL 7.8"
-                        />
-                      </Select>,
-                    },
-                    "label": "Operating system",
-                    "type": "custom",
-                  },
                 ],
               }
             }
@@ -1526,7 +1256,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                     data-ouia-component-id="bulk-select"
                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                     data-ouia-safe="true"
-                                                    id="pf-dropdown-toggle-id-4"
+                                                    id="pf-dropdown-toggle-id-8"
                                                     type="button"
                                                   >
                                                     <span
@@ -1654,7 +1384,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                         data-ouia-component-id="bulk-select"
                                                         data-ouia-component-type="PF4/DropdownToggle"
                                                         data-ouia-safe="true"
-                                                        id="pf-dropdown-toggle-id-4"
+                                                        id="pf-dropdown-toggle-id-8"
                                                         type="button"
                                                       >
                                                         <span
@@ -1775,276 +1505,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                         "type": "checkbox",
                                         "urlParam": "excluded",
                                       },
-                                      Object {
-                                        "filterValues": Object {
-                                          "children": <Select
-                                            aria-describedby=""
-                                            aria-invalid={false}
-                                            aria-label="os-version-filter"
-                                            aria-labelledby=""
-                                            chipGroupComponent={null}
-                                            className=""
-                                            clearSelectionsAriaLabel="Clear all"
-                                            createText="Create"
-                                            customBadgeText={null}
-                                            customContent={null}
-                                            direction="down"
-                                            favorites={Array []}
-                                            favoritesLabel="Favorites"
-                                            hasInlineFilter={false}
-                                            hasPlaceholderStyle={false}
-                                            inlineFilterPlaceholderText={null}
-                                            inputAutoComplete="off"
-                                            inputIdPrefix=""
-                                            isCreatable={false}
-                                            isCreateSelectOptionObject={false}
-                                            isDisabled={false}
-                                            isFlipEnabled={false}
-                                            isGrouped={false}
-                                            isInputFilterPersisted={false}
-                                            isInputValuePersisted={false}
-                                            isOpen={false}
-                                            isPlain={false}
-                                            loadingVariant={
-                                              Object {
-                                                "onClick": [Function],
-                                                "text": "View more",
-                                              }
-                                            }
-                                            menuAppendTo="inline"
-                                            noResultsFoundText="No results found"
-                                            onClear={[Function]}
-                                            onCreateOption={[Function]}
-                                            onFilter={null}
-                                            onSelect={[Function]}
-                                            onToggle={[Function]}
-                                            onTypeaheadInputChanged={null}
-                                            ouiaSafe={true}
-                                            placeholderText="Filter by OS"
-                                            position="left"
-                                            removeSelectionAriaLabel="Remove"
-                                            selections={Array []}
-                                            shouldResetOnSelect={true}
-                                            style={
-                                              Object {
-                                                "maxHeight": "420px",
-                                                "overflow": "auto",
-                                              }
-                                            }
-                                            toggleAriaLabel="Options menu"
-                                            toggleIcon={null}
-                                            toggleId={null}
-                                            typeAheadAriaDescribedby=""
-                                            typeAheadAriaLabel=""
-                                            validated="default"
-                                            variant="checkbox"
-                                            width=""
-                                          >
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 9.0"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.6"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.5"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.4"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.3"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.2"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.1"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 8.0"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 7.9"
-                                            />
-                                            <SelectOption
-                                              className=""
-                                              component="button"
-                                              index={0}
-                                              inputId=""
-                                              isChecked={false}
-                                              isDisabled={false}
-                                              isFavorite={null}
-                                              isLastOptionBeforeFooter={[Function]}
-                                              isLoad={false}
-                                              isLoading={false}
-                                              isNoResultsOption={false}
-                                              isPlaceholder={false}
-                                              isSelected={false}
-                                              keyHandler={[Function]}
-                                              onClick={[Function]}
-                                              sendRef={[Function]}
-                                              setViewMoreNextIndex={[Function]}
-                                              value="RHEL 7.8"
-                                            />
-                                          </Select>,
-                                        },
-                                        "label": "Operating system",
-                                        "type": "custom",
-                                      },
                                     ]
                                   }
                                 >
@@ -2077,14 +1537,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                   ouiaId="systems included in vulnerability analysis"
                                                 >
                                                   Systems included in vulnerability analysis
-                                                </DropdownItem>,
-                                                <DropdownItem
-                                                  component="button"
-                                                  isHovered={false}
-                                                  onClick={[Function]}
-                                                  ouiaId="Operating system"
-                                                >
-                                                  Operating system
                                                 </DropdownItem>,
                                               ]
                                             }
@@ -2133,14 +1585,6 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                     ouiaId="systems included in vulnerability analysis"
                                                   >
                                                     Systems included in vulnerability analysis
-                                                  </DropdownItem>,
-                                                  <DropdownItem
-                                                    component="button"
-                                                    isHovered={false}
-                                                    onClick={[Function]}
-                                                    ouiaId="Operating system"
-                                                  >
-                                                    Operating system
                                                   </DropdownItem>,
                                                 ]
                                               }
@@ -2209,7 +1653,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                           data-ouia-component-id="ConditionalFilter"
                                                           data-ouia-component-type="PF4/DropdownToggle"
                                                           data-ouia-safe="true"
-                                                          id="pf-dropdown-toggle-id-5"
+                                                          id="pf-dropdown-toggle-id-9"
                                                           type="button"
                                                         >
                                                           <span
@@ -2291,7 +1735,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                             data-ouia-component-id="ConditionalFilter"
                                                             data-ouia-component-type="PF4/DropdownToggle"
                                                             data-ouia-safe="true"
-                                                            id="pf-dropdown-toggle-id-5"
+                                                            id="pf-dropdown-toggle-id-9"
                                                             type="button"
                                                           >
                                                             <span
@@ -2758,7 +2202,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                               data-ouia-component-id="Export"
                                               data-ouia-component-type="PF4/DropdownToggle"
                                               data-ouia-safe="true"
-                                              id="pf-dropdown-toggle-id-6"
+                                              id="pf-dropdown-toggle-id-10"
                                               type="button"
                                             >
                                               <span>
@@ -2817,7 +2261,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                                 data-ouia-component-id="Export"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe="true"
-                                                id="pf-dropdown-toggle-id-6"
+                                                id="pf-dropdown-toggle-id-10"
                                                 type="button"
                                               >
                                                 <span>
@@ -3004,7 +2448,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                             aria-haspopup="true"
                                             aria-label="Actions"
                                             class="pf-c-dropdown__toggle pf-m-plain"
-                                            id="pf-dropdown-toggle-id-7"
+                                            id="pf-dropdown-toggle-id-11"
                                             type="button"
                                           >
                                             <svg
@@ -3054,7 +2498,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                                               aria-haspopup="true"
                                               aria-label="Actions"
                                               class="pf-c-dropdown__toggle pf-m-plain"
-                                              id="pf-dropdown-toggle-id-7"
+                                              id="pf-dropdown-toggle-id-11"
                                               type="button"
                                             >
                                               <svg
@@ -3131,7 +2575,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                         Object {
                           "current": <div
                             class="pf-c-toolbar__expandable-content"
-                            id="ins-primary-data-toolbar-expandable-content-2"
+                            id="ins-primary-data-toolbar-expandable-content-4"
                           >
                             <div
                               class="pf-c-toolbar__group"
@@ -3350,7 +2794,7 @@ exports[`SystemsTableToolbar component Should match snapshot 1`] = `
                         Object {
                           "current": <div
                             class="pf-c-toolbar__expandable-content"
-                            id="ins-primary-data-toolbar-expandable-content-3"
+                            id="ins-primary-data-toolbar-expandable-content-5"
                           >
                             <div
                               class="pf-c-toolbar__group"

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -59,6 +59,16 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
                 array.push({ key, category: FILTERS[key].title, chips: [{ name: `${cvssFrom} - ${cvssTo}` }] });
             }
         }
+        else if (key === 'rhel_version' && hasValue(currentFilters, 'rhel_version')) {
+            array.push({
+                key,
+                multiValue: currentFilters.rhel_version.split(','),
+                category: 'Operating system',
+                chips: currentFilters.rhel_version
+                    .split(',')
+                    .map((v) => ({ value: v, name: `RHEL ${v}` }))
+            });
+        }
         else if (hasValue(currentFilters, key)) {
             const multiValue = typeof currentFilters[key] === 'string' && currentFilters[key].split(',');
             const filteredValues = (multiValue && multiValue.length > 1)

--- a/src/Helpers/fixtures.js
+++ b/src/Helpers/fixtures.js
@@ -1,0 +1,361 @@
+export const systems = {
+    data: [
+        {
+            attributes: {
+                culled_timestamp: '2021-08-03T11:30:29.213465+00:00',
+                cve_count: 1,
+                display_name: 'hypervisor.beav',
+                insights_id: '59b3f21a-161e-4037-8c08-86cad1dee1af',
+                inventory_id: 'ece17ad9-97db-4480-a486-3eb4edd6c330',
+                last_evaluation: '2021-07-12T17:48:56.770640+00:00',
+                last_upload: '2021-07-19T06:30:29.437396+00:00',
+                opt_out: false,
+                os: 'RHEL 8.4',
+                rules_evaluation: '2021-07-19T06:30:31.226597+00:00',
+                stale_timestamp: '2021-07-20T11:30:29.213465+00:00',
+                stale_warning_timestamp: '2021-07-27T11:30:29.213465+00:00',
+                tags: [],
+                updated: '2021-07-19T06:30:29.309802+00:00'
+            },
+            id: 'ece17ad9-97db-4480-a486-3eb4edd6c330',
+            type: 'system',
+            culled_timestamp: '2021-08-03T11:30:29.213465+00:00',
+            cve_count: 1,
+            display_name: 'hypervisor.beav',
+            insights_id: '59b3f21a-161e-4037-8c08-86cad1dee1af',
+            inventory_id: 'ece17ad9-97db-4480-a486-3eb4edd6c330',
+            last_evaluation: '2021-07-12T17:48:56.770640+00:00',
+            last_upload: '2021-07-19T06:30:29.437396+00:00',
+            opt_out: false,
+            os: 'RHEL 8.4',
+            rules_evaluation: '2021-07-19T06:30:31.226597+00:00',
+            stale_timestamp: '2021-07-20T11:30:29.213465+00:00',
+            stale_warning_timestamp: '2021-07-27T11:30:29.213465+00:00',
+            tags: [],
+            updated: '2021-07-19T06:30:29.309802+00:00',
+            selected: false
+        },
+        {
+            attributes: {
+                culled_timestamp: '2021-08-03T08:47:57.589677+00:00',
+                cve_count: 312,
+                display_name: 'client01.apex.example.com',
+                insights_id: 'd0828ef3-54b2-4f96-b2fa-0b8b207f59be',
+                inventory_id: '84b763c8-9611-4bf0-9fb8-4f737253b994',
+                last_evaluation: '2021-07-15T13:21:03.229677+00:00',
+                last_upload: '2021-07-19T03:47:57.944472+00:00',
+                opt_out: true,
+                os: 'RHEL 7.7',
+                rules_evaluation: '2021-07-19T03:48:02.730175+00:00',
+                stale_timestamp: '2021-07-20T08:47:57.589677+00:00',
+                stale_warning_timestamp: '2021-07-27T08:47:57.589677+00:00',
+                tags: [],
+                updated: '2021-07-19T03:47:57.719803+00:00'
+            },
+            id: '84b763c8-9611-4bf0-9fb8-4f737253b994',
+            type: 'system',
+            culled_timestamp: '2021-08-03T08:47:57.589677+00:00',
+            cve_count: 312,
+            display_name: 'client01.apex.example.com',
+            insights_id: 'd0828ef3-54b2-4f96-b2fa-0b8b207f59be',
+            inventory_id: '84b763c8-9611-4bf0-9fb8-4f737253b994',
+            last_evaluation: '2021-07-15T13:21:03.229677+00:00',
+            last_upload: '2021-07-19T03:47:57.944472+00:00',
+            opt_out: true,
+            os: 'RHEL 7.7',
+            rules_evaluation: '2021-07-19T03:48:02.730175+00:00',
+            stale_timestamp: '2021-07-20T08:47:57.589677+00:00',
+            stale_warning_timestamp: '2021-07-27T08:47:57.589677+00:00',
+            tags: [],
+            updated: '2021-07-19T03:47:57.719803+00:00',
+            selected: false
+        },
+        {
+            attributes: {
+                culled_timestamp: '2021-07-28T19:54:01.447925+00:00',
+                cve_count: 26,
+                display_name: 'edge-host-1',
+                insights_id: '1681bf3f-aed5-43e7-af58-323fc1c823ec',
+                inventory_id: '9ad25b17-b805-437b-8fc3-074559c453b8',
+                last_evaluation: '2021-07-13T14:50:39.561196+00:00',
+                last_upload: '2021-07-13T14:54:01.669222+00:00',
+                opt_out: false,
+                os: 'RHEL 8.4',
+                rules_evaluation: null,
+                stale_timestamp: '2021-07-14T19:54:01.447925+00:00',
+                stale_warning_timestamp: '2021-07-21T19:54:01.447925+00:00',
+                tags: [],
+                updated: '2021-07-19T00:16:35.573546+00:00'
+            },
+            id: '9ad25b17-b805-437b-8fc3-074559c453b8',
+            type: 'system',
+            culled_timestamp: '2021-07-28T19:54:01.447925+00:00',
+            cve_count: 26,
+            display_name: 'edge-host-1',
+            insights_id: '1681bf3f-aed5-43e7-af58-323fc1c823ec',
+            inventory_id: '9ad25b17-b805-437b-8fc3-074559c453b8',
+            last_evaluation: '2021-07-13T14:50:39.561196+00:00',
+            last_upload: '2021-07-13T14:54:01.669222+00:00',
+            opt_out: false,
+            os: 'RHEL 8.4',
+            rules_evaluation: null,
+            stale_timestamp: '2021-07-14T19:54:01.447925+00:00',
+            stale_warning_timestamp: '2021-07-21T19:54:01.447925+00:00',
+            tags: [],
+            updated: '2021-07-19T00:16:35.573546+00:00',
+            selected: false
+        },
+        {
+            attributes: {
+                culled_timestamp: '2021-07-29T22:11:39.837980+00:00',
+                cve_count: 75,
+                display_name: 'rhel7-insights-client-prod.virbr0.akofink-laptop',
+                insights_id: '256c458f-bdc0-4603-95a3-4031bced2309',
+                inventory_id: 'ae7a9d76-ccc8-44d8-b8f0-692199199f10',
+                last_evaluation: '2021-07-15T13:22:48.155894+00:00',
+                last_upload: '2021-07-14T17:11:40.174162+00:00',
+                opt_out: false,
+                os: 'RHEL 7.9',
+                rules_evaluation: '2021-07-14T17:11:42.407959+00:00',
+                stale_timestamp: '2021-07-15T22:11:39.837980+00:00',
+                stale_warning_timestamp: '2021-07-22T22:11:39.837980+00:00',
+                tags: [],
+                updated: '2021-07-17T00:27:34.357294+00:00'
+            },
+            id: 'ae7a9d76-ccc8-44d8-b8f0-692199199f10',
+            type: 'system',
+            culled_timestamp: '2021-07-29T22:11:39.837980+00:00',
+            cve_count: 75,
+            display_name: 'rhel7-insights-client-prod.virbr0.akofink-laptop',
+            insights_id: '256c458f-bdc0-4603-95a3-4031bced2309',
+            inventory_id: 'ae7a9d76-ccc8-44d8-b8f0-692199199f10',
+            last_evaluation: '2021-07-15T13:22:48.155894+00:00',
+            last_upload: '2021-07-14T17:11:40.174162+00:00',
+            opt_out: false,
+            os: 'RHEL 7.9',
+            rules_evaluation: '2021-07-14T17:11:42.407959+00:00',
+            stale_timestamp: '2021-07-15T22:11:39.837980+00:00',
+            stale_warning_timestamp: '2021-07-22T22:11:39.837980+00:00',
+            tags: [],
+            updated: '2021-07-17T00:27:34.357294+00:00',
+            selected: false
+        },
+        {
+            attributes: {
+                culled_timestamp: '2021-07-30T11:36:36.331980+00:00',
+                cve_count: 230,
+                display_name: 'vm-9-105.lab.eng.tlv2.redhat.com',
+                insights_id: '2f6e5414-514d-4641-a075-1a5eb1effcf9',
+                inventory_id: '721d9b9f-0db5-46f4-ba71-5611d6c12887',
+                last_evaluation: '2021-07-15T13:25:27.030126+00:00',
+                last_upload: '2021-07-15T06:36:36.414039+00:00',
+                opt_out: false,
+                os: 'RHEL 7.2',
+                rules_evaluation: '2021-07-15T06:36:45.513187+00:00',
+                stale_timestamp: '2021-07-16T11:36:36.331980+00:00',
+                stale_warning_timestamp: '2021-07-23T11:36:36.331980+00:00',
+                tags: [
+                    {
+                        key: 'location',
+                        namespace: 'satellite',
+                        value: 'Default Location'
+                    },
+                    {
+                        key: 'content_view',
+                        namespace: 'satellite',
+                        value: 'Default Organization View'
+                    },
+                    {
+                        key: 'organization',
+                        namespace: 'satellite',
+                        value: 'Default Organization'
+                    },
+                    {
+                        key: 'activation_key',
+                        namespace: 'satellite',
+                        value: 'ak1'
+                    },
+                    {
+                        key: 'organization_id',
+                        namespace: 'satellite',
+                        value: '1'
+                    },
+                    {
+                        key: 'lifecycle_environment',
+                        namespace: 'satellite',
+                        value: 'Library'
+                    },
+                    {
+                        key: 'satellite_instance_id',
+                        namespace: 'satellite',
+                        value: '7f4a0df3-7bba-4d5c-ad19-78c08fb0feea'
+                    }
+                ],
+                updated: '2021-07-15T06:36:36.369265+00:00'
+            },
+            id: '721d9b9f-0db5-46f4-ba71-5611d6c12887',
+            type: 'system',
+            culled_timestamp: '2021-07-30T11:36:36.331980+00:00',
+            cve_count: 230,
+            display_name: 'vm-9-105.lab.eng.tlv2.redhat.com',
+            insights_id: '2f6e5414-514d-4641-a075-1a5eb1effcf9',
+            inventory_id: '721d9b9f-0db5-46f4-ba71-5611d6c12887',
+            last_evaluation: '2021-07-15T13:25:27.030126+00:00',
+            last_upload: '2021-07-15T06:36:36.414039+00:00',
+            opt_out: false,
+            os: 'RHEL 7.2',
+            rules_evaluation: '2021-07-15T06:36:45.513187+00:00',
+            stale_timestamp: '2021-07-16T11:36:36.331980+00:00',
+            stale_warning_timestamp: '2021-07-23T11:36:36.331980+00:00',
+            tags: [
+                {
+                    key: 'location',
+                    namespace: 'satellite',
+                    value: 'Default Location'
+                },
+                {
+                    key: 'content_view',
+                    namespace: 'satellite',
+                    value: 'Default Organization View'
+                },
+                {
+                    key: 'organization',
+                    namespace: 'satellite',
+                    value: 'Default Organization'
+                },
+                {
+                    key: 'activation_key',
+                    namespace: 'satellite',
+                    value: 'ak1'
+                },
+                {
+                    key: 'organization_id',
+                    namespace: 'satellite',
+                    value: '1'
+                },
+                {
+                    key: 'lifecycle_environment',
+                    namespace: 'satellite',
+                    value: 'Library'
+                },
+                {
+                    key: 'satellite_instance_id',
+                    namespace: 'satellite',
+                    value: '7f4a0df3-7bba-4d5c-ad19-78c08fb0feea'
+                }
+            ],
+            updated: '2021-07-15T06:36:36.369265+00:00',
+            selected: false
+        },
+        {
+            attributes: {
+                culled_timestamp: '2021-07-30T10:43:32.150325+00:00',
+                cve_count: 7,
+                display_name: 'dhcp-2-44.vms.sat.rdu2.redhat.com',
+                insights_id: '8e7e7f2d-5976-4ee6-8980-93a9be31fd23',
+                inventory_id: '57c715fd-c49c-4c0d-81bc-f95599cd28f8',
+                last_evaluation: '2021-07-15T13:26:41.499289+00:00',
+                last_upload: '2021-07-15T05:43:32.222723+00:00',
+                opt_out: false,
+                os: 'RHEL 7.9',
+                rules_evaluation: '2021-07-15T05:43:33.156583+00:00',
+                stale_timestamp: '2021-07-16T10:43:32.150325+00:00',
+                stale_warning_timestamp: '2021-07-23T10:43:32.150325+00:00',
+                tags: [
+                    {
+                        key: 'location',
+                        namespace: 'satellite',
+                        value: 'Default Location'
+                    },
+                    {
+                        key: 'content_view',
+                        namespace: 'satellite',
+                        value: 'Default Organization View'
+                    },
+                    {
+                        key: 'organization',
+                        namespace: 'satellite',
+                        value: 'Default Organization'
+                    },
+                    {
+                        key: 'activation_key',
+                        namespace: 'satellite',
+                        value: 'testak'
+                    },
+                    {
+                        key: 'organization_id',
+                        namespace: 'satellite',
+                        value: '1'
+                    },
+                    {
+                        key: 'lifecycle_environment',
+                        namespace: 'satellite',
+                        value: 'Library'
+                    },
+                    {
+                        key: 'satellite_instance_id',
+                        namespace: 'satellite',
+                        value: '86a737d0-73d3-5e3a-b43e-b5fa0883ed27'
+                    }
+                ],
+                updated: '2021-07-15T05:43:32.183233+00:00'
+            },
+            id: '57c715fd-c49c-4c0d-81bc-f95599cd28f8',
+            type: 'system',
+            culled_timestamp: '2021-07-30T10:43:32.150325+00:00',
+            cve_count: 7,
+            display_name: 'dhcp-2-44.vms.sat.rdu2.redhat.com',
+            insights_id: '8e7e7f2d-5976-4ee6-8980-93a9be31fd23',
+            inventory_id: '57c715fd-c49c-4c0d-81bc-f95599cd28f8',
+            last_evaluation: '2021-07-15T13:26:41.499289+00:00',
+            last_upload: '2021-07-15T05:43:32.222723+00:00',
+            opt_out: false,
+            os: 'RHEL 7.9',
+            rules_evaluation: '2021-07-15T05:43:33.156583+00:00',
+            stale_timestamp: '2021-07-16T10:43:32.150325+00:00',
+            stale_warning_timestamp: '2021-07-23T10:43:32.150325+00:00',
+            tags: [
+                {
+                    key: 'location',
+                    namespace: 'satellite',
+                    value: 'Default Location'
+                },
+                {
+                    key: 'content_view',
+                    namespace: 'satellite',
+                    value: 'Default Organization View'
+                },
+                {
+                    key: 'organization',
+                    namespace: 'satellite',
+                    value: 'Default Organization'
+                },
+                {
+                    key: 'activation_key',
+                    namespace: 'satellite',
+                    value: 'testak'
+                },
+                {
+                    key: 'organization_id',
+                    namespace: 'satellite',
+                    value: '1'
+                },
+                {
+                    key: 'lifecycle_environment',
+                    namespace: 'satellite',
+                    value: 'Library'
+                },
+                {
+                    key: 'satellite_instance_id',
+                    namespace: 'satellite',
+                    value: '86a737d0-73d3-5e3a-b43e-b5fa0883ed27'
+                }
+            ],
+            updated: '2021-07-15T05:43:32.183233+00:00',
+            selected: false
+        }
+    ],
+    meta: {
+        total_items: 2
+    }
+};

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -295,7 +295,7 @@ export default defineMessages({
     osFilterPlaceholder: {
         id: 'osFilterPlaceholder',
         description: 'Placeholder for OS version filter',
-        defaultMessage: 'Filter by OS'
+        defaultMessage: 'Filter by operating system'
     },
     remediationFilterLabel: {
         id: 'remediationFilterLabel',


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/VULN-2391.

- [x] /systems page: make OS filter values dynamic
- [x] /vulnerability/cves/{cve_id}: make OS filter values dynamic
- [x] Add tests to SystemsExposedTableToolbar

## How to test:

1. Navigate to https://stage.foo.redhat.com:1337/beta/insights/vulnerability/systems.
2. Verify GET  /system_profile/operating_system is made.
3. Check whether OS filter matches the API response.
4. Check basic filter functions (chips loaded, values selected, table updated, URL search params updated, filters can be removed).
5. Navigate to any of CVEs page.
6. Do the same steps as for the systems list page.

## Screenshots

![image](https://user-images.githubusercontent.com/31385370/189340056-dce64d8c-31b1-4154-998b-7f0c2c9dd6d8.png)
![image](https://user-images.githubusercontent.com/31385370/189339983-d158a78b-4b1f-4c8a-8534-7dff1aefc2ff.png)
