### PR TITLE
fix(SystemsCVES): RHINENG-1872 - Remove obsolete Router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React, { useEffect, Fragment, useState } from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
 import SystemCVEs from './Components/SmartComponents/SystemCves/SystemCves';
 import { SystemCvesStore } from './Store/Reducers/SystemCvesStore';
 import PropTypes from 'prop-types';
@@ -21,15 +20,13 @@ const WrappedSystemCves = ({ getRegistry, ...props }) => {
         setWrapper(() => getRegistry ? Provider : Fragment);
     }, []);
 
-    return <Router>
-        {
-            Wrapper ? <Wrapper {...getRegistry && { store: getRegistry()?.getStore() }}>
-                <SystemCVEs canExport={canExport} canEditPairStatus={canEditPairStatus} {...props}/>
-            </Wrapper> : <Bullseye>
-                <Spinner size="xl" />
-            </Bullseye>
-        }
-    </Router>;
+    return (
+        Wrapper ? <Wrapper {...getRegistry && { store: getRegistry()?.getStore() }}>
+            <SystemCVEs canExport={canExport} canEditPairStatus={canEditPairStatus} {...props} />
+        </Wrapper> : <Bullseye>
+            <Spinner size="xl" />
+        </Bullseye>
+    );
 };
 
 WrappedSystemCves.propTypes = {


### PR DESCRIPTION
This removes the now obsolete `Router` component, since the router context is now provided by the chrome router.