### PR TITLE
feat(ESSNTL-3717): Integrate groups with /systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.7.0",
         "@redhat-cloud-services/host-inventory-client": "^1.0.116",
-        "@redhat-cloud-services/vulnerabilities-client": "^1.2.5",
+        "@redhat-cloud-services/vulnerabilities-client": "^1.2.7",
         "@scalprum/react-core": "^0.1.9",
         "@unleash/proxy-client-react": "^3.6.0",
         "axios": "^1.4.0",
@@ -5060,9 +5060,9 @@
       "integrity": "sha512-1aqJcgQZq4uih+LxRpVJQblt2x4o/hlrqSZMYFhWyTLgnVNhJ8Y7B5pwoVjpA5PCE1fBNahrydVwugEKMsDDtg=="
     },
     "node_modules/@redhat-cloud-services/vulnerabilities-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.2.5.tgz",
-      "integrity": "sha512-A/dgGs8vnP+KGCwUv8Go/euqyNZqF7AWmL2S8tMumrrSQQqa1gNADb/wHN/9RWPUzLg9MFOcd2NHcVNs8vgdeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.2.7.tgz",
+      "integrity": "sha512-apeEss3qJwGLWHzmCAVnvgxRW1bsw3Bgw59jXHG6UjGSV8xlITeTh3H6gyVCD+KWpKH1BBwRLi2Dbucbn2b+2A==",
       "dependencies": {
         "axios": "^0.27.2"
       }
@@ -30659,9 +30659,9 @@
       "integrity": "sha512-1aqJcgQZq4uih+LxRpVJQblt2x4o/hlrqSZMYFhWyTLgnVNhJ8Y7B5pwoVjpA5PCE1fBNahrydVwugEKMsDDtg=="
     },
     "@redhat-cloud-services/vulnerabilities-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.2.5.tgz",
-      "integrity": "sha512-A/dgGs8vnP+KGCwUv8Go/euqyNZqF7AWmL2S8tMumrrSQQqa1gNADb/wHN/9RWPUzLg9MFOcd2NHcVNs8vgdeA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/vulnerabilities-client/-/vulnerabilities-client-1.2.7.tgz",
+      "integrity": "sha512-apeEss3qJwGLWHzmCAVnvgxRW1bsw3Bgw59jXHG6UjGSV8xlITeTh3H6gyVCD+KWpKH1BBwRLi2Dbucbn2b+2A==",
       "requires": {
         "axios": "^0.27.2"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
     "@redhat-cloud-services/frontend-components-utilities": "^3.7.0",
     "@redhat-cloud-services/host-inventory-client": "^1.0.116",
-    "@redhat-cloud-services/vulnerabilities-client": "^1.2.5",
+    "@redhat-cloud-services/vulnerabilities-client": "^1.2.7",
     "@scalprum/react-core": "^0.1.9",
     "@unleash/proxy-client-react": "^3.6.0",
     "axios": "^1.4.0",

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -240,7 +240,8 @@ export function getSystems(apiProps) {
         ...systemsParams,
         'report',
         'ansible',
-        'mssql'
+        'mssql',
+        'group_names'
     ];
     let parameterArray = constructParameters(apiProps, parameterNames);
     let result = api.getSystemsList(...parameterArray);

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -48,7 +48,7 @@ export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
 
     const getEntities = async (
         _items,
-        { orderBy, orderDirection, page, per_page: perPage, vulnerabilityParams }
+        { orderBy, orderDirection, page, per_page: perPage, vulnerabilityParams, filters }
     ) => {
         const sort = `${orderDirection === 'ASC' ? '' : '-'}${orderBy}`;
 
@@ -56,7 +56,10 @@ export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
             ...vulnerabilityParams,
             page,
             page_size: perPage,
-            sort
+            sort,
+            ...filters?.hostGroupFilter ? {
+                group_names: filters.hostGroupFilter.join(',')
+            } : {}
         };
 
         setUrlParams?.({ ...params });

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -699,17 +699,8 @@ export const SYSTEMS_HEADER = [
         title: 'Group',
         inventoryGroupsFeatureFlag: true,
         isShownByDefault: true,
-        renderFunc: (data, value, groups) =>
-            isEmpty(groups?.groups) ? (
-                'N/A'
-            ) : (
-                //TODO: replace <a> with Link component when react router is updated
-                <a href={`/insights/inventory/groups/${groups?.groups[0].id}`}>
-                    {
-                        groups?.groups[0].name // currently, one group at maximum is supported
-                    }
-                </a>
-            )
+        renderFunc: (data, value, { inventory_group: group }) =>
+            isEmpty(group) ? 'N/A' : group[0].name // currently, one group at maximum is supported
     },
     {
         key: 'tags',


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3717.

This integrates the group filter and column with the /systems page. The column Group shows a group of each system: if it is not a member of any group, then 'N/A' is rendered, otherwise the name of the group. Also, users now can filter by group(s).

## How to test

Verify basic filtering by the groups, and make sure the group names are mapped correctly to each host.

## Screenshots

<img width="941" alt="Screenshot 2023-08-31 at 20 35 07" src="https://github.com/RedHatInsights/vulnerability-ui/assets/31385370/728fe1b4-e76f-43ae-90f6-04cf946edd9d">
