### PR TITLE
fix: Fix crash when navigating back from CVE detail to CVE list page

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,6 +39,7 @@ rules:
   require-atomic-updates: 0
   array-bracket-spacing: 2
   jsx-quotes: [2, 'prefer-double']
+  react-hooks/exhaustive-deps: 0
   react/jsx-curly-brace-presence: 2
   react/boolean-prop-naming: 2
   react/no-children-prop: 2

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -73,7 +73,7 @@ const SystemsExposedTable = ({
 
     useEffect(() => apply(urlParameters), []);
 
-    useEffect(() => setUrlParams({ ...parameters, ...meta }), [setUrlParams, parameters, meta]);
+    useEffect(() => setUrlParams({ ...parameters, ...meta }), [parameters, meta]);
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
Fixes [VULN-2525](https://issues.redhat.com/browse/VULN-2525).

## Description of problem

> When a cve details page is selected example(https://console.stage.redhat.com/beta/insights/vulnerability/cves/CVE-2023-22809?page=1&page_size=20&show_advisories=true&sort=-updated) the default filter of sort=-updated is applied. 

> If a user attempts to go back to the CVE list page this filter is also applied (https://console.stage.redhat.com/beta/insights/vulnerability/cves?affecting=true&page=1&page_size=20&show_advisories=true&sort=-updated) which causes an error

## How to test:
1. Go to CVE list page (landing page)
2. Click on any CVE
3. Go back to the previous page using browser history
4. CVE list page should be displayed correctly
5. Repeat this multiple times as this bug did not happen everytime

## Why this change fixes the issue:
`setUrlParams` function was in the dependency array of `useEffect` (because otherwise linter would put out warnings (`react-hooks/exhaustive-deps` rule)). As the `setUrlParams` function was not memoized and `useEffect` was firing unnecessary. This firing was also (sometimes) trigged on page unmount and modified the URL as it was unmounted and caused this crash. I also removed the lint rule as it caused more harm then good.