### PR TITLE
fix(REMEDY-300): correctly fetch resolutions

### DIFF
--- a/src/Components/SmartComponents/Remediation/Remediation.js
+++ b/src/Components/SmartComponents/Remediation/Remediation.js
@@ -18,6 +18,7 @@ const Remediation = ({ cves, systems, manyRules, isDisabled }) => {
         systems: [system]
     });
 
+    /*eslint-disable camelcase*/
     const remediationProvider = (cvesProvider = [], systemsProvider = [], manyRules = false) => {
         let cves = [].concat(cvesProvider);
         let systems = [].concat(systemsProvider);
@@ -43,11 +44,13 @@ const Remediation = ({ cves, systems, manyRules, isDisabled }) => {
         if (!manyRules && systems?.length === 1) {
             const [systemID] = systems;
 
-            issues = cves.reduce((acc, { id: cveID, rule }) => {
+            issues = cves.reduce((acc, { id: cveID, rule, rule_id }) => {
                 let issue = baseIssueTemplate(cveID, systemID);
 
                 if (rule?.rule_id) {
                     issue.id = `${issue.id}:${rule.rule_id}`;
+                } else if (rule_id) {
+                    issue.id = `${issue.id}:${rule_id}`;
                 }
 
                 return [...acc, issue];
@@ -56,6 +59,7 @@ const Remediation = ({ cves, systems, manyRules, isDisabled }) => {
 
         return cves.length && systems.length ? { issues } : false;
     };
+    /*eslint-enable camelcase*/
 
     return (
         <AsyncComponent

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -162,7 +162,6 @@ export const useBulkSelect = ({ rawData, selectedRows, selectedRowsCount, handle
     };
 
     const handleSelectAll = async () => {
-
         let { payload } = await fetchResource({ page_size: meta.totalItems, page: 1 });
 
         payload.then(({ data }) => handleSelect(data.map(mapSelectedRows)), true);


### PR DESCRIPTION
In stage, go to Inventory -> Systems and choose a system that has CVEs with multiple resolutions (If logged into qa account, try the following system: rhiqe.fca4cbab-d008-4fbf-ba39-391754625f22.iqe-insights-client-plugin). Next, select the Vulnerability tab.

From there, I like to add filters to include systems with "Has security rule" and "Has a known exploit". This usually gives you a few CVEs that will get you multiple resolutions.

Now, try selecting multiple CVEs one-by-one and click the Remediate button. Now, check the "Network" tab in developer tools and check for the resolutions call. You should notice in the "Payload" tab that the issues are structured like so: `"vulnerabilities:CVE-2022-0847:CVE_2022_0847_kernel|CVE_2022_0847_KERNEL"`

If you now redo the actions above, but select multiple CVEs via the bulk select options, and then click the Remediate button, you'll notice the same resolutions call structure the issues like so: `"vulnerabilities:CVE-2022-0847"`

The first option should be the correct one. And this PR structures it correctly. Nothing else should be different in this PR.