### PR TITLE
feat(ESSNTL-3948): Group filter on exposed table

### DIFF
--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
@@ -27,6 +27,12 @@ jest.mock('../../../Store/Actions/Actions', () => ({
     })
 }));
 
+jest.mock('@unleash/proxy-client-react', () => ( {
+    ...jest.requireActual('@unleash/proxy-client-react'),
+    useFlag: () => true, 
+    useFlagsStatus: () => ({ flagsReady: true })
+}))
+
 let state = {
     ...initialState,
     cveDetails: {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -47,6 +47,7 @@ import useSearchFilter from '../../PresentationalComponents/Filters/PrimaryToolb
 import useOsVersionFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
 import remediationFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/RemediationFilter';
 import advisoryAvailabilityFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/AdvisoryAvailabilityFilter';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 
 const SystemsExposedTable = ({
     intl, cveName, cveStatusDetails, filterRuleValues,
@@ -60,6 +61,7 @@ const SystemsExposedTable = ({
     const [isAllExpanded, setIsAllExpanded] = useState(false);
     const [StatusModal, setStatusModal] = useState(() => () => null);
     const [urlParameters, setUrlParams] = useUrlParams(SYSTEMS_EXPOSED_ALLOWED_PARAMS);
+    const inventoryGroupsEnabled = useFeatureFlag('hbi.ui.inventory-groups');
 
     const items = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
     const totalItems = useSelector(({ entities }) => entities?.total);
@@ -76,13 +78,14 @@ const SystemsExposedTable = ({
     const columns = useSelector(
         ({ CVEDetailsPageStore }) => CVEDetailsPageStore.columns
     );
+    const filteredColumns = columns.filter(column => !column.inventoryGroupsFeatureFlag || inventoryGroupsEnabled);
 
     const apply = (params) => dispatch(changeExposedSystemsParameters(params));
 
     const handleSelect = (payload, selecting) => dispatch(selectRows(payload, selecting));
 
     const [ColumnManagementModal, setColumnManagementModalOpen]
-        = useColumnManagement(columns, newColumns => dispatch(changeColumnsCveDetail(newColumns)));
+        = useColumnManagement(filteredColumns, newColumns => dispatch(changeColumnsCveDetail(newColumns)));
 
     useEffect(() => apply(urlParameters), []);
 
@@ -138,7 +141,7 @@ const SystemsExposedTable = ({
     useEffect(() => setColumnCount(columnCounter + 1), [columns]);
 
     const mergeColumns = inventoryColumns => {
-        return columns
+        return filteredColumns
             .filter(column => column.isShown ?? column.isShownByDefault)
             .map(column => ({ ...inventoryColumns.find(({ key }) => column.key === key), ...column }));
     };
@@ -277,7 +280,7 @@ const SystemsExposedTable = ({
                             getEntities={getEntities}
                             hasCheckbox={canSelect && totalItems !== 0}
                             showActions={totalItems !== 0}
-                            hideFilters={{ all: true }}
+                            hideFilters={{ all: true, hostGroupFilter: false }}
                             noSystemsTable={<EmptyStateNoSystems />}
                             actionsConfig={{
                                 actions: kebabOptions,

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.test.js
@@ -21,6 +21,12 @@ jest.mock("../../../Helpers/DownloadReport", () => ({
     exec: jest.fn()
 }));
 
+jest.mock('@unleash/proxy-client-react', () => ( {
+    ...jest.requireActual('@unleash/proxy-client-react'),
+    useFlag: () => true, 
+    useFlagsStatus: () => ({ flagsReady: true })
+}))
+
 const state = {
     ...initialState
 };

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -133,7 +133,8 @@ export function getAffectedSystemsByCVE({ id, ...apiProps }) {
         ...systemsByCVEparams,
         'report',
         'ansible',
-        'mssql'
+        'mssql',
+        'group_names'
     ];
 
     let parameterArray = constructParameters(apiProps, parameterNames);

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -615,6 +615,13 @@ export const SYSTEMS_EXPOSED_HEADER = [
 
     },
     {
+        key: 'groups',
+        isShownByDefault: true,
+        inventoryGroupsFeatureFlag: true,
+        renderFunc: (data, value, { inventory_group: group }) =>
+            isEmpty(group) ? 'N/A' : group[0].name // currently, one group at maximum is supported
+    },
+    {
         key: 'tags',
         title: intl.formatMessage(messages.systemsColumnHeaderTags),
         props: { isStatic: true },
@@ -696,7 +703,6 @@ export const SYSTEMS_HEADER = [
     },
     {
         key: 'groups',
-        title: 'Group',
         inventoryGroupsFeatureFlag: true,
         isShownByDefault: true,
         renderFunc: (data, value, { inventory_group: group }) =>


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/ESSNTL-3948.

Add the group filter and column to the CVE affected systems page (/cve/%id).

## How to test

Check that the table shows groups for each host, and you are able to filter by groups.

## Screenshots


https://github.com/RedHatInsights/vulnerability-ui/assets/31385370/1b6b41ce-bab4-4eac-b69f-0441d8d7af7a

