### PR TITLE
feat: Add anchor links to Security rule summary links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "query-string": "^7.1.3",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-router-hash-link": "^2.4.3",
         "sanitize-html": "^2.10.0",
         "seamless-immutable": "^7.1.4",
         "semver": "^7.3.7"
@@ -21776,6 +21777,18 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=15",
+        "react-router-dom": ">=4"
+      }
+    },
     "node_modules/react-router/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -42888,6 +42901,14 @@
         "react-router": "5.2.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-shallow-renderer": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "query-string": "^7.1.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-router-hash-link": "^2.4.3",
     "sanitize-html": "^2.10.0",
     "seamless-immutable": "^7.1.4",
     "semver": "^7.3.7"

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -16,7 +16,6 @@ import {
     ExpandableSection
 } from '@patternfly/react-core';
 import { useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import {
     CheckCircleIcon,
@@ -37,6 +36,7 @@ import {
 import CSAwLabel from '../Snippets/CSAwLabel';
 import CSAwRuleSummary from './CSAwRuleSummary';
 import './CSAwRuleBox.scss';
+import { HashLink } from 'react-router-hash-link';
 
 const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) => {
     const dispatch = useDispatch();
@@ -72,9 +72,10 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                             }}
                                             component={TextVariants.small}
                                         >
-                                            <Link
+                                            <HashLink
+                                                smooth
                                                 key={rule.rule_id}
-                                                to={`/cves/${synopsis}/?rule=${rule.rule_id}`}
+                                                to={`/cves/${synopsis}/?rule=${rule.rule_id}#systems-exposed-table-header`}
                                             >
                                                 {
                                                     intl.formatMessage(
@@ -84,7 +85,7 @@ const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) 
                                                         }
                                                     )
                                                 }
-                                            </Link>
+                                            </HashLink>
                                         </Text>
                                     </TextContent>}
                             </SplitItem>

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -180,11 +180,12 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           id="filter-affected-systems"
                           onClick={[Function]}
                         >
-                          <Link
-                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                          <HashLink
+                            smooth={true}
+                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                           >
                             Filter by affected systems
-                          </Link>
+                          </HashLink>
                         </Text>
                       </TextContent>
                     </SplitItem>
@@ -426,22 +427,29 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       id="filter-affected-systems"
                                       onClick={[Function]}
                                     >
-                                      <Link
+                                      <HashLink
                                         key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                        smooth={true}
+                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                       >
-                                        <LinkAnchor
-                                          href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                          navigate={[Function]}
+                                        <Link
+                                          onClick={[Function]}
+                                          to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                         >
-                                          <a
-                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          <LinkAnchor
+                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                            navigate={[Function]}
                                             onClick={[Function]}
                                           >
-                                            Filter by affected systems
-                                          </a>
-                                        </LinkAnchor>
-                                      </Link>
+                                            <a
+                                              href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                              onClick={[Function]}
+                                            >
+                                              Filter by affected systems
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
+                                      </HashLink>
                                     </small>
                                   </Text>
                                 </div>
@@ -1412,11 +1420,12 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           id="filter-affected-systems"
                           onClick={[Function]}
                         >
-                          <Link
-                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                          <HashLink
+                            smooth={true}
+                            to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                           >
                             Filter by affected systems
-                          </Link>
+                          </HashLink>
                         </Text>
                       </TextContent>
                     </SplitItem>
@@ -1658,22 +1667,29 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                       id="filter-affected-systems"
                                       onClick={[Function]}
                                     >
-                                      <Link
+                                      <HashLink
                                         key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                        smooth={true}
+                                        to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                       >
-                                        <LinkAnchor
-                                          href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                          navigate={[Function]}
+                                        <Link
+                                          onClick={[Function]}
+                                          to="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                         >
-                                          <a
-                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          <LinkAnchor
+                                            href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                            navigate={[Function]}
                                             onClick={[Function]}
                                           >
-                                            Filter by affected systems
-                                          </a>
-                                        </LinkAnchor>
-                                      </Link>
+                                            <a
+                                              href="/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                              onClick={[Function]}
+                                            >
+                                              Filter by affected systems
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
+                                      </HashLink>
                                     </small>
                                   </Text>
                                 </div>

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -135,7 +135,7 @@ const SystemsExposedTable = ({
         <Stack hasGutter>
             <StackItem>
                 <TextContent>
-                    <Text component={TextVariants.h2}>
+                    <Text component={TextVariants.h2} id="systems-exposed-table-header">
                         {intl.formatMessage(messages.affectsSystems)}
                     </Text>
                 </TextContent>


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/VULN-2419

1. open CVE detail page of a CVE with Security rule
2. click the "Filter by X systems" link inside any security rule breakdown box
3. your page should automatically scroll down to the table