### PR TITLE
chore: Refactor column management to use hooks

### DIFF
--- a/src/Components/SmartComponents/CVEDetailsPage/__snapshots__/CveDetailsPage.test.js.snap
+++ b/src/Components/SmartComponents/CVEDetailsPage/__snapshots__/CveDetailsPage.test.js.snap
@@ -4,6 +4,7 @@ exports[`CVE details: Should render match snapshot 1`] = `
 <ContextProvider
   value={
     Object {
+      "getServerState": undefined,
       "store": Object {
         "clearActions": [Function],
         "dispatch": [Function],

--- a/src/Components/SmartComponents/CVEDetailsPage/__snapshots__/CveDetailsPage.test.js.snap
+++ b/src/Components/SmartComponents/CVEDetailsPage/__snapshots__/CveDetailsPage.test.js.snap
@@ -4,7 +4,6 @@ exports[`CVE details: Should render match snapshot 1`] = `
 <ContextProvider
   value={
     Object {
-      "getServerState": undefined,
       "store": Object {
         "clearActions": [Function],
         "dispatch": [Function],

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -22,9 +22,8 @@ import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
-import ColumnManagementModal from '../Modals/ColumnManagementModal';
 import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
-import { useRbac } from '../../../Helpers/Hooks';
+import { useColumnManagement, useRbac } from '../../../Helpers/Hooks';
 import { NotAuthorized } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 
 export const CVETableContext = React.createContext({});
@@ -34,8 +33,6 @@ export const CVEs = () => {
     const [CveStatusModal, setStatusModal] = useState(() => () => null);
     const [CveBusinessRiskModal, setBusinessRiskModal] = useState(() => () => null);
     const [isFirstLoad, setFirstLoad] = useState(true);
-
-    const [isColumnModalOpen, setColumnModalOpen] = useState(false);
 
     const [[canEditStatusOrBusinessRisk, canEditPairStatus, canExport, canReadVulnerabilityResults], isRbacLoading] = useRbac([
         PERMISSIONS.setCveStatusAndBusinessRisk,
@@ -62,6 +59,9 @@ export const CVEs = () => {
     const isAllExpanded = useSelector(
         ({ CVEsStore }) => CVEsStore.isAllExpanded
     );
+
+    const [ColumnManagementModal, setColumnManagementModalOpen]
+        = useColumnManagement(columns, newColumns => dispatch(changeColumnsCveList(newColumns)));
 
     const cves = useMemo(() => createCveListByAccount(cveList, columns), [cveList, columns]);
     const [urlParameters, setUrlParam] = useUrlParams(['show_irrelevant', ...CVES_ALLOWED_PARAMS]);
@@ -152,18 +152,14 @@ export const CVEs = () => {
                                 showBusinessRiskModal,
                                 showStatusModal,
                                 openCves,
-                                setColumnModalOpen
+                                setColumnManagementModalOpen
                             }
                         }}
                     >
                         <CveBusinessRiskModal/>
                         <CveStatusModal/>
-                        <ColumnManagementModal
-                            appliedColumns={columns}
-                            applyColumns={newColumns => dispatch(changeColumnsCveList(newColumns))}
-                            isModalOpen={isColumnModalOpen}
-                            setModalOpen={setColumnModalOpen}
-                        />
+
+                        { ColumnManagementModal }
 
                         <Stack>
                             <StackItem>

--- a/src/Components/SmartComponents/CVEs/CVEs.test.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.test.js
@@ -169,7 +169,7 @@ describe('CVEs', () => {
                     apply: expect.any(Function),
                     downloadReport: expect.any(Function),
                     selectCves: expect.any(Function),
-                    setColumnModalOpen: expect.any(Function),
+                    setColumnManagementModalOpen: expect.any(Function),
                     showBusinessRiskModal: expect.any(Function),
                     showStatusModal: expect.any(Function),
                     openCves: expect.any(Function)

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -91,7 +91,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
         ] : [],
         {
             label: intl.formatMessage(messages.columnManagementModalTitle),
-            onClick: () => methods.setColumnModalOpen(true)
+            onClick: () => methods.setColumnManagementModalOpen(true)
         }
     ];
 

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -120,6 +120,7 @@ exports[`CVEs Should render without props 1`] = `
           }
           applyColumns={[Function]}
           isModalOpen={false}
+          key="column-mgmt-modal"
           setModalOpen={[Function]}
         >
           <Modal
@@ -420,7 +421,7 @@ exports[`CVEs Should render without props 1`] = `
                             "downloadReport": [Function],
                             "openCves": [Function],
                             "selectCves": [Function],
-                            "setColumnModalOpen": [Function],
+                            "setColumnManagementModalOpen": [Function],
                             "showBusinessRiskModal": [Function],
                             "showStatusModal": [Function],
                           },
@@ -4004,7 +4005,7 @@ exports[`CVEs Should render without props 1`] = `
                           "downloadReport": [Function],
                           "openCves": [Function],
                           "selectCves": [Function],
-                          "setColumnModalOpen": [Function],
+                          "setColumnManagementModalOpen": [Function],
                           "showBusinessRiskModal": [Function],
                           "showStatusModal": [Function],
                         },

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -65,7 +65,7 @@ const SystemCveToolbarWithContext = ({
         ...canManageColumns ?
             [{
                 label: intl.formatMessage(messages.columnManagementModalTitle),
-                onClick: () => methods.setColumnModalOpen(true)
+                onClick: () => methods.setColumnManagementModalOpen(true)
             }] : []
     ];
 

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -42,7 +42,7 @@ import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
-import ColumnManagementModal from '../Modals/ColumnManagementModal';
+import { useColumnManagement } from '../../../Helpers/Hooks';
 
 export const CVETableContext = createContext({});
 
@@ -64,8 +64,6 @@ export const SystemCVEs = ({
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [isFirstLoad, setFirstLoad] = useState(true);
 
-    const [isColumnModalOpen, setColumnModalOpen] = useState(false);
-
     const systemCVEs = useSelector(
         ({ SystemCvesStore }) => SystemCvesStore.cveList
     );
@@ -85,6 +83,9 @@ export const SystemCVEs = ({
     const isAllExpanded = useSelector(
         ({ SystemCvesStore }) => SystemCvesStore.isAllExpanded
     );
+
+    const [ColumnManagementModal, setColumnManagementModalOpen]
+        = useColumnManagement(columns, newColumns => dispatch(changeColumnsSystemDetail(newColumns)));
 
     const cves = useMemo(() => createCveListBySystem(
         entity.id, systemCVEs, columns, linkToCustomerPortal
@@ -218,18 +219,14 @@ export const SystemCVEs = ({
                         selectCves: handleCveSelect,
                         openCves: handleCveOpen,
                         showStatusModal,
-                        setColumnModalOpen,
+                        setColumnManagementModalOpen,
                         bulkFetchResource: params => fetchCveIdsBySystem({ ...params, system: entity.id })
                     }
                 }}
             >
                 <StatusModal/>
-                <ColumnManagementModal
-                    appliedColumns={columns}
-                    applyColumns={newColumns => dispatch(changeColumnsSystemDetail(newColumns))}
-                    isModalOpen={isColumnModalOpen}
-                    setModalOpen={setColumnModalOpen}
-                />
+
+                { ColumnManagementModal }
 
                 <Stack hasGutter>
                     {showHeaderLabel && (

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -29,9 +29,8 @@ import {
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { SystemsExposedTableToolbar } from './SystemsExposedTableToolbar';
-import { useGetEntities, useRbac } from '../../../Helpers/Hooks';
+import { useColumnManagement, useGetEntities, useRbac } from '../../../Helpers/Hooks';
 import * as APIHelper from '../../../Helpers/APIHelper';
-import ColumnManagementModal from '../Modals/ColumnManagementModal';
 import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 
 const SystemsExposedTable = ({
@@ -48,7 +47,6 @@ const SystemsExposedTable = ({
     const [isAllExpanded, setIsAllExpanded] = useState(false);
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_EXPOSED_ALLOWED_PARAMS);
-    const [isColumnModalOpen, setColumnModalOpen] = useState(false);
 
     const items = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
     const totalItems = useSelector(({ entities }) => entities?.total);
@@ -69,6 +67,9 @@ const SystemsExposedTable = ({
     const apply = (params) => dispatch(changeExposedSystemsParameters(params));
 
     const handleSelect = (payload, selecting) => dispatch(selectRows(payload, selecting));
+
+    const [ColumnManagementModal, setColumnManagementModalOpen]
+        = useColumnManagement(columns, newColumns => dispatch(changeColumnsCveDetail(newColumns)));
 
     useEffect(() => apply(urlParameters), []);
 
@@ -208,18 +209,14 @@ const SystemsExposedTable = ({
                                     apply,
                                     handleSelect,
                                     showStatusModal,
-                                    setColumnModalOpen
+                                    setColumnManagementModalOpen
                                 }}
                                 canEditPairStatus={canEditPairStatus}
                                 canExport={canExport}
                             >
                                 {StatusModal && <StatusModal/>}
-                                <ColumnManagementModal
-                                    appliedColumns={columns}
-                                    applyColumns={newColumns => dispatch(changeColumnsCveDetail(newColumns))}
-                                    isModalOpen={isColumnModalOpen}
-                                    setModalOpen={setColumnModalOpen}
-                                />
+
+                                { ColumnManagementModal }
                             </SystemsExposedTableToolbar>
                         </InventoryTable>}
             </StackItem>

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTableToolbar.js
@@ -36,7 +36,7 @@ export const SystemsExposedTableToolbar = ({
     children
 }) => {
     const intl = useIntl();
-    const { apply, showStatusModal, handleSelect, downloadReport, setColumnModalOpen } = methods;
+    const { apply, showStatusModal, handleSelect, downloadReport, setColumnManagementModalOpen } = methods;
     const { isLoaded, meta } = rawData;
 
     const remediableSystems = selectedRows.filter(system => system.remediation === ANSIBLE_REMEDIATION);
@@ -49,7 +49,7 @@ export const SystemsExposedTableToolbar = ({
         }] : [],
         {
             label: intl.formatMessage(messages.columnManagementModalTitle),
-            onClick: () => setColumnModalOpen(true)
+            onClick: () => setColumnManagementModalOpen(true)
         }
     ];
 
@@ -159,7 +159,7 @@ SystemsExposedTableToolbar.propTypes = {
         handleSelect: propTypes.func,
         showStatusModal: propTypes.func,
         downloadReport: propTypes.func,
-        setColumnModalOpen: propTypes.func
+        setColumnManagementModalOpen: propTypes.func
     }),
     canEditPairStatus: propTypes.bool,
     canExport: propTypes.bool

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -20,10 +20,9 @@ import { useUrlParams } from '../../../Helpers/MiscHelper';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { TableVariant } from '@patternfly/react-table';
-import { useGetEntities, useOptOutSystems, useRbac } from '../../../Helpers/Hooks';
+import { useColumnManagement, useGetEntities, useOptOutSystems, useRbac } from '../../../Helpers/Hooks';
 import * as APIHelper from '../../../Helpers/APIHelper';
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
-import ColumnManagementModal from '../Modals/ColumnManagementModal';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import NoAccessPage from '../../PresentationalComponents/StaticPages/NoAccessPage';
 import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
@@ -66,13 +65,14 @@ const SystemsPage = () => {
     const { hasError, errorCode } = useSelector(({ SystemsPageStore }) => SystemsPageStore.error);
     const columns = useSelector(({ SystemsPageStore }) => SystemsPageStore.columns);
 
-    const [isColumnModalOpen, setColumnModalOpen] = useState(false);
-
     const mergeColumns = inventoryColumns => {
         return columns
             .filter(column => column.isShown ?? column.isShownByDefault)
             .map(column => ({ ...inventoryColumns.find(({ key }) => column.key === key), ...column }));
     };
+
+    const [ColumnManagementModal, setColumnManagementModalOpen]
+        = useColumnManagement(columns, newColumns => dispatch(changeColumnsSystemList(newColumns)));
 
     useEffect(() => {
         return () => {
@@ -105,12 +105,8 @@ const SystemsPage = () => {
     return (
         isLoading ? <Spinner centered/> :
             canReadVulnerabilityResults ? <Fragment>
-                <ColumnManagementModal
-                    appliedColumns={columns}
-                    applyColumns={newColumns => dispatch(changeColumnsSystemList(newColumns))}
-                    isModalOpen={isColumnModalOpen}
-                    setModalOpen={setColumnModalOpen}
-                />
+                { ColumnManagementModal }
+
                 <Header title={intl.formatMessage(messages.vulnerabilitySystemsHeader)} showBreadcrumb={false}/>
                 <Main>
                     {isLoadingInventory ? <Spinner centered/> :
@@ -173,7 +169,7 @@ const SystemsPage = () => {
                                             doOptOut,
                                             apply,
                                             handleSelect,
-                                            setColumnModalOpen
+                                            setColumnManagementModalOpen
                                         }}
                                         actions
                                     />

--- a/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsTableToolbar.js
@@ -32,7 +32,7 @@ const SystemsTableToolbar = ({
     methods
 }) => {
     const [exportPDF, setExportPDF] = useState(false);
-    const { apply, handleSelect, doOptOut, setColumnModalOpen } = methods;
+    const { apply, handleSelect, doOptOut, setColumnManagementModalOpen } = methods;
     const dispatch = useDispatch();
 
     const downloadReport = format => {
@@ -70,7 +70,7 @@ const SystemsTableToolbar = ({
         }] : [],
         {
             label: intl.formatMessage(messages.columnManagementModalTitle),
-            onClick: () => setColumnModalOpen(true)
+            onClick: () => setColumnManagementModalOpen(true)
         }
     ];
 
@@ -152,7 +152,7 @@ SystemsTableToolbar.propTypes = {
         doOptOut: propTypes.func,
         apply: propTypes.func,
         handleSelect: propTypes.func,
-        setColumnModalOpen: propTypes.func
+        setColumnManagementModalOpen: propTypes.func
     }),
     intl: propTypes.any
 };

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import {
@@ -10,6 +10,7 @@ import messages from '../Messages';
 import { NotAuthorizedNotification, ReadOnlyNotification } from './constants';
 import { useState } from 'react';
 import unionBy from 'lodash/unionBy';
+import ColumnManagementModal from '../Components/SmartComponents/Modals/ColumnManagementModal';
 
 export const useNotification = (config) => {
     const dispatch = useDispatch();
@@ -224,4 +225,17 @@ export const useRbac = (requestedPermissions, app = 'vulnerability') => {
 
     return [requestedPermissions.map(requestedPermission =>
         allPermissions?.some(item => matchPermissions(item.permission, requestedPermission))), false];
+};
+
+export const useColumnManagement = (columns, onApply) => {
+    const [isModalOpen, setModalOpen] = useState(false);
+
+    return [(
+        <ColumnManagementModal
+            appliedColumns={columns}
+            applyColumns={newColumns => onApply(newColumns)}
+            isModalOpen={isModalOpen}
+            setModalOpen={setModalOpen}
+            key="column-mgmt-modal"
+        />), setModalOpen];
 };


### PR DESCRIPTION
Resolves [VULN-1406](https://issues.redhat.com/browse/VULN-1406).

There should be no change in functionality. Isolated all column mgmt functionality into a hook. This will make it much easier to:
1. edit column mgmt functionality in all pages at once
2. add column mgmt to a new table if we ever create one
3. port column mgmt to another app

### How to test:
Try to change columns from column management modal in all four tables.