### PR TITLE
Implement global feature flag for CVEs without errata

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -113,6 +113,7 @@
   "emptyState.notConnected.titleText": "This system isn’t connected to Insights yet",
   "emptyState.prodSecLink": "Red Hat Product Security",
   "emptyState.thereShouldBeCVE": "Currently, you are only viewing CVEs with Errata. It is possible the CVE you are searching for does not yet have an associated Errata. Please adjust your settings and search again. Please check the {cveDatabaseLink} or if you would like more information, contact {prodSecLink}",
+  "emptyState.thereShouldBeCVE.featureDisabled": "Currently, Insights Vulnerability only shows CVEs with Errata. It is possible the CVE you are searching for does not yet have an associated Errata. Please check the {cveDatabaseLink} or if you would like more information, contact {prodSecLink}",
   "emptyState.thereShouldBeCVE.noErrata": "Please check the {cveDatabaseLink} or if you would like more information, contact {prodSecLink}",
   "emptyState.thisSystemShouldHaveCVEs": "If you think this system has applicable CVEs or would like more information, contact {prodSecLink}.",
   "emptyStateSystem.enableAnalysis": "Enable Vulnerability analysis",

--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -18,8 +18,9 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
                     props: { colSpan: header?.length },
                     title:
                         <EmptyStateNoCVEs
-                            secondParagraph={
-                                context.cves.meta.cves_without_errata
+                            secondParagraph={context.cves.meta.cves_without_errata === null
+                                ? messages.emptyStateThereShouldBeCVEsFeatureDisabled
+                                : context.cves.meta.cves_without_errata
                                     ? messages.emptyStateThereShouldBeCVEsNoErrata
                                     : messages.emptyStateThereShouldBeCVEs
                             }

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -44,7 +44,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
     const { filter } = params;
     const selectedCvesCount = selectedCves && selectedCves.length;
 
-    const [showCvesWithoutErrata, setShowCvesWithoutErrata] = useState(false);
+    const [showCvesWithoutErrata, setShowCvesWithoutErrata] = useState(null);
 
     useEffect(() => {
         if (!isLoading) {
@@ -98,7 +98,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
             label: intl.formatMessage(messages.columnManagementModalTitle),
             onClick: () => methods.setColumnManagementModalOpen(true)
         },
-        ...canToggleCvesWithoutErrata ? [(
+        ...canToggleCvesWithoutErrata && showCvesWithoutErrata !== null ? [(
             showCvesWithoutErrata ?
                 {
                     label: intl.formatMessage(messages.hideCvesWithoutAdvisories),

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -751,6 +751,11 @@ export default defineMessages({
         description: 'Paragraph for empty state component advising to contact support when there is a problem',
         defaultMessage: 'Please check the {cveDatabaseLink} or if you would like more information, contact {prodSecLink}'
     },
+    emptyStateThereShouldBeCVEsFeatureDisabled: {
+        id: 'emptyState.thereShouldBeCVE.featureDisabled',
+        description: 'Paragraph for empty state component advising to contact support when there is a problem',
+        defaultMessage: 'Currently, Insights Vulnerability only shows CVEs with Errata. It is possible the CVE you are searching for does not yet have an associated Errata. Please check the {cveDatabaseLink} or if you would like more information, contact {prodSecLink}'
+    },
     emptyStateThisSystemShouldHaveCVEs: {
         id: 'emptyState.thisSystemShouldHaveCVEs',
         description: 'Paragraph for empty state component advising to contact support when there is a problem',


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/VULN-2672

There is a feature flag which controls the enablement of CVEs without errata feature, the feature flag is stored on backend and is sent in meta section of most API responses. It has three values:

- globally disabled – don't show option to show/hide CVEs without Advisories, backend retuns null
- account disabled – show option to show CVEs without Advisories, backend returns false
- account enabled – show option to hide CVEs without Advisories, backend returns true

This PR makes it so that if backend sends null, then we want to act as if the feature is account disabled (for example hide Advisory filters) and don't show the button to toggle the feature in CVEs list table toolbar.

