### PR TITLE
Update Advisory column tooltip on detail pages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,7 +11,6 @@
   "advisory": "Advisory",
   "advisoryColumnTooltip": "CVEs with the Security rule label will appear in this list regardless of whether or not an advisory is available. For standard CVEs, advisories may not exist for all major/minor versions of RHEL. Click on the CVE to determine which OS versions have supported advisories.",
   "advisoryName": "Advisory name",
-  "advisoryTooltip": "An advisory is not available. For more information, view this CVE in the {link}",
   "affectsSystems": "Systems",
   "ansibleRemediationTooltip": "You can create Ansible Playbooks and remediate your systems with Remediation application",
   "associatedCves": "Associated CVEs:",

--- a/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
+++ b/src/Components/PresentationalComponents/AdvisoryColumn/AdvisoryColumn.js
@@ -9,7 +9,7 @@ import { createRHDBLink } from '../../../Helpers/CVEHelper';
 import { useParams } from 'react-router-dom';
 
 const AdvisoryColumn = ({ cve, advisoriesList, linkToCustomerPortal }) => {
-    let { cve: cveName } = useParams();
+    const { cve: cveName } = useParams();
 
     return (
         advisoriesList?.length > 0
@@ -26,30 +26,29 @@ const AdvisoryColumn = ({ cve, advisoriesList, linkToCustomerPortal }) => {
                     >
                         {advisory}
                     </a>
-                ).reduce((prev, curr, index) => [prev, ', ', <br key={index}/>, curr])
+                ).reduce((prev, curr, index) => [prev, ', ', <br key={index} />, curr])
             ) : (
                 <Fragment>
                     <FormattedMessage {...messages.notAvailable} />
                     <Tooltip exitDelay={2000} appendTo={document.querySelector('.vulnerability')} content={
-                        <FormattedMessage
-                            {...messages.advisoryTooltip}
-                            values={
-                                {
-                                    link: createRHDBLink(
-                                        cve ?? cveName,
-                                        messages.rhCVEdb,
-                                        { className: 'toolip-link--embeded' }
-                                    )
-                                }
+                        <Fragment>
+                            <FormattedMessage {...messages.fixableTooltip} />
+                            <br />
+                            {
+                                createRHDBLink(
+                                    cve ?? cveName,
+                                    messages.rhCVEdb,
+                                    { className: 'toolip-link--embeded' }
+                                )
                             }
-                        />
+                        </Fragment>
                     }>
                         <OutlinedQuestionCircleIcon
                             className="pf-u-ml-xs"
                             color="var(--pf-global--Color--200)"
                         />
                     </Tooltip>
-                </Fragment>
+                </Fragment >
             )
     );
 };

