### PR TITLE
chore: Refactor SystemCvesStore

### DIFF
--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -85,8 +85,9 @@ export const SystemCVEs = ({
         ({ SystemCvesStore }) => SystemCvesStore.isAllExpanded
     );
 
-    const cves = useMemo(() =>
-        createCveListBySystem(entity.id, systemCVEs, columns, linkToCustomerPortal), [systemCVEs, entity.id, columns]);
+    const cves = useMemo(() => createCveListBySystem(
+        entity.id, systemCVEs, columns, linkToCustomerPortal
+    ), [systemCVEs, systemCVEs.isLoading, entity.id, columns]);
     const [urlParameters, setUrlParams] = useUrlParams(CVES_ALLOWED_PARAMS);
 
     const downloadReport = format => {

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -121,13 +121,13 @@ export function createCveListByAccount(cveList, columns) {
 }
 
 export function createCveListBySystem(systemId, cveList, columns, linkToCustomerPortal) {
-    let isLoading = cveList && cveList.isLoading;
+    let isLoading = cveList?.isLoading;
 
     if (!isLoading) {
         const {
             payload: { data, meta, errors }
         } = cveList;
-        const cvesCount = data && data.length;
+        const cvesCount = data?.length;
 
         const columnKeys = columns.reduce((acc, curr) => curr.isShown ?? curr.isShownByDefault ? acc.concat(curr.key) : acc, []);
 

--- a/src/Store/Reducers/SystemCvesStore.js
+++ b/src/Store/Reducers/SystemCvesStore.js
@@ -1,6 +1,13 @@
-import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
-import { FETCH_SYSTEM_CVE_LIST } from '../ActionTypes';
+import {
+    CHANGE_COLUMNS_SYSTEM_DETAIL,
+    CHANGE_SYSTEM_CVE_LIST_PARAMETERS,
+    CLEAR_SYSTEM_CVES_STORE,
+    EXPAND_SYSTEM_CVE,
+    FETCH_SYSTEM_CVE_LIST,
+    SELECT_SYSTEM_CVE
+} from '../ActionTypes';
 import { SYSTEM_DETAILS_HEADER } from '../../Helpers/constants';
+import { isTimestampValid } from './reducersHelper';
 
 export const initialState = {
     parameters: {
@@ -21,117 +28,104 @@ export const initialState = {
     columns: SYSTEM_DETAILS_HEADER
 };
 
-function pendingVulnerabilities(state, { meta }) {
-    return {
-        ...state,
-        timestamp: meta,
-        cveList: {
-            ...state.cveList,
-            isLoading: true
-        }
-    };
-}
+export const SystemCvesStore = (state = initialState, action) => {
+    let newState = { ...state };
 
-function rejectedVulnerabilities(state, { meta, payload }) {
-    return {
-        ...state,
-        timestamp: meta,
-        cveList: {
-            payload: { errors: payload },
-            isLoading: false
-        }
-    };
-}
-
-function fulfilledVulnerabilities(state, action) {
     const { payload, meta } = action;
-    if (meta >= state.timestamp) {
-        return {
-            ...state,
-            timestamp: meta,
-            cveList: {
-                payload,
+
+    switch (action.type) {
+        case FETCH_SYSTEM_CVE_LIST + '_PENDING':
+            newState.timestamp = meta;
+            newState.cveList.isLoading = true;
+
+            return newState;
+
+        case FETCH_SYSTEM_CVE_LIST + '_REJECTED':
+            newState.timestamp = meta;
+            newState.cveList = {
+                payload: { errors: payload },
                 isLoading: false
-            },
-            ...state.isAllExpanded && { expandedRows: action.payload.data.map(({ id }) => ({ id, isOpen: true })) }
-        };
-    }
+            };
 
-    return state;
-}
+            return newState;
 
-function selectCve(state, action) {
-    let newState = state;
-    let selectedCves = newState.selectedCves.slice();
+        case FETCH_SYSTEM_CVE_LIST + '_FULFILLED':
+            if (isTimestampValid(state.timestamp, meta)) {
+                newState.timestamp = meta;
+                newState.cveList = {
+                    payload,
+                    isLoading: false
+                };
 
-    if (Array.isArray(action.payload)) {
-        selectedCves = action.payload;
-    } else {
-        const selectedCve = selectedCves.find(cve => cve.id === action.payload.id);
-        if (selectedCve) {
-            selectedCves.splice(selectedCves.indexOf(selectedCve), 1);
-        } else {
-            selectedCves.push(action.payload);
+                if (state.isAllExpanded) {
+                    newState.expandedRows = payload.data.map(({ id }) => ({ id, isOpen: true }));
+                }
+            }
+
+            return newState;
+
+        case CHANGE_SYSTEM_CVE_LIST_PARAMETERS:
+            newState.parameters = { ...state.parameters, ...payload };
+
+            return newState;
+
+        case CHANGE_COLUMNS_SYSTEM_DETAIL:
+            newState.columns = payload;
+            return newState;
+
+        case SELECT_SYSTEM_CVE: {
+            let selectedCves = newState.selectedCves.slice();
+
+            if (Array.isArray(payload)) {
+                selectedCves = payload;
+            } else {
+                const selectedCve = selectedCves.find(cve => cve.id === payload.id);
+
+                if (selectedCve) {
+                    selectedCves.splice(selectedCves.indexOf(selectedCve), 1);
+                } else {
+                    selectedCves.push(payload);
+                }
+            }
+
+            newState.selectedCves = selectedCves;
+
+            return newState;
         }
+
+        case EXPAND_SYSTEM_CVE: {
+            const { isOpen, cves, isAllExpanded } = payload;
+            let expandedRows = newState.expandedRows.slice();
+
+            if (cves.length > 0) {
+                cves.map(cve => {
+                    const index = expandedRows.findIndex(element => element.id === cve);
+                    if (index > -1) { expandedRows[index] = ({ id: cve, isOpen }); }
+                    else { expandedRows.push({ id: cve, isOpen }); }
+                });
+            }
+            else {
+                expandedRows = expandedRows.map(cve => ({ id: cve.id, isOpen: false }));
+            }
+
+            newState.expandedRows = expandedRows;
+            newState.isAllExpanded = isAllExpanded;
+
+            return newState;
+        }
+
+        case CLEAR_SYSTEM_CVES_STORE:
+            newState.selectedCves = [];
+            newState.expandedRows = [];
+            newState.parameters = {
+                page: 1,
+                page_size: 20,
+                show_advisories: true
+            };
+
+            return newState;
+
+        default:
+            return state;
     }
-
-    return {
-        ...newState,
-        selectedCves
-    };
-}
-
-function expandCve(state, action) {
-    let newState = state;
-    const { isOpen, cves, isAllExpanded } = action.payload;
-    let expandedRows = newState.expandedRows.slice();
-
-    if (cves.length > 0) {
-        cves.map(cve => {
-            const index = expandedRows.findIndex(element => element.id === cve);
-            if (index > -1) { expandedRows[index] = ({ id: cve, isOpen }); }
-            else { expandedRows.push({ id: cve, isOpen }); }
-        });
-    }
-    else {
-        expandedRows = expandedRows.map(cve => ({ id: cve.id, isOpen: false }));
-    }
-
-    return { ...newState, expandedRows, isAllExpanded };
-}
-
-function changeParameters(state, action) {
-    let newState = state;
-    newState.parameters = { ...state.parameters, ...action.payload };
-    return newState;
-}
-
-function clearSystemCvesStore(state) {
-    let newState = state;
-    newState.selectedCves = [];
-    newState.expandedRows = [];
-    newState.parameters = {
-        page: 1,
-        page_size: 20,
-        show_advisories: true
-    };
-    return newState;
-}
-
-function changeColumns(state, action) {
-    return {
-        ...state,
-        columns: action.payload
-    };
-}
-
-export const SystemCvesStore = applyReducerHash({
-    [`${FETCH_SYSTEM_CVE_LIST}_PENDING`]: pendingVulnerabilities,
-    [`${FETCH_SYSTEM_CVE_LIST}_REJECTED`]: rejectedVulnerabilities,
-    [`${FETCH_SYSTEM_CVE_LIST}_FULFILLED`]: fulfilledVulnerabilities,
-    ['CHANGE_SYSTEM_CVE_LIST_PARAMETERS']: changeParameters,
-    ['CHANGE_COLUMNS_SYSTEM_DETAIL']: changeColumns,
-    ['SELECT_SYSTEM_CVE']: selectCve,
-    ['EXPAND_SYSTEM_CVE']: expandCve,
-    ['CLEAR_SYSTEM_CVES_STORE']: clearSystemCvesStore
-}, initialState);
+};


### PR DESCRIPTION
## Why:
Vulnerability store reducers are implemented inconsistently, for example this one was using `applyReducerHash` which is a vastly different approach to other stores, which use switch statements.

## What:
I removed `applyReducerHash` and moved contents of individual functions into case blocks of switch statements. Also did some small cleanups for readability. But if you compare previous actions' code to current it should functionally be the same.

## How to test:
There should be no change in functionality. Go to System CVEs (System detail) page and try to perform various table operations and see if everything works as it should. 