### PR TITLE
Improve table mobile views and skeletons

### DIFF
--- a/src/Components/PresentationalComponents/TableColumns/RemediationColumn.js
+++ b/src/Components/PresentationalComponents/TableColumns/RemediationColumn.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropType from 'prop-types';
 import { AnsibleTowerIcon } from '@patternfly/react-icons';
-import { Tooltip } from '@patternfly/react-core';
+import { Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { FormattedMessage } from 'react-intl';
 import messages from '../../../Messages';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -35,10 +35,14 @@ const RemediationColumn = ({ fixable }) => {
 
         case 2: {
             return (
-                <Fragment>
-                    <AnsibleTowerIcon className="pf-u-mr-xs" />
-                    <FormattedMessage {...messages.playbook} />
-                </Fragment>
+                <Split>
+                    <SplitItem>
+                        <AnsibleTowerIcon className="pf-u-mr-xs" />
+                    </SplitItem>
+                    <SplitItem>
+                        <FormattedMessage {...messages.playbook} />
+                    </SplitItem>
+                </Split>
             );
         }
 

--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -31,14 +31,13 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
         }]);
     };
 
+    const { cves, methods, selectedCves, expandedRows, isAllExpanded, params } = context;
+    const isEmpty = cves.data.length === 0;
+
     const handleOnSelect = (event, isSelected, rowId) => {
-        const { cves, methods } = context;
         const cveName = cves.data[rowId] && cves.data[rowId].id;
         methods.selectCves(isSelected, cveName);
     };
-
-    const { cves, methods, selectedCves, expandedRows } = context;
-    const isEmpty = cves.data.length === 0;
 
     const rows = cves.data && cves.data
         .map(cve => (selectedCves.find(selectedCve => selectedCve.id === cve.id) && { ...cve, selected: true }) || cve)
@@ -48,8 +47,6 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
         });
 
     const onCollapseAll = () => {
-        const { cves, methods, isAllExpanded } = context;
-
         const expandedRows = !isAllExpanded ? cves.data.filter(cve => cve.id).map(cve => cve.id) : [];
         methods.openCves(expandedRows);
     };
@@ -63,8 +60,8 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
     };
 
     return (
-        !cves.isLoading ? (
-            <Fragment>
+        <Fragment>
+            {!cves.isLoading ? (
                 <Table
                     canSelectAll={false}
                     aria-label="Vulnerability CVE table"
@@ -76,14 +73,14 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
                     actionResolver={canEditStatusOrBusinessRisk && cves.data.length > 0 ?
                         (rowData, rowIndex) => cveTableRowActions(methods, rowIndex.rowIndex) : undefined}
                     sortBy={!isEmpty ?
-                        createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], cves.meta.sort) : undefined}
+                        createSortBy([{ key: 'collapse' }, { key: 'checkbox' }, ...header], params.sort) : undefined}
                     onSort={!isEmpty ?
                         (event, key, direction) =>
                             handleSortColumn(
                                 key,
                                 direction,
                                 [{ key: 'collapse' }, { key: 'checkbox' }, ...header],
-                                cves.meta.sort,
+                                params.sort,
                                 methods.apply
                             ) : undefined
                     }
@@ -95,11 +92,17 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
                     <TableHeader />
                     <TableBody />
                 </Table>
-                <PaginationWrapper meta={cves.meta} apply={methods.apply} />
-            </Fragment>
-        ) : (
-            <SkeletonTable colSize={header?.length} rowSize={DEFAULT_PAGE_SIZE} variant={TableVariant.compact} />
-        )
+            ) : (
+                <SkeletonTable
+                    columns={header}
+                    rowSize={parseInt(params.page_size) || DEFAULT_PAGE_SIZE}
+                    variant={TableVariant.compact}
+                    sortBy={createSortBy([{ key: 'checkbox' }, ...header], params.sort)}
+                    isSelectable
+                />)
+            }
+            <PaginationWrapper meta={cves.meta} apply={methods.apply} />
+        </Fragment>
     );
 
 };

--- a/src/Components/SmartComponents/CVEs/CVEsTable.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTable.js
@@ -8,6 +8,7 @@ import PaginationWrapper from '../../PresentationalComponents/PaginationWrapper/
 import { EmptyStateNoCVEs } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { CVETableContext } from './CVEs';
 import messages from '../../../Messages';
+import { DEFAULT_PAGE_SIZE } from '../../../Helpers/constants';
 
 const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) => {
     const noCves = () => {
@@ -97,7 +98,7 @@ const CVEsTableWithContext = ({ context, header, canEditStatusOrBusinessRisk }) 
                 <PaginationWrapper meta={cves.meta} apply={methods.apply} />
             </Fragment>
         ) : (
-            <SkeletonTable colSize={header?.length} rowSize={20} variant={TableVariant.compact} />
+            <SkeletonTable colSize={header?.length} rowSize={DEFAULT_PAGE_SIZE} variant={TableVariant.compact} />
         )
     );
 

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -29,6 +29,7 @@ import {
 import {
     CVES_DEFAULT_FILTERS,
     CVES_FILTER_PARAMS,
+    DEFAULT_PAGE_SIZE,
     ONLY_NON_VULNERABLE_SYSTEMS,
     RULE_PRESENCE_OPTIONS
 } from '../../../Helpers/constants';
@@ -118,7 +119,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
                     isDisabled: cves.meta.total_items === 0,
                     itemCount: cves.meta.total_items || 0,
                     page: cves.meta.page || 1,
-                    perPage: cves.meta.page_size || 1,
+                    perPage: cves.meta.page_size || DEFAULT_PAGE_SIZE,
                     ouiaId: 'pagination-top',
                     onSetPage: (_event, page) => handleChangePage(_event, page, methods.apply),
                     onPerPageSelect: (_event, perPage) => handleSetPageSize(_event, perPage, methods.apply)

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEs.test.js.snap
@@ -130,6 +130,7 @@ exports[`CVEs Should render without props 1`] = `
                   ],
                 },
                 {
+                  "dataLabel": "Advisory",
                   "isShownByDefault": true,
                   "key": "advisory_available",
                   "title": <span>
@@ -903,7 +904,7 @@ exports[`CVEs Should render without props 1`] = `
                               "onSetPage": [Function],
                               "ouiaId": "pagination-top",
                               "page": 1,
-                              "perPage": 1,
+                              "perPage": 20,
                             }
                           }
                         >
@@ -1100,7 +1101,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       <DropdownToggle
                                                         aria-haspopup={true}
                                                         getMenuRef={[Function]}
