### PR TITLE
chore: Remove unnecessary global filter refreshing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,6 +45,11 @@ const App = () => {
             }
         });
 
+        chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
+            const [workloads, SIDs, tags] = chrome.mapGlobalFilter(data, true, true) ?? [null, null, null];
+            dispatch(setGlobalFilter({ workloads, SIDs, tags }));
+        });
+
         return () => unregister();
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -56,13 +61,6 @@ const App = () => {
             baseComponentUrl &&
             appNavClick[baseComponentUrl] !== undefined &&
             appNavClick[baseComponentUrl](false);
-
-        const unregister = chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {
-            const [workloads, SIDs, tags] = chrome.mapGlobalFilter(data, true, true) ?? [null, null, null];
-            dispatch(setGlobalFilter({ workloads, SIDs, tags }));
-        });
-
-        return () => unregister();
     }, [appNavClick, pathname, dispatch]);
 
     window.setReadOnlyBannerVisible = setVisible => setReadOnlyBannerVisible(setVisible);


### PR DESCRIPTION
There should be no change in functionality.

Previously the global filter Redux action listener was executed every time `pathname` was changed. This was unnecessary as the listener needs to only be called once on page load.