### PR TITLE
chore: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "leSamo"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps):"
+    allow:
+      - dependency-name: "@redhat-cloud-services/frontend*"
+      - dependency-name: "@patternfly/*"
+        dependency-type: direct
+    ignore:
+      - dependency-name: "react-router-dom"
+        versions: ["6.x"]


### PR DESCRIPTION
This aligns the dependabot configuration to be consistent with Inventory, OCP Advisor, etc. Also it limits the scope of dependabot PRs to the FEC and PF modules only.