-                                                        id="pf-dropdown-toggle-id-17"
+                                                        id="pf-dropdown-toggle-id-18"
                                                         isDisabled={false}
                                                         isOpen={false}
                                                         isPlain={false}
@@ -1143,7 +1144,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                   data-ouia-component-id="bulk-select"
                                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                                   data-ouia-safe="true"
-                                                                  id="pf-dropdown-toggle-id-17"
+                                                                  id="pf-dropdown-toggle-id-18"
                                                                   type="button"
                                                                 >
                                                                   <span
@@ -1227,7 +1228,7 @@ exports[`CVEs Should render without props 1`] = `
                                                             data-ouia-component-type="PF4/DropdownToggle"
                                                             data-ouia-safe={true}
                                                             getMenuRef={[Function]}
-                                                            id="pf-dropdown-toggle-id-17"
+                                                            id="pf-dropdown-toggle-id-18"
                                                             isActive={false}
                                                             isDisabled={false}
                                                             isOpen={false}
@@ -1271,7 +1272,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                       data-ouia-component-id="bulk-select"
                                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                                       data-ouia-safe="true"
-                                                                      id="pf-dropdown-toggle-id-17"
+                                                                      id="pf-dropdown-toggle-id-18"
                                                                       type="button"
                                                                     >
                                                                       <span
@@ -1307,7 +1308,7 @@ exports[`CVEs Should render without props 1`] = `
                                                               data-ouia-component-type="PF4/DropdownToggle"
                                                               data-ouia-safe={true}
                                                               disabled={false}
-                                                              id="pf-dropdown-toggle-id-17"
+                                                              id="pf-dropdown-toggle-id-18"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
                                                               type="button"
@@ -1866,7 +1867,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                 aria-label="Conditional filter"
                                                                 className=""
                                                                 getMenuRef={[Function]}
-                                                                id="pf-dropdown-toggle-id-18"
+                                                                id="pf-dropdown-toggle-id-19"
                                                                 isDisabled={false}
                                                                 isOpen={false}
                                                                 isPlain={false}
@@ -1891,7 +1892,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                         data-ouia-component-id="ConditionalFilter"
                                                                         data-ouia-component-type="PF4/DropdownToggle"
                                                                         data-ouia-safe="true"
-                                                                        id="pf-dropdown-toggle-id-18"
+                                                                        id="pf-dropdown-toggle-id-19"
                                                                         type="button"
                                                                       >
                                                                         <span
@@ -1947,7 +1948,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                   data-ouia-component-type="PF4/DropdownToggle"
                                                                   data-ouia-safe={true}
                                                                   getMenuRef={[Function]}
-                                                                  id="pf-dropdown-toggle-id-18"
+                                                                  id="pf-dropdown-toggle-id-19"
                                                                   isActive={false}
                                                                   isDisabled={false}
                                                                   isOpen={false}
@@ -1973,7 +1974,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                           data-ouia-component-id="ConditionalFilter"
                                                                           data-ouia-component-type="PF4/DropdownToggle"
                                                                           data-ouia-safe="true"
-                                                                          id="pf-dropdown-toggle-id-18"
+                                                                          id="pf-dropdown-toggle-id-19"
                                                                           type="button"
                                                                         >
                                                                           <span
@@ -2030,7 +2031,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                                     data-ouia-safe={true}
                                                                     disabled={false}
-                                                                    id="pf-dropdown-toggle-id-18"
+                                                                    id="pf-dropdown-toggle-id-19"
                                                                     onClick={[Function]}
                                                                     onKeyDown={[Function]}
                                                                     type="button"
@@ -2416,7 +2417,7 @@ exports[`CVEs Should render without props 1`] = `
                                                     aria-haspopup={true}
                                                     aria-label="Export"
                                                     getMenuRef={[Function]}
-                                                    id="pf-dropdown-toggle-id-19"
+                                                    id="pf-dropdown-toggle-id-20"
                                                     isDisabled={false}
                                                     isOpen={false}
                                                     isPlain={true}
@@ -2441,7 +2442,7 @@ exports[`CVEs Should render without props 1`] = `
                                                             data-ouia-component-id="Export"
                                                             data-ouia-component-type="PF4/DropdownToggle"
                                                             data-ouia-safe="true"
-                                                            id="pf-dropdown-toggle-id-19"
+                                                            id="pf-dropdown-toggle-id-20"
                                                             type="button"
                                                           >
                                                             <span>
@@ -2474,7 +2475,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                       data-ouia-safe={true}
                                                       getMenuRef={[Function]}
-                                                      id="pf-dropdown-toggle-id-19"
+                                                      id="pf-dropdown-toggle-id-20"
                                                       isActive={false}
                                                       isDisabled={false}
                                                       isOpen={false}
@@ -2500,7 +2501,7 @@ exports[`CVEs Should render without props 1`] = `
                                                               data-ouia-component-id="Export"
                                                               data-ouia-component-type="PF4/DropdownToggle"
                                                               data-ouia-safe="true"
-                                                              id="pf-dropdown-toggle-id-19"
+                                                              id="pf-dropdown-toggle-id-20"
                                                               type="button"
                                                             >
                                                               <span>
@@ -2533,7 +2534,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         data-ouia-component-type="PF4/DropdownToggle"
                                                         data-ouia-safe={true}
                                                         disabled={false}
-                                                        id="pf-dropdown-toggle-id-19"
+                                                        id="pf-dropdown-toggle-id-20"
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
                                                         type="button"
@@ -2669,7 +2670,7 @@ exports[`CVEs Should render without props 1`] = `
                                                 <KebabToggle
                                                   aria-haspopup={true}
                                                   getMenuRef={[Function]}
-                                                  id="pf-dropdown-toggle-id-20"
+                                                  id="pf-dropdown-toggle-id-21"
                                                   isOpen={false}
                                                   isPlain={true}
                                                   isText={false}
@@ -2689,7 +2690,7 @@ exports[`CVEs Should render without props 1`] = `
                                                           aria-haspopup="true"
                                                           aria-label="Actions"
                                                           class="pf-c-dropdown__toggle pf-m-plain"
-                                                          id="pf-dropdown-toggle-id-20"
+                                                          id="pf-dropdown-toggle-id-21"
                                                           type="button"
                                                         >
                                                           <svg
@@ -2716,7 +2717,7 @@ exports[`CVEs Should render without props 1`] = `
                                                     bubbleEvent={false}
                                                     className=""
                                                     getMenuRef={[Function]}
-                                                    id="pf-dropdown-toggle-id-20"
+                                                    id="pf-dropdown-toggle-id-21"
                                                     isActive={false}
                                                     isDisabled={false}
                                                     isOpen={false}
