### PR TITLE
fix: Update executive report title

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -124,6 +124,7 @@
   "executiveReport.securityPanelSecerity": "Severity",
   "executiveReport.subheader": "The vulnerability service is analyzing {systems} and has identified {cves} and {rules} that impact 1 or more of these systems.",
   "executiveReport.systems": "{systems, plural, one {# RHEL system} other {# RHEL systems}}",
+  "executiveReport.title": "Vulnerability",
   "executiveReport.top3": "Top 3 vulnerabilities in your infrastructure",
   "executiveReportCardButton": "Download PDF",
   "executiveReportCardDescription": "An executive summary of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.",

--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -70,7 +70,7 @@ const DownloadExecutive = () => {
             {
                 renderPDF && <DownloadButton
                     fallback={<div />}
-                    type={intl.formatMessage(messages.vulnerabilitiesHeader)}
+                    type={intl.formatMessage(messages.executiveReportTitle)}
                     fileName={`vulnerability_executive-report--${date}.pdf`}
                     buttonProps={{ variant: 'link', isInline: true }}
                     groupName="Red Hat Insights"

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -517,6 +517,11 @@ export default defineMessages({
         description: 'Systems PDF report OS filter',
         defaultMessage: '{prefix} with OS of <b>{values}</b>'
     },
+    executiveReportTitle: {
+        id: 'executiveReport.title',
+        description: 'Executive report header title',
+        defaultMessage: 'Vulnerability'
+    },
     executiveReportGenerated: {
         id: 'executiveReport.generated',
         description: 'Executive report generated note',


### PR DESCRIPTION
Update red exec report title from Vulnerabilities to Vulnerability as per https://docs.google.com/document/d/1IQ5BdyZApCYd_oz-RGIILJumrvI9RYMOWmaVA5bbloA page 6.

## Before:
![exec-before](https://user-images.githubusercontent.com/8426204/192658167-10d40794-8d66-406e-87e3-cd78e40392e8.png)


## After:
![exec-after](https://user-images.githubusercontent.com/8426204/192658162-fe4012a9-db71-4bd4-a62b-b61f326daa3b.png)
