### PR TITLE
update docs urls

### DIFF
--- a/src/Components/SmartComponents/LandingPage/LandingPage.js
+++ b/src/Components/SmartComponents/LandingPage/LandingPage.js
@@ -1,7 +1,10 @@
 import React, { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Popover } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import {
+  OutlinedQuestionCircleIcon,
+  ExternalLinkAltIcon,
+} from '@patternfly/react-icons';
 import messages from '../../../Messages';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import Header from '../../PresentationalComponents/Header/Header';
@@ -9,39 +12,42 @@ import CVEs from '../CVEs/CVEs';
 import Dashbar from '../Dashbar/Dashbar';
 
 const LandingPage = () => {
-    // eslint-disable-next-line max-len
-    const PRODUCT_DOC = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/assessing_and_monitoring_security_vulnerabilities_on_rhel_systems/index';
+  // eslint-disable-next-line max-len
+  const PRODUCT_DOC =
+    'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_monitoring_security_vulnerabilities_on_rhel_systems/index';
 
-    const title = (
-        <Popover
-            enableFlip
-            position="right"
-            headerContent={<FormattedMessage {...messages.ovalPopoverHeader} />}
-            bodyContent={<FormattedMessage {...messages.ovalPopoverBody} />}
-            footerContent={<a href={PRODUCT_DOC} target="__blank" rel="noopener noreferrer">
-                <FormattedMessage {...messages.learnMore} /> <ExternalLinkAltIcon />
-            </a>}
-        >
-            <span>
-                <FormattedMessage {...messages.cvesHeader} />
-                <OutlinedQuestionCircleIcon
-                    color="var(--pf-global--secondary-color--100)"
-                    className="pf-u-ml-sm pointer cves-header-questionmark"
-                    style={{ verticalAlign: '0' }}
-                />
-            </span>
-        </Popover>
-    );
+  const title = (
+    <Popover
+      enableFlip
+      position="right"
+      headerContent={<FormattedMessage {...messages.ovalPopoverHeader} />}
+      bodyContent={<FormattedMessage {...messages.ovalPopoverBody} />}
+      footerContent={
+        <a href={PRODUCT_DOC} target="__blank" rel="noopener noreferrer">
+          <FormattedMessage {...messages.learnMore} /> <ExternalLinkAltIcon />
+        </a>
+      }
+    >
+      <span>
+        <FormattedMessage {...messages.cvesHeader} />
+        <OutlinedQuestionCircleIcon
+          color="var(--pf-global--secondary-color--100)"
+          className="pf-u-ml-sm pointer cves-header-questionmark"
+          style={{ verticalAlign: '0' }}
+        />
+      </span>
+    </Popover>
+  );
 
-    return (
-        <Fragment>
-            <Header title={title} showBreadcrumb={false} />
-            <Dashbar />
-            <Main>
-                <CVEs />
-            </Main>
-        </Fragment>
-    );
+  return (
+    <Fragment>
+      <Header title={title} showBreadcrumb={false} />
+      <Dashbar />
+      <Main>
+        <CVEs />
+      </Main>
+    </Fragment>
+  );
 };
 
 export default LandingPage;


### PR DESCRIPTION
Where links to Insights, Console, Cost & Subscriptions docs exist, this PR updates the url to the 2023 version

Prettier seems to have messed with empty lines as well, if I need to recreate let me know.