--- a/src/Components/PresentationalComponents/TableColumns/RemediationColumn.js
+++ b/src/Components/PresentationalComponents/TableColumns/RemediationColumn.js
@@ -5,8 +5,12 @@ import { Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { FormattedMessage } from 'react-intl';
 import messages from '../../../Messages';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { createRHDBLink } from '../../../Helpers/CVEHelper';
+import { useParams } from 'react-router-dom';
 
-const RemediationColumn = ({ fixable }) => {
+const RemediationColumn = ({ cve, fixable }) => {
+    const { cve: cveName } = useParams();
+
     switch (fixable) {
         case 0: {
             return (
@@ -15,7 +19,17 @@ const RemediationColumn = ({ fixable }) => {
                     <Tooltip
                         appendTo={document.querySelector('.vulnerability')}
                         content={
-                            <FormattedMessage {...messages.fixableTooltip} />
+                            <Fragment>
+                                <FormattedMessage {...messages.fixableTooltip} />
+                                <br />
+                                {
+                                    createRHDBLink(
+                                        cve ?? cveName,
+                                        messages.rhCVEdb,
+                                        { className: 'toolip-link--embeded' }
+                                    )
+                                }
+                            </Fragment>
                         }
                     >
                         <OutlinedQuestionCircleIcon
@@ -53,6 +67,7 @@ const RemediationColumn = ({ fixable }) => {
 };
 
 RemediationColumn.propTypes = {
+    cve: PropType.string,
     fixable: PropType.number.isRequired
 };
 

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -7721,33 +7721,32 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                     <Tooltip
                                                       appendTo={null}
                                                       content={
-                                                        <Memo(MemoizedFormattedMessage)
-                                                          defaultMessage="An advisory is not available. For more information, view this CVE in the {link}"
-                                                          description="advisory column tooltip"
-                                                          id="advisoryTooltip"
-                                                          values={
-                                                            {
-                                                              "link": <a
-                                                                className="toolip-link--embeded"
-                                                                href="https://access.redhat.com/security/cve/CVE-2019-6454"
-                                                                rel="noopener noreferrer"
-                                                                target="_blank"
-                                                              >
-                                                                <Memo(MemoizedFormattedMessage)
-                                                                  defaultMessage="Red Hat CVE database"
-                                                                  description="Red Hat CVE database"
-                                                                  id="rhCVEdb"
-                                                                />
-                                                                <ExternalLinkAltIcon
-                                                                  className="pf-u-ml-sm"
-                                                                  color="currentColor"
-                                                                  noVerticalAlign={false}
-                                                                  size="sm"
-                                                                />
-                                                              </a>,
-                                                            }
-                                                          }
-                                                        />
+                                                        <React.Fragment>
+                                                          <Memo(MemoizedFormattedMessage)
+                                                            defaultMessage="Red Hat has not published an Advisory which applies to this system and OS version which addresses this CVE. There are multiple reasons why this may be the case."
+                                                            description="Tooltip for not available"
+                                                            id="systems.row.fixable.tooltip"
+                                                          />
+                                                          <br />
+                                                          <a
+                                                            className="toolip-link--embeded"
+                                                            href="https://access.redhat.com/security/cve/CVE-2019-6454"
+                                                            rel="noopener noreferrer"
+                                                            target="_blank"
+                                                          >
+                                                            <Memo(MemoizedFormattedMessage)
+                                                              defaultMessage="Red Hat CVE database"
+                                                              description="Red Hat CVE database"
+                                                              id="rhCVEdb"
+                                                            />
+                                                            <ExternalLinkAltIcon
+                                                              className="pf-u-ml-sm"
+                                                              color="currentColor"
+                                                              noVerticalAlign={false}
+                                                              size="sm"
+                                                            />
+                                                          </a>
+                                                        </React.Fragment>
                                                       }
                                                       exitDelay={2000}
                                                     >
@@ -7795,33 +7794,32 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                             <TooltipContent
                                                               isLeftAligned={false}
                                                             >
-                                                              <Memo(MemoizedFormattedMessage)
-                                                                defaultMessage="An advisory is not available. For more information, view this CVE in the {link}"
-                                                                description="advisory column tooltip"
-                                                                id="advisoryTooltip"
-                                                                values={
-                                                                  {
-                                                                    "link": <a
-                                                                      className="toolip-link--embeded"
-                                                                      href="https://access.redhat.com/security/cve/CVE-2019-6454"
-                                                                      rel="noopener noreferrer"
-                                                                      target="_blank"
-                                                                    >
-                                                                      <Memo(MemoizedFormattedMessage)
-                                                                        defaultMessage="Red Hat CVE database"
-                                                                        description="Red Hat CVE database"
-                                                                        id="rhCVEdb"
-                                                                      />
-                                                                      <ExternalLinkAltIcon
-                                                                        className="pf-u-ml-sm"
-                                                                        color="currentColor"
-                                                                        noVerticalAlign={false}
-                                                                        size="sm"
-                                                                      />
-                                                                    </a>,
-                                                                  }
-                                                                }
-                                                              />
+                                                              <React.Fragment>
+                                                                <Memo(MemoizedFormattedMessage)
+                                                                  defaultMessage="Red Hat has not published an Advisory which applies to this system and OS version which addresses this CVE. There are multiple reasons why this may be the case."
+                                                                  description="Tooltip for not available"
+                                                                  id="systems.row.fixable.tooltip"
+                                                                />
+                                                                <br />
+                                                                <a
+                                                                  className="toolip-link--embeded"
+                                                                  href="https://access.redhat.com/security/cve/CVE-2019-6454"
+                                                                  rel="noopener noreferrer"
+                                                                  target="_blank"
+                                                                >
+                                                                  <Memo(MemoizedFormattedMessage)
+                                                                    defaultMessage="Red Hat CVE database"
+                                                                    description="Red Hat CVE database"
+                                                                    id="rhCVEdb"
+                                                                  />
+                                                                  <ExternalLinkAltIcon
+                                                                    className="pf-u-ml-sm"
+                                                                    color="currentColor"
+                                                                    noVerticalAlign={false}
+                                                                    size="sm"
+                                                                  />
+                                                                </a>
+                                                              </React.Fragment>
                                                             </TooltipContent>
                                                           </div>
                                                         }

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTable.test.js.snap
@@ -137,6 +137,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                   "title": <span>
                     <AdvisoryColumn
                       cve="CVE-2019-6454"
+                      linkToCustomerPortal={false}
                     />
                   </span>,
                 },
@@ -490,6 +491,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                 "title": <span>
                   <AdvisoryColumn
                     cve="CVE-2019-6454"
+                    linkToCustomerPortal={false}
                   />
                 </span>,
               },
@@ -3877,6 +3879,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                             "title": <span>
                               <AdvisoryColumn
                                 cve="CVE-2019-6454"
+                                linkToCustomerPortal={false}
                               />
                             </span>,
                           },
@@ -3974,6 +3977,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                             "title": <span>
                               <AdvisoryColumn
                                 cve="CVE-2019-6454"
+                                linkToCustomerPortal={false}
                               />
                             </span>,
                           },
@@ -4031,6 +4035,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "title": <span>
                                 <AdvisoryColumn
                                   cve="CVE-2019-6454"
+                                  linkToCustomerPortal={false}
                                 />
                               </span>,
                             },
@@ -4256,6 +4261,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                             "title": <span>
                               <AdvisoryColumn
                                 cve="CVE-2019-6454"
+                                linkToCustomerPortal={false}
                               />
                             </span>,
                           },
