### PR TITLE
chore: Pin loader-utils package version to fix a CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "file-loader": "^6.2.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "28.1.1",
+        "loader-utils": "^2.0.3",
         "npm-run-all": "^4.1.5",
         "prop-types": "^15.8.1",
         "qs": "^6.11.0",
@@ -16457,9 +16458,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "devOptional": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -40803,9 +40804,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "devOptional": true,
       "requires": {
         "big.js": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "file-loader": "^6.2.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "28.1.1",
+    "loader-utils": "^2.0.3",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.8.1",
     "qs": "^6.11.0",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/VULN-2434.

CVE is fixed in version 2.0.3 https://github.com/webpack/loader-utils/issues/212