@@ -2739,7 +2740,7 @@ exports[`CVEs Should render without props 1`] = `
                                                             aria-haspopup="true"
                                                             aria-label="Actions"
                                                             class="pf-c-dropdown__toggle pf-m-plain"
-                                                            id="pf-dropdown-toggle-id-20"
+                                                            id="pf-dropdown-toggle-id-21"
                                                             type="button"
                                                           >
                                                             <svg
@@ -2766,7 +2767,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       aria-label="Actions"
                                                       className="pf-c-dropdown__toggle pf-m-plain"
                                                       disabled={false}
-                                                      id="pf-dropdown-toggle-id-20"
+                                                      id="pf-dropdown-toggle-id-21"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       type="button"
@@ -2831,7 +2832,7 @@ exports[`CVEs Should render without props 1`] = `
                                           ouiaId="pagination-top"
                                           ouiaSafe={true}
                                           page={1}
-                                          perPage={1}
+                                          perPage={20}
                                           perPageComponent="div"
                                           perPageOptions={
                                             [
@@ -2919,7 +2920,7 @@ exports[`CVEs Should render without props 1`] = `
                                               onPerPageSelect={[Function]}
                                               optionsToggle=""
                                               page={0}
-                                              perPage={1}
+                                              perPage={20}
                                               perPageComponent="div"
                                               perPageOptions={
                                                 [
@@ -2961,13 +2962,22 @@ exports[`CVEs Should render without props 1`] = `
                                                        per page
                                                     </DropdownItem>,
                                                     <DropdownItem
-                                                      className=""
+                                                      className="pf-m-selected"
                                                       component="button"
                                                       data-action="per-page-20"
                                                       onClick={[Function]}
                                                     >
                                                       20
                                                        per page
+                                                      <div
+                                                        className="pf-c-options-menu__menu-item-icon"
+                                                      >
+                                                        <CheckIcon
+                                                          color="currentColor"
+                                                          noVerticalAlign={false}
+                                                          size="sm"
+                                                        />
+                                                      </div>
                                                     </DropdownItem>,
                                                     <DropdownItem
                                                       className=""
@@ -3026,7 +3036,7 @@ exports[`CVEs Should render without props 1`] = `
                                                     aria-haspopup={true}
                                                     firstIndex={0}
                                                     getMenuRef={[Function]}
-                                                    id="pf-dropdown-toggle-id-21"
+                                                    id="pf-dropdown-toggle-id-22"
                                                     isDisabled={false}
                                                     isOpen={false}
                                                     isPlain={true}
@@ -3352,7 +3362,7 @@ exports[`CVEs Should render without props 1`] = `
                                               pagesTitle=""
                                               pagesTitlePlural=""
                                               paginationTitle="Pagination"
-                                              perPage={1}
+                                              perPage={20}
                                               toFirstPage="Go to first page"
                                               toLastPage="Go to last page"
                                               toNextPage="Go to next page"
@@ -3876,6 +3886,7 @@ exports[`CVEs Should render without props 1`] = `
                           ],
                         },
                         {
+                          "dataLabel": "Advisory",
                           "isShownByDefault": true,
                           "key": "advisory_available",
                           "title": <span>
@@ -4098,6 +4109,7 @@ exports[`CVEs Should render without props 1`] = `
                             ],
                           },
                           {
+                            "dataLabel": "Advisory",
                             "isShownByDefault": true,
                             "key": "advisory_available",
                             "title": <span>
@@ -4211,6 +4223,7 @@ exports[`CVEs Should render without props 1`] = `
                               ],
                             },
                             {
+                              "dataLabel": "Advisory",
                               "isShownByDefault": true,
                               "key": "advisory_available",
                               "title": <span>
@@ -4348,7 +4361,12 @@ exports[`CVEs Should render without props 1`] = `
                           ]
                         }
                         selectVariant="checkbox"
-                        sortBy={{}}
+                        sortBy={
+                          {
+                            "direction": "desc",
+                            "index": 3,
+                          }
+                        }
                         variant="compact"
                       >
                         <Provider
@@ -4395,7 +4413,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4449,7 +4470,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4505,7 +4529,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4562,7 +4589,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4620,7 +4650,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4676,7 +4709,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4732,7 +4768,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4788,7 +4827,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4844,7 +4886,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4900,7 +4945,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -4932,7 +4980,7 @@ exports[`CVEs Should render without props 1`] = `
                                 "property": "column-9",
                                 "props": {
                                   "data-key": 9,
-                                  "data-label": "column-9",
+                                  "data-label": "Advisory",
                                 },
                               },
                               {
@@ -4972,7 +5020,10 @@ exports[`CVEs Should render without props 1`] = `
                                   "onSort": [Function],
                                   "rowLabeledBy": "simple-node",
                                   "selectVariant": "checkbox",
