### PR TITLE
refactor: Remove patch_access and show_advisories parameters

### DIFF
--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -12,11 +12,6 @@ import messages from '../../../Messages';
 const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
     const { cves, methods, selectedCves, expandedRows, canEditPairStatus } = context;
 
-    // TODO Material for refatoring when we'll introduce "manage column"
-    if (!cves?.meta?.patch_access) {
-        header = header.filter(item => item.key !== 'advisory');
-    }
-
     const noCves = () => {
         return ([{
             heightAuto: true,

--- a/src/Components/SmartComponents/SystemCves/SystemCves.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.test.js
@@ -33,8 +33,7 @@ let state = {
         isLoading: false,
         payload: {
             meta: {
-                test: 'test',
-                patch_access: true
+                test: 'test'
             },
             data: [
                 {

--- a/src/Components/SmartComponents/SystemCves/SystemCvesTable.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCvesTable.test.js
@@ -23,8 +23,7 @@ const mockContext = {
         payload: {
             isLoading: false,
             meta: {
-                test: 'test',
-                patch_access: true
+                test: 'test'
             },
             data: [
                 {
@@ -108,12 +107,6 @@ describe('SystemCvesTable', () => {
         const testContext = { ...mockContext, cves: { isLoading: false, meta: {}, data: [] } };
         const wrapper = mountComponent(testContext);
         expect(wrapper.find('.pf-c-empty-state')).toHaveLength(1);
-    });
-
-    it('Should render without advisory column', () => {
-        const testContext = { ...mockContext, cves: { isLoading: false, meta: { patch_access: false }, data: [] } };
-        const wrapper = mountComponent(testContext);
-        expect(wrapper.find('HeaderCell [data-label="Advisory"]')).toHaveLength(0)
     });
 
     it('Should render advisory column', () => {

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -226,7 +226,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
           "isLoading": undefined,
           "meta": {
             "cvesCount": 1,
-            "patch_access": true,
             "test": "test",
           },
         },
@@ -9511,7 +9510,6 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
       meta={
         {
           "cvesCount": 1,
-          "patch_access": true,
           "test": "test",
         }
       }

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -150,6 +150,13 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                         },
                         {
                           "title": <span>
+                            <AdvisoryColumn
+                              cve="CVE-2019-6454"
+                            />
+                          </span>,
+                        },
+                        {
+                          "title": <span>
                             Not defined
                           </span>,
                         },

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -183,7 +183,6 @@ export function getCveListBySystem(apiProps) {
         ...cveBySystemParams,
         'report'
     ];
-    apiProps.show_advisories = true;
 
     if (apiProps && system) {
         Object.keys(apiProps).forEach(key => (apiProps[key] === undefined || apiProps[key] === '') && delete apiProps[key]);

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -15,11 +15,10 @@ import messages from '../Messages';
  * @param {Array} cveId CVE id
  *
  */
-export const createExposedSystemsRows = ({ items: { data, meta }, cveId }) => {
+export const createExposedSystemsRows = ({ items: { data }, cveId }) => {
     return data?.map(row => ({
         id: row.id,
         ...row.attributes,
-        patchAccess: meta.patch_access || false,
         status: row.attributes.status_name,
         children: row.attributes.mitigation_reason
             ? <InsightsNotVulnerable cve={cveId} mitigationReason={row.attributes.mitigation_reason} />

--- a/src/Helpers/CVEHelper.test.js
+++ b/src/Helpers/CVEHelper.test.js
@@ -62,20 +62,6 @@ const cves_payload = Immutable({
 });
 
 describe('CVEHelper', () => {
-    it('createExposedSystemsRows without patch access', () => {
-        const cveId = 'CVE-2016-0800';
-        const items = { data: affected_payload.data, meta: affected_payload.meta }
-        const page = createExposedSystemsRows({ cveId, items });
-        expect(page.patchAccess).toBeFalsy();
-    });
-
-    it('createExposedSystemsRows with patch access', () => {
-        const cveId = 'CVE-2016-0800';
-        const items = { data: affected_payload.data, meta: { ...affected_payload.meta, patch_access: true } }
-        const page = createExposedSystemsRows({ cveId, items });
-        expect(page[1].patchAccess).toBeTruthy();
-    });
-
     it('createCveDetailsPage', () => {
         const page = createCveDetailsPage(cves_payload);
         expect(page.meta.testObject).toEqual('testObject');

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -221,15 +221,6 @@ export function createCveListBySystem(systemId, cveList, columns, linkToCustomer
                 }
             ]);
 
-        if (!meta?.patch_access) {
-            rows = rows?.map(row => {
-                return {
-                    ...row,
-                    cells: row.cells.filter(cell => cell?.title?.key !== 'advisory')
-                };
-            });
-        }
-
         return {
             data: rows,
             meta: { ...meta, cvesCount },

--- a/src/Helpers/VulnerabilityHelper.test.js
+++ b/src/Helpers/VulnerabilityHelper.test.js
@@ -245,8 +245,7 @@ describe('VulnerabilitiesHelper', () => {
             isLoading: false,
             payload: {
                 meta: {
-                    test: 'test',
-                    patch_access: true
+                    test: 'test'
                 },
                 data: [
                     {
@@ -280,47 +279,6 @@ describe('VulnerabilitiesHelper', () => {
         const result = createCveListBySystem(null, cveList, SYSTEM_DETAILS_HEADER);
         const cell = result.data[0].cells.filter(cell => cell.title.key === 'advisory');
         expect(cell).toHaveLength(1);
-    });
-    it('Should render cves rows by system without advisory column', () => {
-        const cveList = {
-            isLoading: false,
-            payload: {
-                meta: {
-                    test: 'test',
-                    patch_access: false
-                },
-                data: [
-                    {
-                        type: 'cve',
-                        id: 'CVE-2019-6454',
-                        attributes: {
-                            business_risk: "Not Defined",
-                            business_risk_id: 0,
-                            business_risk_text: null,
-                            cve_status_id: 2,
-                            cve_status_text: "testhello",
-                            cvss2_score: null,
-                            cvss3_score: "6.500",
-                            description: "A new domain bypass",
-                            impact: "Moderate",
-                            public_date: "2020-06-09T17:00:00+00:00",
-                            reporter: 1,
-                            rule: null,
-                            status: "On-Hold",
-                            status_id: 2,
-                            status_text: "testhello",
-                            synopsis: "CVE-2020-0543",
-                            rule: 'testRule',
-                            known_exploit: false
-                        }
-                    }
-                ]
-            }
-        };
-
-        const result = createCveListBySystem(null, cveList, SYSTEM_DETAILS_HEADER);
-        const cell = result.data[0].cells.filter(cell => cell.title.key === 'advisory');
-        expect(cell).toHaveLength(0);
     });
 
     it('VulnerabilitiesHelper createCveListBySystem - loading', () => {

--- a/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
+++ b/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
@@ -311,6 +311,13 @@ exports[`VulnerabilitiesHelper test function createCveListBySystem() with cveLis
         },
         {
           "title": <span>
+            <AdvisoryColumn
+              cve="CVE-2019-6116"
+            />
+          </span>,
+        },
+        {
+          "title": <span>
             Not defined
           </span>,
         },

--- a/src/Store/Reducers/CVEDetailsPageStore.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.js
@@ -9,8 +9,7 @@ export const initialState = Immutable({
         page_size: 20,
         selectedHosts: [],
         status_id: undefined,
-        sort: '-updated',
-        show_advisories: true
+        sort: '-updated'
     },
     cveDetails: {
         isLoading: true,

--- a/src/Store/Reducers/InventoryEntitiesReducer.js
+++ b/src/Store/Reducers/InventoryEntitiesReducer.js
@@ -20,8 +20,6 @@ export const initialState = {
 };
 
 function modifyInventory(columns, state, action) {
-    let advisory = columns.find(({ key }) => key === 'advisory');
-
     if (!state.selectedRows) {
         state.selectedRows = [];
     }
@@ -34,12 +32,6 @@ function modifyInventory(columns, state, action) {
     }
 
     if (state.loaded) {
-        let hasPatchAccess = state.rows.some(({ patchAccess }) => patchAccess);
-
-        if (!hasPatchAccess && advisory) {
-            advisory.isShown = false;
-        }
-
         return {
             ...state,
             columns,

--- a/src/Store/Reducers/SystemCvesStore.js
+++ b/src/Store/Reducers/SystemCvesStore.js
@@ -13,7 +13,6 @@ export const initialState = {
     parameters: {
         page: 1,
         page_size: 20,
-        show_advisories: true,
         sort: '-public_date'
     },
     cveList: {
@@ -119,8 +118,7 @@ export const SystemCvesStore = (state = initialState, action) => {
             newState.expandedRows = [];
             newState.parameters = {
                 page: 1,
-                page_size: 20,
-                show_advisories: true
+                page_size: 20
             };
 
             return newState;

--- a/src/Store/Reducers/SystemCvesStore.test.js
+++ b/src/Store/Reducers/SystemCvesStore.test.js
@@ -70,8 +70,7 @@ describe('System Cves Store: ', () => {
                 expandedRows: [],
                 parameters: {
                     page: 1,
-                    page_size: 20,
-                    show_advisories: true
+                    page_size: 20
                 }
             })
         );


### PR DESCRIPTION
[VULN-2534](https://issues.redhat.com/browse/VULN-2534)

patch_access is a parameter previously used to indicate whether user had permission to access Patchman advisory information, but advisories information is not available from vulnerability engine therefore user does not need Patchman access to receive the information, so the parameter is currently always returned as true and is redundant.

show_advisories is a similar parameter that has been made obsolete by storing advisory information in Vuln engine. Also this parameter is ignored by the backend either way.
