### PR TITLE
perf(RHIF-170): remove AppInfo usage together with activeApps in redux

### DIFF
--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
@@ -36,7 +36,7 @@ const SystemDetails = ({ optOutSystemHandler }) => {
             } else {
                 return <NotAuthorized title={intl.formatMessage(messages.notAuthorizedNoAccessForSystem)} />;
             }
-        } else {
+        } else if (entity) {
             return <ConnectedSystemCves
                 entity={{ id: entity?.id, display_name: entity?.display_name }}
                 showHeaderLabel
@@ -44,6 +44,8 @@ const SystemDetails = ({ optOutSystemHandler }) => {
                 canExport={canExport}
                 canEditPairStatus={canEditPairStatus}
             />;
+        } else {
+            return loaded ? null : <Spinner centered />;
         }
     } else {
         return <NotAuthorized />;

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { fetchSystemDetails, optOutSystemsAction } from '../../../Store/Actions/Actions';
-import { systemDetailsPageStore } from '../../../Store/Reducers/SystemDetailsPageStore';
+import SystemDetails from './SystemDetails';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
 import Header from '../../PresentationalComponents/Header/Header';
 import { useIntl } from 'react-intl';
@@ -16,8 +16,9 @@ import {
 } from '../../../Helpers/constants';
 import messages from '../../../Messages';
 
-import { AppInfo, DetailWrapper, InventoryDetailHead } from '@redhat-cloud-services/frontend-components/Inventory';
+import { DetailWrapper, InventoryDetailHead } from '@redhat-cloud-services/frontend-components/Inventory';
 import { useRbac } from '../../../Helpers/Hooks';
+import { systemDetailsPageStore } from '../../../Store/Reducers/SystemDetailsPageStore';
 
 const InventoryDetail = () => {
     const dispatch = useDispatch();
@@ -110,7 +111,7 @@ const InventoryDetail = () => {
                                 ReducerRegistry.register({
                                     ...mergeWithEntities(),
                                     ...mergeWithDetail(systemDetailsPageStore(
-                                        INVENTORY_ACTION_TYPES, handleOptOutSystem
+                                        INVENTORY_ACTION_TYPES
                                     ))
                                 });
                             }}
@@ -133,7 +134,7 @@ const InventoryDetail = () => {
                 </Header>
             </section>
             <Main>
-                <AppInfo optOutSystemHandler={handleOptOutSystem} />
+                <SystemDetails optOutSystemHandler={handleOptOutSystem} />
             </Main>
         </DetailWrapper>
     );

--- a/src/Store/Reducers/SystemDetailsPageStore.js
+++ b/src/Store/Reducers/SystemDetailsPageStore.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import SystemDetails from '../../Components/SmartComponents/SystemDetailsPage/SystemDetails';
 import { FETCH_SYSTEM_DETAILS } from '../ActionTypes';
 
 export const initialState = {
@@ -7,7 +5,7 @@ export const initialState = {
 };
 
 export const systemDetailsPageStore = (
-    INVENTORY_ACTION_TYPES, optOutSystemHandler
+    INVENTORY_ACTION_TYPES
 ) => (state = initialState, action) => {
     switch (action.type) {
         case FETCH_SYSTEM_DETAILS + '_FULFILLED':
@@ -18,28 +16,12 @@ export const systemDetailsPageStore = (
         case INVENTORY_ACTION_TYPES.LOAD_ENTITY_FULFILLED:
             return {
                 ...state,
-                loaded: true,
-                activeApps: [
-                    {
-                        title: 'Vulnerabilities',
-                        name: 'vulnerabilities',
-                        component: () => <SystemDetails
-                            optOutSystemHandler={optOutSystemHandler}
-                        />
-                    }
-                ]
+                loaded: true
             };
         case INVENTORY_ACTION_TYPES.LOAD_ENTITY_REJECTED:
             return {
                 ...state,
-                loaded: true,
-                activeApps: [
-                    {
-                        title: 'Vulnerabilities',
-                        name: 'vulnerabilities',
-                        component: () => <SystemDetails />
-                    }
-                ]
+                loaded: true
             };
         default:
             return state;

--- a/src/Store/Reducers/SystemDetailsPageStore.test.js
+++ b/src/Store/Reducers/SystemDetailsPageStore.test.js
@@ -50,14 +50,7 @@ describe('inventoryEntitiesReducer', () => {
         const reducer = wrappingFn({ ...initialState, loaded: true }, action);
         expect(reducer).toEqual({
             ...initialState,
-            loaded: true,
-            activeApps: [
-                {
-                    title: 'Vulnerabilities',
-                    name: 'vulnerabilities',
-                    component: expect.anything()
-                }
-            ]
+            loaded: true
         });
     });
 
@@ -67,14 +60,7 @@ describe('inventoryEntitiesReducer', () => {
         const reducer = wrappingFn({ ...initialState, loaded: false }, action);
         expect(reducer).toEqual({
             ...initialState,
-            loaded: true,
-            activeApps: [
-                {
-                    title: 'Vulnerabilities',
-                    name: 'vulnerabilities',
-                    component: expect.anything()
-                }
-            ]
+            loaded: true
         });
     });
 });


### PR DESCRIPTION
Resolves: [RHIF-170](https://issues.redhat.com/browse/RHIF-170)

This PR removes AppInfo federated module usage together with rendering `SystemDetail` component using activeApps in redux. Thus, making the application's complexity and performance. 

How to test:
Basic functionality should not change. Observer that the system details page works as expected. 