### PR TITLE
fix: Systems with partial rule hit can also be affected but not vulnerable

### DIFF
--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -21,10 +21,10 @@ export const createExposedSystemsRows = ({ items: { data, meta }, cveId }) => {
         ...row.attributes,
         patchAccess: meta.patch_access || false,
         status: row.attributes.status_name,
-        children: row.attributes?.rule?.rule?.reason
-            ? <InsightsSystemRule cve={cveId} rule={row.attributes.rule} />
-            : row.attributes.mitigation_reason
-                ? <InsightsNotVulnerable cve={cveId} mitigationReason={row.attributes.mitigation_reason} />
+        children: row.attributes.mitigation_reason
+            ? <InsightsNotVulnerable cve={cveId} mitigationReason={row.attributes.mitigation_reason} />
+            : row.attributes?.rule?.rule?.reason
+                ? <InsightsSystemRule cve={cveId} rule={row.attributes.rule} />
                 : <InsightsNoSystemRule cve={cveId} />
     }));
 

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -560,12 +560,12 @@ export const SYSTEMS_EXPOSED_HEADER = [
         renderFunc: (
             value,
             _id,
-            { mitigation_reason: mitigationReason, rule }) => {
+            { mitigation_reason: mitigationReason }) => {
             return (
                 <span>
                     {value}
-                    {/* "Affected but not vulnerable" is when mitigation reason is set and rule is null */}
-                    {(mitigationReason && !rule?.rule?.reason) && <NotVulnerableLabel isCompact/>}
+                    {/* "Affected but not vulnerable" is when mitigation reason is set */}
+                    {mitigationReason && <NotVulnerableLabel isCompact/>}
                 </span>
             );
         }


### PR DESCRIPTION
Resolves [VULN-2468](https://issues.redhat.com/browse/VULN-2468).

Vulnerability CVE detail page (AKA systems exposed page) for CVEs with security rule distinguishes three kinds of systems. If a CVE has a rule it does mean that all affected systems by that CVE are hit by a rule.

1. vulnerable and not hit
2. vulnerable and hit by a rule -- backend sends `rule.rule.reason` from endpoint
3. affected but not vulnerable -- has a green badge saying "Not vulnerable" -- system is not affected to the CVE because there is some mitigation in place (for example system is affected by Bluetooth CVE, but is not vulnerable, because it has disabled Bluetooth module) -- backend always send `mitigation_reason` from endpoint, that's how they are recognized by the frontend.

## The problem:
Previously affected but not vulnerable system (has `mitigation_reason`) that is hit by a rule (does have `rule.rule.reason`) was showing as vulnerable and and hit. But affected but not vulnerable should have higher priority.

## The fix:
Changed the condition, so `mitigation_reason` has higher priority when deciding how is system going to get displayed.

## How to test:
Find a CVE which has rule and some systems which are both not hit and affected but not vulnerable, for example https://console.stage.redhat.com/beta/insights/vulnerability/cves/CVE-2022-23816?filter=patch&page=1&page_size=20&rule=affected_not_vulnerable&show_advisories=true&sort=-updated

These systems should have green chip with "Not vulnerable".