@@ -4313,6 +4319,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "title": <span>
                                 <AdvisoryColumn
                                   cve="CVE-2019-6454"
+                                  linkToCustomerPortal={false}
                                 />
                               </span>,
                             },
@@ -5101,6 +5108,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "title": <span>
                                 <AdvisoryColumn
                                   cve="CVE-2019-6454"
+                                  linkToCustomerPortal={false}
                                 />
                               </span>,
                             },
@@ -5158,6 +5166,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 "title": <span>
                                   <AdvisoryColumn
                                     cve="CVE-2019-6454"
+                                    linkToCustomerPortal={false}
                                   />
                                 </span>,
                               },
@@ -5407,6 +5416,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                               "title": <span>
                                 <AdvisoryColumn
                                   cve="CVE-2019-6454"
+                                  linkToCustomerPortal={false}
                                 />
                               </span>,
                             },
@@ -5464,6 +5474,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 "title": <span>
                                   <AdvisoryColumn
                                     cve="CVE-2019-6454"
+                                    linkToCustomerPortal={false}
                                   />
                                 </span>,
                               },
@@ -5691,6 +5702,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                 "title": <span>
                                   <AdvisoryColumn
                                     cve="CVE-2019-6454"
+                                    linkToCustomerPortal={false}
                                   />
                                 </span>,
                               },
@@ -5748,6 +5760,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                   "title": <span>
                                     <AdvisoryColumn
                                       cve="CVE-2019-6454"
+                                      linkToCustomerPortal={false}
                                     />
                                   </span>,
                                 },
@@ -6556,6 +6569,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                       "title": <span>
                                         <AdvisoryColumn
                                           cve="CVE-2019-6454"
+                                          linkToCustomerPortal={false}
                                         />
                                       </span>,
                                     },
@@ -6613,6 +6627,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "title": <span>
                                           <AdvisoryColumn
                                             cve="CVE-2019-6454"
+                                            linkToCustomerPortal={false}
                                           />
                                         </span>,
                                       },
@@ -6790,6 +6805,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                         "title": <span>
                                           <AdvisoryColumn
                                             cve="CVE-2019-6454"
+                                            linkToCustomerPortal={false}
                                           />
                                         </span>,
                                       },
@@ -6847,6 +6863,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                           "title": <span>
                                             <AdvisoryColumn
                                               cve="CVE-2019-6454"
+                                              linkToCustomerPortal={false}
                                             />
                                           </span>,
                                         },
@@ -7710,6 +7727,7 @@ exports[`SystemCvesTable Should match snapshots 1`] = `
                                                 >
                                                   <AdvisoryColumn
                                                     cve="CVE-2019-6454"
+                                                    linkToCustomerPortal={false}
                                                   >
                                                     <FormattedMessage
                                                       defaultMessage="Not available"

--- a/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
+++ b/src/Components/SmartComponents/SystemCves/__snapshots__/SystemCvesTableToolbar.test.js.snap
@@ -152,6 +152,7 @@ exports[`SystemCvesTableToolbar Should render without errors 1`] = `
                           "title": <span>
                             <AdvisoryColumn
                               cve="CVE-2019-6454"
