### PR TITLE
Fix System-CVE pair status not being set correctly

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -119,15 +119,15 @@ export const CvePairStatusModal = ({ cveList, updateRef, inventoryList, intl, ty
             case 'systemDetail': {
                 if (isOverallChecked) {
                     const sameOverallAsEachOther = cveList.every((item, _, arr) =>
-                        item.cve_justification === arr[0]?.cve_justification);
+                        item.cve_status_text === arr[0]?.cve_status_text);
 
-                    return sameOverallAsEachOther ? cveList[0]?.cve_justification || '' : '';
+                    return sameOverallAsEachOther ? cveList[0]?.cve_status_text || '' : '';
                 }
                 else {
                     const sameAsEachOther = cveList.every((item, _, arr) =>
-                        item.justification === arr[0]?.justification);
+                        item.status_text === arr[0]?.status_text);
 
-                    return sameAsEachOther ? cveList[0]?.justification || '' : '';
+                    return sameAsEachOther ? cveList[0]?.status_text || '' : '';
                 }
             }
         }

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -157,20 +157,7 @@ export const SystemCVEs = ({
     }, [dispatch]);
 
     const showStatusModal = (selectedCveList, goToFirstPage) => {
-        let cveList = selectedCveList.map(
-            ({
-                id,
-                // eslint-disable-next-line camelcase
-                cve_status_id,
-                // eslint-disable-next-line camelcase
-                status_id,
-                status_text: justification,
-                // eslint-disable-next-line camelcase
-                cve_status_text: cve_justification,
-                ...rest
-                // eslint-disable-next-line camelcase
-            }) => ({ id, cve_status_id, status_id, justification, cve_justification, ...rest })
-        );
+        let cveList = selectedCveList.map(cve => ({ id: cve.id, ...cve.attributes }));
 
         setStatusModal(() => () => (
             <CvePairStatusModal

--- a/src/Components/SmartComponents/SystemCves/SystemCves.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.test.js
@@ -249,12 +249,14 @@ describe('SystemCves', () => {
     it('Should display status modal', () => {
         const selectedCves = [{
             id: 'CVE-2019-6454',
-            status_id: 'testStatusId',
-            cve_status_text: "testhello",
-            cve_status_id: 2,
-            status_id: "testStatusId",
-            status_text: "testhello",
-            status_id: 2
+            attributes: {
+                status_id: 'testStatusId',
+                cve_status_text: "testhello",
+                cve_status_id: 2,
+                status_id: "testStatusId",
+                status_text: "testhello",
+                status_id: 2
+            }
         }]
 
         const { context } = wrapper.find('SystemCvesTableWithContext').props();
@@ -266,10 +268,10 @@ describe('SystemCves', () => {
         expect(cveList).toEqual([{
             id: 'CVE-2019-6454',
             status_id: 'testStatusId',
-            cve_justification: "testhello",
+            cve_status_text: "testhello",
             cve_status_id: 2,
             status_id: "testStatusId",
-            justification: "testhello",
+            status_text: "testhello",
             status_id: 2
         }]);
     });


### PR DESCRIPTION
https://issues.redhat.com/browse/VULN-2637

During some refactoring of selected items, the names of some parameters got changed which caused multiple issues while editing the status on the CVE detail page:
1. If you try to edit status, don't open the status select and click "Save", you'd get an error
2. If you selected an item which already has status/justification set, the form field did not get prefilled.