### PR TITLE
Fix breadcrumb skeleton loader showing "Invalid system"

### DIFF
--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -24,7 +24,7 @@ const InventoryDetail = () => {
     const match = useRouteMatch();
     const intl = useIntl();
 
-    const { loaded, opt_out: isOptOut } = useSelector(({ SystemDetailsPageStore }) => SystemDetailsPageStore) ?? {};
+    const { opt_out: isOptOut } = useSelector(({ SystemDetailsPageStore }) => SystemDetailsPageStore) ?? {};
     const { entity } = useSelector(state => state.entityDetails) ?? {};
 
     const errors = useSelector(({ SystemCvesStore }) => SystemCvesStore.cveList.payload.errors);
@@ -108,7 +108,7 @@ const InventoryDetail = () => {
                         {
                             title: entity?.display_name || intl.formatMessage(messages.invalidSystem),
                             isActive: true,
-                            isLoaded: loaded
+                            isLoaded: entity?.display_name !== undefined
                         }
                     ]}
                 >


### PR DESCRIPTION
Previously when you loaded System detail page, sometimes "Invalid system" text would flash before the system is loaded in the breadcrumb, this is now fixed.

![Screenshot from 2023-08-04 13-07-23](https://github.com/RedHatInsights/vulnerability-ui/assets/8426204/f1c25b2d-70ee-4a32-9d83-2d790e94f173)
