### PR TITLE
Fix Reports page crash when CVEs without errata FF was off

### DIFF
--- a/src/Components/PresentationalComponents/Filters/CustomFilters/CheckboxCustomFilter.js
+++ b/src/Components/PresentationalComponents/Filters/CustomFilters/CheckboxCustomFilter.js
@@ -12,7 +12,8 @@ const CheckboxCustomFilter = ({
     groups,
     filterName,
     filterId,
-    allSelectedText
+    allSelectedText,
+    isHidden
 }) => {
     const [isOpen, setOpen] = useState(false);
 
@@ -35,7 +36,7 @@ const CheckboxCustomFilter = ({
             ? allSelectedText ?? intl.formatMessage(messages.optionsAll) : itemsString}`;
     };
 
-    return (
+    return isHidden ? undefined : (
         <Select
             variant="checkbox"
             aria-label="Select Input"
@@ -81,7 +82,8 @@ CheckboxCustomFilter.propTypes = {
         value: propTypes.string.isRequired,
         renderFunc: propTypes.oneOfType([propTypes.string, propTypes.node])
     })),
-    groups: propTypes.object
+    groups: propTypes.object,
+    isHidden: propTypes.bool
 };
 
 export default CheckboxCustomFilter;

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -59,7 +59,7 @@ const ReportConfigModal = ({
         'status_id',
         'publish_date',
         'rhel_version',
-        ...cvesWithoutErrata ? ['advisory_available'] : []
+        'advisory_available'
     ];
 
     const handleCheckboxChange = (parameter, value) => {
@@ -131,27 +131,26 @@ const ReportConfigModal = ({
                     label={intl.formatMessage(messages.customReportFilterDataByLabel)}
                 >
                     <div className="custom-report-select-wrapper">
-                        {ACTIVE_FILTERS.map((filterId) => {
-                            return (
-                                CVE_REPORT_FILTERS[filterId]?.component({
-                                    ...CVE_REPORT_FILTERS[filterId],
-                                    filterData,
-                                    setFilterData,
-                                    selectProps: {
-                                        className: 'pf-u-mr-sm pf-u-mb-sm',
-                                        ...CVE_REPORT_FILTERS[filterId].selectProps
-                                    },
-                                    options: CVE_REPORT_FILTERS[filterId].items,
-                                    filterId,
-                                    filterName: CVE_REPORT_FILTERS[filterId].title,
-                                    ...(filterId === 'rhel_version' ? {
-                                        // overriding parameters specific to the OS filter
-                                        options: Object.values(osGroups).flat(),
-                                        groups: osGroups
-                                    } : {})
-                                })
-                            );
-                        })}
+                        {ACTIVE_FILTERS.map((filterId) =>
+                            CVE_REPORT_FILTERS[filterId]?.component({
+                                ...CVE_REPORT_FILTERS[filterId],
+                                filterData,
+                                setFilterData,
+                                selectProps: {
+                                    className: 'pf-u-mr-sm pf-u-mb-sm',
+                                    ...CVE_REPORT_FILTERS[filterId].selectProps
+                                },
+                                isHidden: !cvesWithoutErrata && filterId === 'advisory_available',
+                                options: CVE_REPORT_FILTERS[filterId].items,
+                                filterId,
+                                filterName: CVE_REPORT_FILTERS[filterId].title,
+                                ...(filterId === 'rhel_version' ? {
+                                    // overriding parameters specific to the OS filter
+                                    options: Object.values(osGroups).flat(),
+                                    groups: osGroups
+                                } : {})
+                            })
+                        )}
                     </div>
                 </FormGroup>
                 <FormGroup


### PR DESCRIPTION
Fixed the following bug:
1. Make sure CVEs without advisories are shown (use the button in CVE list page toolbar kebab)
2. Go to Reports page
3. The page crashes after a moment