-                                  "sortBy": {},
+                                  "sortBy": {
+                                    "direction": "desc",
+                                    "index": 3,
+                                  },
                                 },
                                 "header": {
                                   "formatters": [],
@@ -5100,7 +5151,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5154,7 +5208,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5210,7 +5267,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5267,7 +5327,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5325,7 +5388,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5381,7 +5447,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5437,7 +5506,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5493,7 +5565,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5549,7 +5624,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5605,7 +5683,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5637,7 +5718,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "property": "column-9",
                                               "props": {
                                                 "data-key": 9,
-                                                "data-label": "column-9",
+                                                "data-label": "Advisory",
                                               },
                                             },
                                             {
@@ -5677,7 +5758,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -5787,7 +5871,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -5841,7 +5928,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -5897,7 +5987,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -5954,7 +6047,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6012,7 +6108,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6068,7 +6167,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6124,7 +6226,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6180,7 +6285,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6236,7 +6344,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6292,7 +6403,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6324,7 +6438,7 @@ exports[`CVEs Should render without props 1`] = `
                                                       "property": "column-9",
                                                       "props": {
                                                         "data-key": 9,
-                                                        "data-label": "column-9",
+                                                        "data-label": "Advisory",
                                                       },
                                                     },
                                                     {
@@ -6364,7 +6478,10 @@ exports[`CVEs Should render without props 1`] = `
                                                         "onSort": [Function],
                                                         "rowLabeledBy": "simple-node",
                                                         "selectVariant": "checkbox",
-                                                        "sortBy": {},
+                                                        "sortBy": {
+                                                          "direction": "desc",
+                                                          "index": 3,
+                                                        },
                                                       },
                                                       "header": {
                                                         "formatters": [],
@@ -6464,7 +6581,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                       aria-label="Expand all rows"
                                                                       aria-labelledby="simple-node-1 expandable-toggle-1"
                                                                       className="pf-c-button pf-m-plain"
-                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-8"
                                                                       data-ouia-component-type="PF4/Button"
                                                                       data-ouia-safe={true}
                                                                       disabled={false}
@@ -6642,16 +6759,16 @@ exports[`CVEs Should render without props 1`] = `
                                                         </Th>
                                                       </HeaderCell>
                                                       <HeaderCell
-                                                        aria-sort="none"
-                                                        className="pf-c-table__sort pf-m-wrap hide-description"
+                                                        aria-sort="descending"
+                                                        className="pf-c-table__sort pf-m-selected pf-m-wrap hide-description"
                                                         data-key={3}
                                                         data-label="Publish date"
                                                         key="3-header"
                                                         scope="col"
                                                       >
                                                         <Th
-                                                          aria-sort="none"
-                                                          className="pf-c-table__sort pf-m-wrap hide-description"
+                                                          aria-sort="descending"
+                                                          className="pf-c-table__sort pf-m-selected pf-m-wrap hide-description"
                                                           component="th"
                                                           data-key={3}
                                                           data-label="Publish date"
@@ -6661,8 +6778,8 @@ exports[`CVEs Should render without props 1`] = `
                                                           tooltip=""
                                                         >
                                                           <ThBase
-                                                            aria-sort="none"
-                                                            className="pf-c-table__sort pf-m-wrap hide-description"
+                                                            aria-sort="descending"
+                                                            className="pf-c-table__sort pf-m-selected pf-m-wrap hide-description"
                                                             component="th"
                                                             data-key={3}
                                                             data-label="Publish date"
@@ -6673,17 +6790,17 @@ exports[`CVEs Should render without props 1`] = `
                                                             tooltip=""
                                                           >
                                                             <th
-                                                              aria-sort="none"
-                                                              className="pf-c-table__sort pf-m-wrap hide-description"
+                                                              aria-sort="descending"
+                                                              className="pf-c-table__sort pf-m-selected pf-m-wrap hide-description"
                                                               data-key={3}
                                                               data-label="Publish date"
                                                               onMouseEnter={[Function]}
                                                               scope="col"
                                                             >
                                                               <SortColumn
-                                                                isSortedBy={false}
+                                                                isSortedBy={true}
                                                                 onSort={[Function]}
-                                                                sortDirection=""
+                                                                sortDirection="desc"
                                                               >
                                                                 <button
                                                                   className="pf-c-table__button"
@@ -6704,7 +6821,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                     <span
                                                                       className="pf-c-table__sort-indicator"
                                                                     >
-                                                                      <ArrowsAltVIcon
+                                                                      <LongArrowAltDownIcon
                                                                         color="currentColor"
                                                                         noVerticalAlign={false}
                                                                         size="sm"
@@ -6724,10 +6841,10 @@ exports[`CVEs Should render without props 1`] = `
                                                                           width="1em"
                                                                         >
                                                                           <path
-                                                                            d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                                                            d="M168 345.941V44c0-6.627-5.373-12-12-12h-56c-6.627 0-12 5.373-12 12v301.941H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.569 9.373 33.941 0l86.059-86.059c15.119-15.119 4.411-40.971-16.971-40.971H168z"
                                                                           />
                                                                         </svg>
-                                                                      </ArrowsAltVIcon>
+                                                                      </LongArrowAltDownIcon>
                                                                     </span>
                                                                   </div>
                                                                 </button>
@@ -7215,7 +7332,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         aria-sort="none"
                                                         className="pf-c-table__sort pf-m-wrap"
                                                         data-key={9}
-                                                        data-label="column-9"
+                                                        data-label="Advisory"
                                                         key="9-header"
                                                         scope="col"
                                                       >
@@ -7224,7 +7341,7 @@ exports[`CVEs Should render without props 1`] = `
                                                           className="pf-c-table__sort pf-m-wrap"
                                                           component="th"
                                                           data-key={9}
-                                                          data-label="column-9"
+                                                          data-label="Advisory"
                                                           onMouseEnter={[Function]}
                                                           scope="col"
                                                           textCenter={false}
@@ -7235,7 +7352,7 @@ exports[`CVEs Should render without props 1`] = `
                                                             className="pf-c-table__sort pf-m-wrap"
                                                             component="th"
                                                             data-key={9}
-                                                            data-label="column-9"
+                                                            data-label="Advisory"
                                                             innerRef={null}
                                                             onMouseEnter={[Function]}
                                                             scope="col"
@@ -7246,7 +7363,7 @@ exports[`CVEs Should render without props 1`] = `
                                                               aria-sort="none"
                                                               className="pf-c-table__sort pf-m-wrap"
                                                               data-key={9}
-                                                              data-label="column-9"
+                                                              data-label="Advisory"
                                                               onMouseEnter={[Function]}
                                                               scope="col"
                                                             >
@@ -7303,7 +7420,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                                 <div
                                                                                   aria-live="off"
                                                                                   className="pf-c-tooltip"
-                                                                                  id="pf-tooltip-1"
+                                                                                  id="pf-tooltip-2"
                                                                                   role="tooltip"
                                                                                   style={
                                                                                     {
@@ -7521,7 +7638,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7575,7 +7695,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7631,7 +7754,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7688,7 +7814,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7746,7 +7875,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7802,7 +7934,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7858,7 +7993,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7914,7 +8052,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -7970,7 +8111,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -8026,7 +8170,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -8058,7 +8205,7 @@ exports[`CVEs Should render without props 1`] = `
                                           "property": "column-9",
                                           "props": {
                                             "data-key": 9,
-                                            "data-label": "column-9",
+                                            "data-label": "Advisory",
                                           },
                                         },
                                         {
@@ -8098,7 +8245,10 @@ exports[`CVEs Should render without props 1`] = `
                                             "onSort": [Function],
                                             "rowLabeledBy": "simple-node",
                                             "selectVariant": "checkbox",
-                                            "sortBy": {},
+                                            "sortBy": {
+                                              "direction": "desc",
+                                              "index": 3,
+                                            },
                                           },
                                           "header": {
                                             "formatters": [],
@@ -8678,7 +8828,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -8732,7 +8885,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -8788,7 +8944,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -8845,7 +9004,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -8903,7 +9065,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -8959,7 +9124,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9015,7 +9183,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9071,7 +9242,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9127,7 +9301,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9183,7 +9360,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9215,7 +9395,7 @@ exports[`CVEs Should render without props 1`] = `
                                               "property": "column-9",
                                               "props": {
                                                 "data-key": 9,
-                                                "data-label": "column-9",
+                                                "data-label": "Advisory",
                                               },
                                             },
                                             {
@@ -9255,7 +9435,10 @@ exports[`CVEs Should render without props 1`] = `
                                                 "onSort": [Function],
                                                 "rowLabeledBy": "simple-node",
                                                 "selectVariant": "checkbox",
-                                                "sortBy": {},
+                                                "sortBy": {
+                                                  "direction": "desc",
+                                                  "index": 3,
+                                                },
                                               },
                                               "header": {
                                                 "formatters": [],
@@ -9988,7 +10171,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10042,7 +10228,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10098,7 +10287,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10155,7 +10347,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10213,7 +10408,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10269,7 +10467,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10325,7 +10526,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10381,7 +10585,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10437,7 +10644,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10493,7 +10703,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -10525,7 +10738,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "property": "column-9",
                                                         "props": {
                                                           "data-key": 9,
-                                                          "data-label": "column-9",
+                                                          "data-label": "Advisory",
                                                         },
                                                       },
                                                       {
@@ -10565,7 +10778,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -11036,7 +11252,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                           aria-label="Details"
                                                                           aria-labelledby="simple-node0 expandable-toggle0"
                                                                           className="pf-c-button pf-m-plain"
-                                                                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                                                          data-ouia-component-id="OUIA-Generated-Button-plain-9"
                                                                           data-ouia-component-type="PF4/Button"
                                                                           data-ouia-safe={true}
                                                                           disabled={false}
@@ -11309,7 +11525,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                               <div
                                                                                 aria-live="off"
                                                                                 className="pf-c-tooltip"
-                                                                                id="pf-tooltip-2"
+                                                                                id="pf-tooltip-3"
                                                                                 role="tooltip"
                                                                                 style={
                                                                                   {
@@ -11566,7 +11782,7 @@ exports[`CVEs Should render without props 1`] = `
                                                           </BodyCell>
                                                           <BodyCell
                                                             data-key={9}
-                                                            data-label="column-9"
+                                                            data-label="Advisory"
                                                             isVisible={true}
                                                             key="col-9-row-0"
                                                           >
@@ -11574,7 +11790,7 @@ exports[`CVEs Should render without props 1`] = `
                                                               className=""
                                                               component="td"
                                                               data-key={9}
-                                                              dataLabel="column-9"
+                                                              dataLabel="Advisory"
                                                               onMouseEnter={[Function]}
                                                               textCenter={false}
                                                             >
@@ -11582,7 +11798,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                 className=""
                                                                 component="td"
                                                                 data-key={9}
-                                                                dataLabel="column-9"
+                                                                dataLabel="Advisory"
                                                                 innerRef={null}
                                                                 onMouseEnter={[Function]}
                                                                 textCenter={false}
@@ -11590,7 +11806,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                 <td
                                                                   className=""
                                                                   data-key={9}
-                                                                  data-label="column-9"
+                                                                  data-label="Advisory"
                                                                   onMouseEnter={[Function]}
                                                                 >
                                                                   <span
@@ -11694,7 +11910,10 @@ exports[`CVEs Should render without props 1`] = `
                                                                             "onSort": [Function],
                                                                             "rowLabeledBy": "simple-node",
                                                                             "selectVariant": "checkbox",
-                                                                            "sortBy": {},
+                                                                            "sortBy": {
+                                                                              "direction": "desc",
+                                                                              "index": 3,
+                                                                            },
                                                                           },
                                                                           "header": {
                                                                             "formatters": [],
@@ -12005,7 +12224,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                           <KebabToggle
                                                                             aria-haspopup={true}
                                                                             getMenuRef={[Function]}
-                                                                            id="pf-dropdown-toggle-id-10"
+                                                                            id="pf-dropdown-toggle-id-11"
                                                                             isOpen={false}
                                                                             isPlain={true}
                                                                             isText={false}
@@ -12025,7 +12244,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                                     aria-haspopup="true"
                                                                                     aria-label="Actions"
                                                                                     class="pf-c-dropdown__toggle pf-m-plain"
-                                                                                    id="pf-dropdown-toggle-id-10"
+                                                                                    id="pf-dropdown-toggle-id-11"
                                                                                     type="button"
                                                                                   >
                                                                                     <svg
@@ -12052,7 +12271,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                               bubbleEvent={false}
                                                                               className=""
                                                                               getMenuRef={[Function]}
-                                                                              id="pf-dropdown-toggle-id-10"
+                                                                              id="pf-dropdown-toggle-id-11"
                                                                               isActive={false}
                                                                               isDisabled={false}
                                                                               isOpen={false}
@@ -12075,7 +12294,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                                       aria-haspopup="true"
                                                                                       aria-label="Actions"
                                                                                       class="pf-c-dropdown__toggle pf-m-plain"
-                                                                                      id="pf-dropdown-toggle-id-10"
+                                                                                      id="pf-dropdown-toggle-id-11"
                                                                                       type="button"
                                                                                     >
                                                                                       <svg
@@ -12102,7 +12321,7 @@ exports[`CVEs Should render without props 1`] = `
                                                                                 aria-label="Actions"
                                                                                 className="pf-c-dropdown__toggle pf-m-plain"
                                                                                 disabled={false}
-                                                                                id="pf-dropdown-toggle-id-10"
+                                                                                id="pf-dropdown-toggle-id-11"
                                                                                 onClick={[Function]}
                                                                                 onKeyDown={[Function]}
                                                                                 type="button"
@@ -12188,7 +12407,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12242,7 +12464,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12298,7 +12523,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12355,7 +12583,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12413,7 +12644,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12469,7 +12703,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12525,7 +12762,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12581,7 +12821,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12637,7 +12880,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12693,7 +12939,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -12725,7 +12974,7 @@ exports[`CVEs Should render without props 1`] = `
                                                         "property": "column-9",
                                                         "props": {
                                                           "data-key": 9,
-                                                          "data-label": "column-9",
+                                                          "data-label": "Advisory",
                                                         },
                                                       },
                                                       {
@@ -12765,7 +13014,10 @@ exports[`CVEs Should render without props 1`] = `
                                                           "onSort": [Function],
                                                           "rowLabeledBy": "simple-node",
                                                           "selectVariant": "checkbox",
-                                                          "sortBy": {},
+                                                          "sortBy": {
+                                                            "direction": "desc",
+                                                            "index": 3,
+                                                          },
                                                         },
                                                         "header": {
                                                           "formatters": [],
@@ -13094,7 +13346,7 @@ exports[`CVEs Should render without props 1`] = `
                                                           />
                                                           <BodyCell
                                                             data-key={9}
-                                                            data-label="column-9"
+                                                            data-label="Advisory"
                                                             key="col-9-row-1"
                                                             parentId={0}
                                                           />
@@ -13380,7 +13632,7 @@ exports[`CVEs Should render without props 1`] = `
                                     aria-haspopup={true}
                                     firstIndex={0}
                                     getMenuRef={[Function]}
-                                    id="pf-dropdown-toggle-id-11"
+                                    id="pf-dropdown-toggle-id-12"
                                     isDisabled={true}
                                     isOpen={false}
                                     isPlain={true}
@@ -13742,7 +13994,7 @@ exports[`CVEs Should render without props 1`] = `
                                         aria-label="Go to first page"
                                         className="pf-c-button pf-m-plain pf-m-disabled"
                                         data-action="first"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-4"
                                         data-ouia-component-type="PF4/Button"
                                         data-ouia-safe={true}
                                         disabled={true}
@@ -13802,7 +14054,7 @@ exports[`CVEs Should render without props 1`] = `
                                         aria-label="Go to previous page"
                                         className="pf-c-button pf-m-plain pf-m-disabled"
                                         data-action="previous"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-5"
                                         data-ouia-component-type="PF4/Button"
                                         data-ouia-safe={true}
                                         disabled={true}
@@ -13884,7 +14136,7 @@ exports[`CVEs Should render without props 1`] = `
                                         aria-label="Go to next page"
                                         className="pf-c-button pf-m-plain pf-m-disabled"
                                         data-action="next"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-6"
                                         data-ouia-component-type="PF4/Button"
                                         data-ouia-safe={true}
                                         disabled={true}
@@ -13944,7 +14196,7 @@ exports[`CVEs Should render without props 1`] = `
                                         aria-label="Go to last page"
                                         className="pf-c-button pf-m-plain pf-m-disabled"
                                         data-action="last"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                                        data-ouia-component-id="OUIA-Generated-Button-plain-7"
                                         data-ouia-component-type="PF4/Button"
                                         data-ouia-safe={true}
                                         disabled={true}

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTable.test.js.snap
@@ -103,6 +103,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
             ],
           },
           {
+            "dataLabel": "Advisory",
             "isShownByDefault": true,
             "key": "advisory_available",
             "title": <span>
@@ -326,6 +327,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
               ],
             },
             {
+              "dataLabel": "Advisory",
               "isShownByDefault": true,
               "key": "advisory_available",
               "title": <span>
@@ -439,6 +441,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                 ],
               },
               {
+                "dataLabel": "Advisory",
                 "isShownByDefault": true,
                 "key": "advisory_available",
                 "title": <span>
@@ -1159,7 +1162,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                   "property": "column-9",
                   "props": {
                     "data-key": 9,
-                    "data-label": "column-9",
+                    "data-label": "Advisory",
                   },
                 },
                 {
@@ -1864,7 +1867,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 "property": "column-9",
                                 "props": {
                                   "data-key": 9,
-                                  "data-label": "column-9",
+                                  "data-label": "Advisory",
                                 },
                               },
                               {
@@ -2551,7 +2554,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                         "property": "column-9",
                                         "props": {
                                           "data-key": 9,
-                                          "data-label": "column-9",
+                                          "data-label": "Advisory",
                                         },
                                       },
                                       {
@@ -3442,7 +3445,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           aria-sort="none"
                                           className="pf-c-table__sort pf-m-wrap"
                                           data-key={9}
-                                          data-label="column-9"
+                                          data-label="Advisory"
                                           key="9-header"
                                           scope="col"
                                         >
@@ -3451,7 +3454,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             className="pf-c-table__sort pf-m-wrap"
                                             component="th"
                                             data-key={9}
-                                            data-label="column-9"
+                                            data-label="Advisory"
                                             onMouseEnter={[Function]}
                                             scope="col"
                                             textCenter={false}
@@ -3462,7 +3465,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                               className="pf-c-table__sort pf-m-wrap"
                                               component="th"
                                               data-key={9}
-                                              data-label="column-9"
+                                              data-label="Advisory"
                                               innerRef={null}
                                               onMouseEnter={[Function]}
                                               scope="col"
@@ -3473,7 +3476,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                 aria-sort="none"
                                                 className="pf-c-table__sort pf-m-wrap"
                                                 data-key={9}
-                                                data-label="column-9"
+                                                data-label="Advisory"
                                                 onMouseEnter={[Function]}
                                                 scope="col"
                                               >
@@ -4285,7 +4288,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                             "property": "column-9",
                             "props": {
                               "data-key": 9,
-                              "data-label": "column-9",
+                              "data-label": "Advisory",
                             },
                           },
                           {
@@ -5437,7 +5440,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                 "property": "column-9",
                                 "props": {
                                   "data-key": 9,
-                                  "data-label": "column-9",
+                                  "data-label": "Advisory",
                                 },
                               },
                               {
@@ -6741,7 +6744,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "property": "column-9",
                                           "props": {
                                             "data-key": 9,
-                                            "data-label": "column-9",
+                                            "data-label": "Advisory",
                                           },
                                         },
                                         {
@@ -7777,7 +7780,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             </BodyCell>
                                             <BodyCell
                                               data-key={9}
-                                              data-label="column-9"
+                                              data-label="Advisory"
                                               isVisible={true}
                                               key="col-9-row-0"
                                             >
@@ -7785,7 +7788,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                 className=""
                                                 component="td"
                                                 data-key={9}
-                                                dataLabel="column-9"
+                                                dataLabel="Advisory"
                                                 onMouseEnter={[Function]}
                                                 textCenter={false}
                                               >
@@ -7793,7 +7796,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                   className=""
                                                   component="td"
                                                   data-key={9}
-                                                  dataLabel="column-9"
+                                                  dataLabel="Advisory"
                                                   innerRef={null}
                                                   onMouseEnter={[Function]}
                                                   textCenter={false}
@@ -7801,7 +7804,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                                   <td
                                                     className=""
                                                     data-key={9}
-                                                    data-label="column-9"
+                                                    data-label="Advisory"
                                                     onMouseEnter={[Function]}
                                                   >
                                                     <span
@@ -8934,7 +8937,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                           "property": "column-9",
                                           "props": {
                                             "data-key": 9,
-                                            "data-label": "column-9",
+                                            "data-label": "Advisory",
                                           },
                                         },
                                         {
@@ -9303,7 +9306,7 @@ exports[`CVEs:  Should match the snapshot 1`] = `
                                             />
                                             <BodyCell
                                               data-key={9}
-                                              data-label="column-9"
+                                              data-label="Advisory"
                                               key="col-9-row-1"
                                               parentId={0}
                                             />

--- a/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/CVEs/__snapshots__/CVEsTableToolbar.test.js.snap
@@ -546,7 +546,7 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
             "onSetPage": [Function],
             "ouiaId": "pagination-top",
             "page": 1,
-            "perPage": 1,
+            "perPage": 20,
           }
         }
       >
