### PR TITLE
fix(ESSNTL-5048): Add param for Inventory

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -835,7 +835,8 @@ export const CVES_ALLOWED_PARAMS = [
     'sap_system',
     'remediation',
     'ansible',
-    'mssql'
+    'mssql',
+    'appName'
 ];
 
 export const SYSTEMS_EXPOSED_ALLOWED_PARAMS = [


### PR DESCRIPTION
[ESSNTL-5048](https://issues.redhat.com/browse/ESSNTL-5048)

Added `appName` to allowed query params so the Vulnerability Tab in Inventory Detail can work properly

[Related Inventory PR](https://github.com/RedHatInsights/insights-inventory-frontend/pull/1992)