+                              linkToCustomerPortal={false}
                             />
                           </span>,
                         },

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -6,7 +6,7 @@ import { processDate } from '@redhat-cloud-services/frontend-components-utilitie
 import { flatMap } from 'lodash';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BUSINESS_RISK_OPTIONS, STATUS_OPTIONS, CVES_PATH, CUSTOMER_PORTAL_CVE_PATH } from './constants';
+import { BUSINESS_RISK_OPTIONS, STATUS_OPTIONS, CVES_PATH, CUSTOMER_PORTAL_CVE_PATH, MANUAL_REMEDIATION } from './constants';
 import SnippetWithPopover from '../Components/PresentationalComponents/Snippets/SnippetWithPopover';
 import { FormattedMessage } from 'react-intl';
 import messages from '../Messages';
@@ -171,7 +171,7 @@ export function createCveListBySystem(systemId, cveList, columns, linkToCustomer
                     <AdvisoryColumn
                         cve={row?.id}
                         advisoriesList={row?.attributes?.advisories_list}
-                        linkToCustomerPortal={linkToCustomerPortal}
+                        linkToCustomerPortal={linkToCustomerPortal || row.attributes.remediation === MANUAL_REMEDIATION}
                     />
                 </span>
             ),

--- a/src/Helpers/VulnerabilityHelper.js
+++ b/src/Helpers/VulnerabilityHelper.js
@@ -191,7 +191,7 @@ export function createCveListBySystem(systemId, cveList, columns, linkToCustomer
             ),
             remediation: (
                 <span key="remediation-column">
-                    <RemediationColumn fixable={row.attributes.remediation} />
+                    <RemediationColumn cve={row.attributes.synopsis} fixable={row.attributes.remediation} />
                 </span>
             )
         });

--- a/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
+++ b/src/Helpers/__snapshots__/VulnerabilityHelper.test.js.snap
@@ -328,6 +328,7 @@ exports[`VulnerabilitiesHelper test function createCveListBySystem() with cveLis
           "title": <span>
             <AdvisoryColumn
               cve="CVE-2019-6116"
+              linkToCustomerPortal={false}
             />
           </span>,
         },

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -320,6 +320,8 @@ export const BUSINESS_RISK_OPTIONS = [
     }
 ];
 
+export const MANUAL_REMEDIATION = 1;
+
 export const REMEDIATION_OPTIONS = [
     {
         value: '2',
@@ -637,8 +639,8 @@ export const SYSTEMS_EXPOSED_HEADER = [
         renderFunc: (
             value,
             _id,
-            { advisories_list: advisoriesList }
-        ) => <AdvisoryColumn advisoriesList={advisoriesList} />,
+            { advisories_list: advisoriesList, remediation }
+        ) => <AdvisoryColumn advisoriesList={advisoriesList} linkToCustomerPortal={remediation === MANUAL_REMEDIATION} />,
         isShownByDefault: true
     },
     {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -676,16 +676,6 @@ export const SYSTEMS_EXPOSED_HEADER = [
         isShownByDefault: false
     }
 ];
-export const SYSTEMS_ADVISORY_COLUMN =
-{
-    key: 'advisory',
-    title: intl.formatMessage(messages.advisory),
-    renderFunc: (
-        value,
-        _id,
-        { cve, advisories_list: advisoriesList }
-    ) => <AdvisoryColumn cve={cve} advisoriesList={advisoriesList} />
-};
 
 export const SYSTEMS_HEADER = [
     {

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -67,11 +67,6 @@ export default defineMessages({
         description: 'Not available',
         defaultMessage: 'Not available'
     },
-    advisoryTooltip: {
-        id: 'advisoryTooltip',
-        description: 'advisory column tooltip',
-        defaultMessage: 'An advisory is not available. For more information, view this CVE in the {link}'
-    },
     rhCVEdb: {
         id: 'rhCVEdb',
         description: 'Red Hat CVE database',


### PR DESCRIPTION
https://issues.redhat.com/browse/VULN-2677
https://issues.redhat.com/browse/VULN-2673
https://issues.redhat.com/browse/VULN-2578

## To test:
1. Find CVE that has Advisory not available
2. Go to column management and enable Remediation column
3. Make sure tooltips on question mark icons in columns are as in mockups (except the link text, that should not say Documentation)