@@ -2507,7 +2507,7 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                         ouiaId="pagination-top"
                         ouiaSafe={true}
                         page={1}
-                        perPage={1}
+                        perPage={20}
                         perPageComponent="div"
                         perPageOptions={
                           [
@@ -2595,7 +2595,7 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                             onPerPageSelect={[Function]}
                             optionsToggle=""
                             page={0}
-                            perPage={1}
+                            perPage={20}
                             perPageComponent="div"
                             perPageOptions={
                               [
@@ -2637,13 +2637,22 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                                      per page
                                   </DropdownItem>,
                                   <DropdownItem
-                                    className=""
+                                    className="pf-m-selected"
                                     component="button"
                                     data-action="per-page-20"
                                     onClick={[Function]}
                                   >
                                     20
                                      per page
+                                    <div
+                                      className="pf-c-options-menu__menu-item-icon"
+                                    >
+                                      <CheckIcon
+                                        color="currentColor"
+                                        noVerticalAlign={false}
+                                        size="sm"
+                                      />
+                                    </div>
                                   </DropdownItem>,
                                   <DropdownItem
                                     className=""
@@ -3028,7 +3037,7 @@ exports[`CVEsTableToolbar Should render without errors 1`] = `
                             pagesTitle=""
                             pagesTitlePlural=""
                             paginationTitle="Pagination"
-                            perPage={1}
+                            perPage={20}
                             toFirstPage="Go to first page"
                             toLastPage="Go to last page"
                             toNextPage="Go to next page"

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -8,9 +8,10 @@ import PaginationWrapper from '../../PresentationalComponents/PaginationWrapper/
 import { EmptyStateNoCVEs } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { CVETableContext } from './SystemCves';
 import messages from '../../../Messages';
+import { DEFAULT_PAGE_SIZE } from '../../../Helpers/constants';
 
 const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
-    const { cves, methods, selectedCves, expandedRows, canEditPairStatus } = context;
+    const { cves, methods, selectedCves, expandedRows, canEditPairStatus, parameters } = context;
 
     const noCves = () => {
         return ([{
@@ -77,8 +78,7 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
                     onSelect={(canSelect && !isEmpty) ? handleOnSelect : undefined}
                     actionResolver={(!isEmpty && canEditPairStatus) &&
                         ((rowData, rowIndex) => systemCveTableRowActions(methods, entity, rowIndex.rowIndex))}
-                    sortBy={!isEmpty
-                        ? createSortBy(sortingHeader, cves.meta.sort) : undefined}
+                    sortBy={isEmpty ? undefined : createSortBy(sortingHeader, parameters.sort)}
                     onCollapse={isEmpty ? undefined : onCollapse}
                     isExpandable
                     onSort={!isEmpty ?
@@ -87,7 +87,7 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
                                 key,
                                 direction,
                                 sortingHeader,
-                                cves.meta.sort,
+                                parameters.sort,
                                 methods.apply
                             ) : undefined
                     }
@@ -103,7 +103,13 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
                 <PaginationWrapper meta={cves.meta} apply={methods.apply} />
             </Fragment>
         ) : (
-            <SkeletonTable colSize={6} rowSize={20} variant={TableVariant.compact} />
+            <SkeletonTable
+                columns={header}
+                rowSize={DEFAULT_PAGE_SIZE}
+                variant={TableVariant.compact}
+                sortBy={createSortBy([...canSelect ? [{ key: 'checkbox' }] : [], ...header], parameters.sort)}
+                isSelectable={canSelect}
+            />
         )
     );
 };

--- a/src/Components/SmartComponents/SystemCves/SystemCveTable.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTable.js
@@ -66,8 +66,8 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
     };
 
     return (
-        !cves.isLoading ? (
-            <Fragment>
+        <Fragment>
+            {!cves.isLoading ? (
                 <Table
                     isStickyHeader
                     canCollapseAll
@@ -100,17 +100,17 @@ const SystemCvesTableWithContext = ({ context, header, entity, canSelect }) => {
                         <TableBody />
                     </Fragment>
                 </Table>
-                <PaginationWrapper meta={cves.meta} apply={methods.apply} />
-            </Fragment>
-        ) : (
-            <SkeletonTable
-                columns={header}
-                rowSize={DEFAULT_PAGE_SIZE}
-                variant={TableVariant.compact}
-                sortBy={createSortBy([...canSelect ? [{ key: 'checkbox' }] : [], ...header], parameters.sort)}
-                isSelectable={canSelect}
-            />
-        )
+            ) : (
+                <SkeletonTable
+                    columns={header}
+                    rowSize={parseInt(parameters.page_size) || DEFAULT_PAGE_SIZE}
+                    variant={TableVariant.compact}
+                    sortBy={createSortBy([...canSelect ? [{ key: 'checkbox' }] : [], ...header], parameters.sort)}
+                    isSelectable={canSelect}
+                />
+            )}
+            <PaginationWrapper meta={cves.meta} apply={methods.apply} />
+        </Fragment>
     );
 };
 

--- a/src/Components/SmartComponents/SystemCves/SystemCvesTable.test.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCvesTable.test.js
@@ -53,7 +53,7 @@ const mockContext = {
 
         }
     }, SYSTEM_DETAILS_HEADER),
-    params: {},
+    parameters: {},
     selectedCves: [{ id: 'CVE-2019-6454', attributes: {} }],
     systemCVEs: { payload: { data: [{ id: 'CVE-2019-6454' }]} },
     expandedRows: ['CVE-2019-6454'],

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -236,7 +236,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
           "selectCves": [MockFunction],
           "showStatusModal": [MockFunction],
         },
-        "params": {},
+        "parameters": {},
         "selectedCves": [
           {
             "attributes": {},

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -25,7 +25,8 @@ import {
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
     PERMISSIONS,
     ANSIBLE_REMEDIATION,
-    RULE_PRESENCE_OPTIONS
+    RULE_PRESENCE_OPTIONS,
+    DEFAULT_PAGE_SIZE
 } from '../../../Helpers/constants';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -234,7 +235,7 @@ const SystemsExposedTable = ({
                                         inventoryEntitiesReducer(SYSTEMS_EXPOSED_HEADER),
                                         {
                                             page: Number(parameters.page || 1),
-                                            perPage: 20,
+                                            perPage: DEFAULT_PAGE_SIZE,
                                             ...(parameters.sort && {
                                                 sortBy: {
                                                     key: parameters.sort.replace(/^-/, ''),

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -2,7 +2,13 @@ import React, { useEffect, useState, Fragment, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import { PERMISSIONS, SYSTEMS_ALLOWED_PARAMS, SYSTEMS_DEFAULT_FILTERS, SYSTEMS_FILTER_PARAMS } from '../../../Helpers/constants';
+import {
+    DEFAULT_PAGE_SIZE,
+    PERMISSIONS,
+    SYSTEMS_ALLOWED_PARAMS,
+    SYSTEMS_DEFAULT_FILTERS,
+    SYSTEMS_FILTER_PARAMS
+} from '../../../Helpers/constants';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { systemTableRowActions } from '../../../Helpers/CVEHelper';
@@ -198,7 +204,7 @@ const SystemsPage = () => {
                                                 inventoryEntitiesReducer(filteredColumns),
                                                 {
                                                     page: Number(parameters.page || 1),
-                                                    perPage: Number(parameters.page_size || 20),
+                                                    perPage: Number(parameters.page_size || DEFAULT_PAGE_SIZE),
                                                     ...(parameters.sort && {
                                                         sortBy: {
                                                             key: parameters.sort.replace(/^-/, ''),

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -581,6 +581,7 @@ export const VULNERABILITIES_HEADER = [
                 />
             </Tooltip>
         </span>,
+        dataLabel: intl.formatMessage(messages.advisory),
         key: 'advisory_available',
         transforms: [sortable, wrappable],
         isShownByDefault: true

--- a/src/Store/Reducers/CVEDetailsPageStore.js
+++ b/src/Store/Reducers/CVEDetailsPageStore.js
@@ -1,12 +1,12 @@
 import Immutable from 'seamless-immutable';
 import * as ActionTypes from '../ActionTypes';
 import { applyGlobalFilter } from './reducersHelper';
-import { SYSTEMS_EXPOSED_HEADER } from '../../Helpers/constants';
+import { DEFAULT_PAGE_SIZE, SYSTEMS_EXPOSED_HEADER } from '../../Helpers/constants';
 
 export const initialState = Immutable({
     parameters: {
         page: 1,
-        page_size: 20,
+        page_size: DEFAULT_PAGE_SIZE,
         selectedHosts: [],
         status_id: undefined,
         sort: '-updated'

--- a/src/Store/Reducers/InventoryEntitiesReducer.js
+++ b/src/Store/Reducers/InventoryEntitiesReducer.js
@@ -1,5 +1,6 @@
 import { selectRows } from './reducersHelper';
 import * as ActionTypes from '../ActionTypes';
+import { DEFAULT_PAGE_SIZE } from '../../Helpers/constants';
 
 export const initialState = {
     columns: [],
@@ -14,7 +15,7 @@ export const initialState = {
         direction: 'desc'
     },
     page: 1,
-    perPage: 20,
+    perPage: DEFAULT_PAGE_SIZE,
     selectedRows: [],
     selectedRowsCount: 0
 };

--- a/src/Store/Reducers/SystemCvesStore.js
+++ b/src/Store/Reducers/SystemCvesStore.js
@@ -6,13 +6,13 @@ import {
     FETCH_SYSTEM_CVE_LIST,
     SELECT_SYSTEM_CVE
 } from '../ActionTypes';
-import { SYSTEM_DETAILS_HEADER } from '../../Helpers/constants';
+import { DEFAULT_PAGE_SIZE, SYSTEM_DETAILS_HEADER } from '../../Helpers/constants';
 import { isTimestampValid } from './reducersHelper';
 
 export const initialState = {
     parameters: {
         page: 1,
-        page_size: 20,
+        page_size: DEFAULT_PAGE_SIZE,
         sort: '-public_date'
     },
     cveList: {
@@ -118,7 +118,7 @@ export const SystemCvesStore = (state = initialState, action) => {
             newState.expandedRows = [];
             newState.parameters = {
                 page: 1,
-                page_size: 20
+                page_size: DEFAULT_PAGE_SIZE
             };
 
             return newState;

--- a/src/Store/Reducers/SystemsPageStore.js
+++ b/src/Store/Reducers/SystemsPageStore.js
@@ -1,19 +1,19 @@
 import * as ActionTypes from '../ActionTypes';
 import { error, applyGlobalFilter } from './reducersHelper';
-import { SYSTEMS_DEFAULT_FILTERS, SYSTEMS_HEADER } from './../../Helpers/constants';
+import { DEFAULT_PAGE_SIZE, SYSTEMS_DEFAULT_FILTERS, SYSTEMS_HEADER } from './../../Helpers/constants';
 
 export const initialState = {
     isLoading: true,
     payload: {},
     metadata: {
         page: 1,
-        limit: 20,
+        limit: DEFAULT_PAGE_SIZE,
         offet: 0,
         total_items: 0
     },
     params: {
         page: 1,
-        page_size: 20,
+        page_size: DEFAULT_PAGE_SIZE,
         sort: '-updated',
         ...SYSTEMS_DEFAULT_FILTERS
     },


### PR DESCRIPTION
Includes partial fix to https://issues.redhat.com/browse/VULN-2768

- Fix Remediation column being on two lines in CVE detail table in mobile view
![Screenshot from 2023-08-16 17-52-36](https://github.com/RedHatInsights/vulnerability-ui/assets/8426204/fd927138-4af5-4952-8931-b693db1dc5c9)
- Fix Advisory column being titled "column-9" in mobile view
![Screenshot from 2023-08-16 17-53-49](https://github.com/RedHatInsights/vulnerability-ui/assets/8426204/67ec0961-3672-46dc-9942-0b233fdb7c9b)
- [Refactor] Use DEFAULT_PAGE_SIZE instead of hardcoded 20 in tables
- Improved CVE list and System CVE list tables loading skeletons:
  - Number of rows reflects loaded table
  - Table header reflects loaded table
  - Current sort reflects loaded table
  - Selecting checkboxes reflect loaded table
  - Mobile view shows header titles instead of "column-n"

## Before
![Screenshot from 2023-08-16 17-58-48](https://github.com/RedHatInsights/vulnerability-ui/assets/8426204/67b10389-86f6-4b13-8b03-497c90a28987)

## After
![Screenshot from 2023-08-16 17-58-35](https://github.com/RedHatInsights/vulnerability-ui/assets/8426204/fcdf6aa4-6734-43a4-99e4-73783360c881)
