### PR TITLE
fix: Fix global filter not applying and resetting correctly

### DIFF
--- a/src/Store/Reducers/reducersHelper.js
+++ b/src/Store/Reducers/reducersHelper.js
@@ -8,21 +8,23 @@ const hasResetFilters = (
     workloads,
     SIDs,
     tags
-) => (workloads === undefined || workloads?.SAP === undefined) && SIDs.length === 0 && tags.length === 0;
+) => (workloads === undefined || Object.keys(workloads).length === 0) && SIDs.length === 0 && tags.length === 0;
 
-const hasSetAnyFilter = (state) => ['sap_system', 'tags', 'sap_sids'].some(key => state.hasOwnProperty(key));
+const hasSetAnyFilter = (state) => ['sap_system', 'ansible', 'mssql', 'tags', 'sap_sids'].some(key => state.hasOwnProperty(key));
 
 export const applyGlobalFilter = (state, { workloads, SIDs, tags }) => {
-    // DO nothing in first load
+    // do nothing on first load
     if (!hasSetAnyFilter(state) && hasResetFilters(workloads, SIDs, tags)) {
         return state;
     }
 
+    // reset filters
     if (hasSetAnyFilter(state) && hasResetFilters(workloads, SIDs, tags)) {
-        // reset the filters
         state = {
             ...state,
             sap_system: undefined,
+            ansible: undefined,
+            mssql: undefined,
             tags: undefined,
             sap_sids: undefined,
             page: 1


### PR DESCRIPTION
Bug 1: Previously applying the AAP or MSSQL workload in global filter might not trigger a rerefresh of table data.
Bug 2: Previously resetting global filter configuration with "Clear filters" button might not clear AAP nor MSSQL workload.

Both bugs have been fixed.

### How to test:
Verify that selecting, deselecting and resetting workloads in global filter has the correct effect on the table.