### PR TITLE
fix(SystemsTable): Fix resetting to default filters

### DIFF
--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -102,7 +102,7 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
 
 export const removeFilters = (chips, apply, reset = false, defaultFilters = {}) => {
     if (reset) {
-        apply({ ...defaultFilters, page: 1 });
+        apply({ ...defaultFilters, page: 1, reset });
         return;
     }
 

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -102,7 +102,6 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
 
 export const removeFilters = (chips, apply, reset = false, defaultFilters = {}) => {
     if (reset) {
-        removeFilters(chips, apply);
         apply({ ...defaultFilters, page: 1 });
         return;
     }

--- a/src/Helpers/TableToolbarHelper.test.js
+++ b/src/Helpers/TableToolbarHelper.test.js
@@ -25,6 +25,10 @@ const mockGeneralChip = {
 const mockApply = jest.fn();
 
 describe('TableToolbarHelper', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('Should handleChangePage apply with provided page', () => {
         const testPage = 1;
         const testApply = jest.fn();
@@ -147,6 +151,12 @@ describe('TableToolbarHelper', () => {
     it('Should remove filters', () => {
         removeFilters([mockGeneralChip], mockApply);
         expect(mockApply).toHaveBeenCalledWith({ rule_presence: undefined, rule: '', page: 1 });
+    });
+
+    it('Should reset to default filters when given and reset is ture', () => {
+        removeFilters([mockGeneralChip], mockApply, true, { rule_presence: "true" });
+        expect(mockApply).toHaveBeenCalledTimes(1);
+        expect(mockApply).toHaveBeenCalledWith({ rule_presence: 'true', page: 1 });
     });
 
     it('Should remove search filters and multi value filters with only one value safely', () => {

--- a/src/Helpers/TableToolbarHelper.test.js
+++ b/src/Helpers/TableToolbarHelper.test.js
@@ -26,7 +26,7 @@ const mockApply = jest.fn();
 
 describe('TableToolbarHelper', () => {
     afterEach(() => {
-      jest.clearAllMocks();
+        jest.clearAllMocks();
     });
 
     it('Should handleChangePage apply with provided page', () => {
@@ -156,7 +156,7 @@ describe('TableToolbarHelper', () => {
     it('Should reset to default filters when given and reset is ture', () => {
         removeFilters([mockGeneralChip], mockApply, true, { rule_presence: "true" });
         expect(mockApply).toHaveBeenCalledTimes(1);
-        expect(mockApply).toHaveBeenCalledWith({ rule_presence: 'true', page: 1 });
+        expect(mockApply).toHaveBeenCalledWith({ rule_presence: 'true', page: 1, reset: true });
     });
 
     it('Should remove search filters and multi value filters with only one value safely', () => {

--- a/src/Store/Reducers/SystemsPageStore.js
+++ b/src/Store/Reducers/SystemsPageStore.js
@@ -25,13 +25,17 @@ export const initialState = {
 export const SystemsPageStore = (state = initialState, action) => {
     let newState = { ...state };
     switch (action.type) {
-        case ActionTypes.CHANGE_SYSTEMS_PARAMS:
+        case ActionTypes.CHANGE_SYSTEMS_PARAMS: {
+            const { reset, ...params } = action.payload;
             newState.params = {
-                ...newState.params,
-                ...action.payload,
+                ...!reset ? newState.params : {},
+                ...params,
                 page_size: action.payload.page_size || newState.params.page_size
             };
+
             return newState;
+        }
+
         case ActionTypes.CHANGE_COLUMNS_SYSTEM_LIST:
             return {
                 ...newState,


### PR DESCRIPTION
This fixes resetting the filters to the default filters on the Systems page.

1) Go to Vulnerability app, Systems page
2) Remove default "Systems with Vulnerability analysis enabled: Enabled systems" filter
3) Click "Reset filters"
4) The default filter should be enabled again