### PR TITLE
fix(ESSNTL-3948): Wrap the group column value in span

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -619,7 +619,9 @@ export const SYSTEMS_EXPOSED_HEADER = [
         isShownByDefault: true,
         inventoryGroupsFeatureFlag: true,
         renderFunc: (data, value, { inventory_group: group }) =>
-            isEmpty(group) ? 'N/A' : group[0].name // currently, one group at maximum is supported
+            <span>
+                {isEmpty(group) ? 'N/A' : group[0].name} {/* currently, one group at maximum is supported */}
+            </span>
     },
     {
         key: 'tags',


### PR DESCRIPTION
This helps to avoid the run-time error while build the table with security rules.

## How to test

Find a CVE with a security rule, and check that you are able to open the CVE's details page normally, and the systems table should be loaded without issues.