### PR TITLE
feat(RHIF-294): apply cve detail header filters  apply to both conventional and immutable systems

### DIFF
--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -36,15 +36,17 @@ import {
 import CSAwLabel from '../Snippets/CSAwLabel';
 import CSAwRuleSummary from './CSAwRuleSummary';
 import './CSAwRuleBox.scss';
+import { changeExposedDevicesParameters, changeExposedSystemsParameters } from '../../../Store/Actions/Actions';
 import { HashLink } from 'react-router-hash-link';
 
-const CSAwRuleBox = ({ rules, synopsis, changeExposedSystemsParameters, intl }) => {
+const CSAwRuleBox = ({ rules, synopsis, intl }) => {
     const dispatch = useDispatch();
 
     const sortedRules = [].concat(rules).sort((a, b) => (b.systems_affected - a.systems_affected));
 
     const handleExposedSystemFilter = (ruleId) => {
         dispatch(changeExposedSystemsParameters({ rule: ruleId }));
+        dispatch(changeExposedDevicesParameters({ rule: ruleId }));
     };
 
     /*eslint-disable max-len*/

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.js
@@ -13,9 +13,9 @@ import {
     GridItem,
     Card,
     CardBody,
-    ExpandableSection
+    ExpandableSection,
+    Button
 } from '@patternfly/react-core';
-import { useDispatch } from 'react-redux';
 import { InsightsLabel } from '@redhat-cloud-services/frontend-components/InsightsLabel';
 import {
     CheckCircleIcon,
@@ -36,17 +36,15 @@ import {
 import CSAwLabel from '../Snippets/CSAwLabel';
 import CSAwRuleSummary from './CSAwRuleSummary';
 import './CSAwRuleBox.scss';
-import { changeExposedDevicesParameters, changeExposedSystemsParameters } from '../../../Store/Actions/Actions';
 import { HashLink } from 'react-router-hash-link';
 
-const CSAwRuleBox = ({ rules, synopsis, intl }) => {
-    const dispatch = useDispatch();
-
+const CSAwRuleBox = ({ rules, synopsis, intl, setHeaderFilters, headerFilters }) => {
     const sortedRules = [].concat(rules).sort((a, b) => (b.systems_affected - a.systems_affected));
-
     const handleExposedSystemFilter = (ruleId) => {
-        dispatch(changeExposedSystemsParameters({ rule: ruleId }));
-        dispatch(changeExposedDevicesParameters({ rule: ruleId }));
+        setHeaderFilters(headerFilters?.rule !== ruleId
+            ? { rule: ruleId }
+            : { rule: undefined }
+        );
     };
 
     /*eslint-disable max-len*/
@@ -55,7 +53,7 @@ const CSAwRuleBox = ({ rules, synopsis, intl }) => {
             rule.summary && (
                 <Card className="card-box" key={rule.rule_id} ouiaId={'security-rule-card-' + index}>
                     <ExpandableSection toggleText={
-                        <Split>
+                        <Split isWrappable>
                             <SplitItem className="pf-u-mr-xl">
                                 <TextContent>
                                     <Text component={TextVariants.h4}>
@@ -64,16 +62,19 @@ const CSAwRuleBox = ({ rules, synopsis, intl }) => {
                                     </Text>
                                 </TextContent>
                             </SplitItem>
-                            <SplitItem id="filter-affected-systems-split">
+                            <SplitItem id="filter-affected-systems-split" className="pf-u-mr-xl">
                                 {rule.rule_id &&
                                     <TextContent>
-                                        <Text
+                                        <Button
                                             id="filter-affected-systems"
                                             onClick={event => {
                                                 handleExposedSystemFilter(rule.rule_id);
                                                 event.stopPropagation();
                                             }}
-                                            component={TextVariants.small}
+                                            isActive={headerFilters?.rule === rule?.rule_id}
+                                            isSmall
+                                            isInline
+                                            variant="secondary"
                                         >
                                             <HashLink
                                                 smooth
@@ -91,7 +92,7 @@ const CSAwRuleBox = ({ rules, synopsis, intl }) => {
                                                     )
                                                 }
                                             </HashLink>
-                                        </Text>
+                                        </Button>
                                     </TextContent>}
                             </SplitItem>
                         </Split>
@@ -244,7 +245,9 @@ CSAwRuleBox.propTypes = {
     intl: PropTypes.any,
     rules: PropTypes.array,
     synopsis: PropTypes.string,
-    changeExposedSystemsParameters: PropTypes.func
+    changeExposedSystemsParameters: PropTypes.func,
+    setHeaderFilters: PropTypes.func,
+    headerFilters: PropTypes.object
 };
 
 export default injectIntl(CSAwRuleBox);

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
@@ -36,13 +36,15 @@ const rules = [
         "rule_impact": 2
     }
 ]
-const synopsis = 'CVE-2019-11135'
+const synopsis = 'CVE-2019-11135';
+const setHeaderFilters = jest.fn();
+
 describe('CSAW Rule Box', () => {
     it('Should render without rules ', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -54,7 +56,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -82,7 +84,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -109,7 +111,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -139,7 +141,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -169,7 +171,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -199,7 +201,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -229,7 +231,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -258,7 +260,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
@@ -267,9 +269,6 @@ describe('CSAW Rule Box', () => {
     });
 
     it('Should filter based on the error key', () => {
-        changeExposedDevicesParameters.mockImplementation((filters) => filters);
-        changeExposedSystemsParameters.mockImplementation((filters) => filters);
-
         const rules = [
             {
                 "associated_cves": [
@@ -291,18 +290,19 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis} setHeaderFilters={setHeaderFilters}/>
                 </Router>
             </Provider>
         );
 
         wrapper.find('#filter-affected-systems a').simulate('click')
-        const dispatchedActions = store.getActions();
-        const action = dispatchedActions.filter(item => item.type === 'CHANGE_SYSTEM_CVE_LIST_PARAMETERS');
 
-        expect(changeExposedDevicesParameters).toBeCalledTimes(1)
-        expect(changeExposedSystemsParameters).toBeCalledTimes(1)
-        expect(changeExposedDevicesParameters).toHaveBeenCalledWith({ rule: rules[0].rule_id })
-        expect(changeExposedSystemsParameters).toHaveBeenCalledWith({ rule: rules[0].rule_id })
+        expect(setHeaderFilters).toBeCalledTimes(1)
+        expect(setHeaderFilters).toHaveBeenCalledWith({ rule: rules[0].rule_id })
+
+    });
+
+    it('Should show active button when there is already the same filter', () => {
+
     });
 });

--- a/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/CSAwRuleBox.test.js
@@ -5,6 +5,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { Provider, useSelector } from 'react-redux';
 import { initialState } from '../../../Store/Reducers/CVEDetailsPageStore';
+import { changeExposedDevicesParameters, changeExposedSystemsParameters } from '../../../Store/Actions/Actions';
+
+jest.mock('../../../Store/Actions/Actions', () => ({
+    ...jest.requireActual('../../../Store/Actions/Actions'),
+    changeExposedDevicesParameters: jest.fn(),
+    changeExposedSystemsParameters: jest.fn()
+}));
 
 const mockStore = configureStore([store => next => action => {}]);
 let store = mockStore(initialState);
@@ -260,7 +267,8 @@ describe('CSAW Rule Box', () => {
     });
 
     it('Should filter based on the error key', () => {
-        const fetchMock = jest.fn(filters => { return filters });
+        changeExposedDevicesParameters.mockImplementation((filters) => filters);
+        changeExposedSystemsParameters.mockImplementation((filters) => filters);
 
         const rules = [
             {
@@ -283,7 +291,7 @@ describe('CSAW Rule Box', () => {
         const wrapper = mountWithIntl(
             <Provider store={store}>
                 <Router>
-                    <CSAwRuleBox changeExposedSystemsParameters={fetchMock} rules={rules} synopsis={synopsis}/>
+                    <CSAwRuleBox rules={rules} synopsis={synopsis}/>
                 </Router>
             </Provider>
         );
@@ -291,7 +299,10 @@ describe('CSAW Rule Box', () => {
         wrapper.find('#filter-affected-systems a').simulate('click')
         const dispatchedActions = store.getActions();
         const action = dispatchedActions.filter(item => item.type === 'CHANGE_SYSTEM_CVE_LIST_PARAMETERS');
-        expect(fetchMock).toBeCalledTimes(1)
-        expect(fetchMock).toHaveBeenCalledWith({ rule: rules[0].rule_id })
+
+        expect(changeExposedDevicesParameters).toBeCalledTimes(1)
+        expect(changeExposedSystemsParameters).toBeCalledTimes(1)
+        expect(changeExposedDevicesParameters).toHaveBeenCalledWith({ rule: rules[0].rule_id })
+        expect(changeExposedSystemsParameters).toHaveBeenCalledWith({ rule: rules[0].rule_id })
     });
 });

--- a/src/Components/PresentationalComponents/CSAwRuleBox/NotVulnerableBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/NotVulnerableBox.js
@@ -8,24 +8,23 @@ import {
     Split,
     Card,
     CardBody,
-    ExpandableSection
+    ExpandableSection,
+    Button
 } from '@patternfly/react-core';
-import { useDispatch } from 'react-redux';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
 import './CSAwRuleBox.scss';
 import NotVulnerableLabel from '../Snippets/NotVulnerableLabel';
-import { changeExposedSystemsParameters, changeExposedDevicesParameters } from '../../../Store/Actions/Actions';
 import { ONLY_NON_VULNERABLE_SYSTEMS } from '../../../Helpers/constants';
 
-const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
-    const dispatch = useDispatch();
+const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount, setHeaderFilters, headerFilters }) => {
     const intl = useIntl();
-
     const handleExposedSystemFilter = () => {
-        dispatch(changeExposedSystemsParameters({ rule: ONLY_NON_VULNERABLE_SYSTEMS }));
-        dispatch(changeExposedDevicesParameters({ rule: ONLY_NON_VULNERABLE_SYSTEMS }));
+        setHeaderFilters(headerFilters?.rule !== ONLY_NON_VULNERABLE_SYSTEMS
+            ? { rule: ONLY_NON_VULNERABLE_SYSTEMS }
+            : { rule: undefined }
+        );
     };
 
     return (
@@ -41,15 +40,18 @@ const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
                             </Text>
                         </TextContent>
                     </SplitItem>
-                    <SplitItem id="filter-affected-systems-split">
+                    <SplitItem id="filter-affected-systems-split" className="pf-u-mr-xl">
                         <TextContent>
-                            <Text
+                            <Button
                                 id="filter-affected-systems"
                                 onClick={event => {
                                     handleExposedSystemFilter();
                                     event.stopPropagation();
                                 }}
-                                component={TextVariants.small}
+                                isActive={headerFilters?.rule === ONLY_NON_VULNERABLE_SYSTEMS}
+                                isSmall
+                                isInline
+                                variant="secondary"
                             >
                                 <InsightsLink
                                     to={`/cves/${synopsis}`}
@@ -63,7 +65,7 @@ const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
                                         )
                                     }
                                 </InsightsLink>
-                            </Text>
+                            </Button>
                         </TextContent>
                     </SplitItem>
                 </Split>
@@ -78,7 +80,9 @@ const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
 
 NotVulnerableBox.propTypes = {
     synopsis: PropTypes.string,
-    notVulnerableSystemCount: PropTypes.number
+    notVulnerableSystemCount: PropTypes.number,
+    setHeaderFilters: PropTypes.func,
+    headerFilters: PropTypes.object
 };
 
 export default NotVulnerableBox;

--- a/src/Components/PresentationalComponents/CSAwRuleBox/NotVulnerableBox.js
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/NotVulnerableBox.js
@@ -16,7 +16,7 @@ import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
 import './CSAwRuleBox.scss';
 import NotVulnerableLabel from '../Snippets/NotVulnerableLabel';
-import { changeExposedSystemsParameters } from '../../../Store/Actions/Actions';
+import { changeExposedSystemsParameters, changeExposedDevicesParameters } from '../../../Store/Actions/Actions';
 import { ONLY_NON_VULNERABLE_SYSTEMS } from '../../../Helpers/constants';
 
 const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
@@ -25,6 +25,7 @@ const NotVulnerableBox = ({ synopsis, notVulnerableSystemCount }) => {
 
     const handleExposedSystemFilter = () => {
         dispatch(changeExposedSystemsParameters({ rule: ONLY_NON_VULNERABLE_SYSTEMS }));
+        dispatch(changeExposedDevicesParameters({ rule: ONLY_NON_VULNERABLE_SYSTEMS }));
     };
 
     return (

--- a/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
+++ b/src/Components/PresentationalComponents/CSAwRuleBox/__snapshots__/CSAwRuleBox.test.js.snap
@@ -70,6 +70,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
             },
           ]
         }
+        setHeaderFilters={[MockFunction]}
         synopsis="CVE-2019-11135"
       >
         <CSAwRuleBox
@@ -141,6 +142,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
               },
             ]
           }
+          setHeaderFilters={[MockFunction]}
           synopsis="CVE-2019-11135"
         >
           <Card
@@ -165,7 +167,9 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                 isWidthLimited={false}
                 onToggle={[Function]}
                 toggleText={
-                  <Split>
+                  <Split
+                    isWrappable={true}
+                  >
                     <SplitItem
                       className="pf-u-mr-xl"
                     >
@@ -181,13 +185,17 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                       </TextContent>
                     </SplitItem>
                     <SplitItem
+                      className="pf-u-mr-xl"
                       id="filter-affected-systems-split"
                     >
                       <TextContent>
-                        <Text
-                          component="small"
+                        <Button
                           id="filter-affected-systems"
+                          isActive={false}
+                          isInline={true}
+                          isSmall={true}
                           onClick={[Function]}
+                          variant="secondary"
                         >
                           <HashLink
                             smooth={true}
@@ -195,7 +203,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           >
                             Filter by affected systems
                           </HashLink>
-                        </Text>
+                        </Button>
                       </TextContent>
                     </SplitItem>
                   </Split>
@@ -244,9 +252,11 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                     <span
                       className="pf-c-expandable-section__toggle-text"
                     >
-                      <Split>
+                      <Split
+                        isWrappable={true}
+                      >
                         <div
-                          className="pf-l-split"
+                          className="pf-l-split pf-m-wrap"
                         >
                           <SplitItem
                             className="pf-u-mr-xl"
@@ -263,7 +273,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                   >
                                     <h4
                                       className=""
-                                      data-ouia-component-id="OUIA-Generated-Text-5"
+                                      data-ouia-component-id="OUIA-Generated-Text-4"
                                       data-ouia-component-type="PF4/Text"
                                       data-ouia-safe={true}
                                       data-pf-content={true}
@@ -412,49 +422,67 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                             </div>
                           </SplitItem>
                           <SplitItem
+                            className="pf-u-mr-xl"
                             id="filter-affected-systems-split"
                           >
                             <div
-                              className="pf-l-split__item"
+                              className="pf-l-split__item pf-u-mr-xl"
                               id="filter-affected-systems-split"
                             >
                               <TextContent>
                                 <div
                                   className="pf-c-content"
                                 >
-                                  <Text
-                                    component="small"
+                                  <Button
                                     id="filter-affected-systems"
+                                    isActive={false}
+                                    isInline={true}
+                                    isSmall={true}
                                     onClick={[Function]}
+                                    variant="secondary"
                                   >
-                                    <small
-                                      className=""
-                                      data-ouia-component-id="OUIA-Generated-Text-6"
-                                      data-ouia-component-type="PF4/Text"
-                                      data-ouia-safe={true}
-                                      data-pf-content={true}
+                                    <ButtonBase
                                       id="filter-affected-systems"
+                                      innerRef={null}
+                                      isActive={false}
+                                      isInline={true}
+                                      isSmall={true}
                                       onClick={[Function]}
+                                      variant="secondary"
                                     >
-                                      <HashLink
-                                        key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        smooth={true}
-                                        to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                      <button
+                                        aria-disabled={false}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary pf-m-small"
+                                        data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+                                        data-ouia-component-type="PF4/Button"
+                                        data-ouia-safe={true}
+                                        disabled={false}
+                                        id="filter-affected-systems"
+                                        onClick={[Function]}
+                                        role={null}
+                                        type="button"
                                       >
-                                        <Link
-                                          onClick={[Function]}
+                                        <HashLink
+                                          key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          smooth={true}
                                           to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                         >
-                                          <a
-                                            href="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                          <Link
                                             onClick={[Function]}
+                                            to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                           >
-                                            Filter by affected systems
-                                          </a>
-                                        </Link>
-                                      </HashLink>
-                                    </small>
-                                  </Text>
+                                            <a
+                                              href="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                              onClick={[Function]}
+                                            >
+                                              Filter by affected systems
+                                            </a>
+                                          </Link>
+                                        </HashLink>
+                                      </button>
+                                    </ButtonBase>
+                                  </Button>
                                 </div>
                               </TextContent>
                             </div>
@@ -1134,7 +1162,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                             >
                                               <p
                                                 className="pf-u-mt-xs"
-                                                data-ouia-component-id="OUIA-Generated-Text-7"
+                                                data-ouia-component-id="OUIA-Generated-Text-5"
                                                 data-ouia-component-type="PF4/Text"
                                                 data-ouia-safe={true}
                                                 data-pf-content={true}
@@ -1212,7 +1240,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                     >
                                       <p
                                         className="pf-u-mt-xs associated-cves"
-                                        data-ouia-component-id="OUIA-Generated-Text-8"
+                                        data-ouia-component-id="OUIA-Generated-Text-6"
                                         data-ouia-component-type="PF4/Text"
                                         data-ouia-safe={true}
                                         data-pf-content={true}
@@ -1313,6 +1341,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
             },
           ]
         }
+        setHeaderFilters={[MockFunction]}
         synopsis="CVE-2019-11135"
       >
         <CSAwRuleBox
@@ -1384,6 +1413,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
               },
             ]
           }
+          setHeaderFilters={[MockFunction]}
           synopsis="CVE-2019-11135"
         >
           <Card
@@ -1408,7 +1438,9 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                 isWidthLimited={false}
                 onToggle={[Function]}
                 toggleText={
-                  <Split>
+                  <Split
+                    isWrappable={true}
+                  >
                     <SplitItem
                       className="pf-u-mr-xl"
                     >
@@ -1424,13 +1456,17 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                       </TextContent>
                     </SplitItem>
                     <SplitItem
+                      className="pf-u-mr-xl"
                       id="filter-affected-systems-split"
                     >
                       <TextContent>
-                        <Text
-                          component="small"
+                        <Button
                           id="filter-affected-systems"
+                          isActive={false}
+                          isInline={true}
+                          isSmall={true}
                           onClick={[Function]}
+                          variant="secondary"
                         >
                           <HashLink
                             smooth={true}
@@ -1438,7 +1474,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                           >
                             Filter by affected systems
                           </HashLink>
-                        </Text>
+                        </Button>
                       </TextContent>
                     </SplitItem>
                   </Split>
@@ -1487,9 +1523,11 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                     <span
                       className="pf-c-expandable-section__toggle-text"
                     >
-                      <Split>
+                      <Split
+                        isWrappable={true}
+                      >
                         <div
-                          className="pf-l-split"
+                          className="pf-l-split pf-m-wrap"
                         >
                           <SplitItem
                             className="pf-u-mr-xl"
@@ -1655,49 +1693,67 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                             </div>
                           </SplitItem>
                           <SplitItem
+                            className="pf-u-mr-xl"
                             id="filter-affected-systems-split"
                           >
                             <div
-                              className="pf-l-split__item"
+                              className="pf-l-split__item pf-u-mr-xl"
                               id="filter-affected-systems-split"
                             >
                               <TextContent>
                                 <div
                                   className="pf-c-content"
                                 >
-                                  <Text
-                                    component="small"
+                                  <Button
                                     id="filter-affected-systems"
+                                    isActive={false}
+                                    isInline={true}
+                                    isSmall={true}
                                     onClick={[Function]}
+                                    variant="secondary"
                                   >
-                                    <small
-                                      className=""
-                                      data-ouia-component-id="OUIA-Generated-Text-2"
-                                      data-ouia-component-type="PF4/Text"
-                                      data-ouia-safe={true}
-                                      data-pf-content={true}
+                                    <ButtonBase
                                       id="filter-affected-systems"
+                                      innerRef={null}
+                                      isActive={false}
+                                      isInline={true}
+                                      isSmall={true}
                                       onClick={[Function]}
+                                      variant="secondary"
                                     >
-                                      <HashLink
-                                        key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
-                                        smooth={true}
-                                        to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                      <button
+                                        aria-disabled={false}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary pf-m-small"
+                                        data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+                                        data-ouia-component-type="PF4/Button"
+                                        data-ouia-safe={true}
+                                        disabled={false}
+                                        id="filter-affected-systems"
+                                        onClick={[Function]}
+                                        role={null}
+                                        type="button"
                                       >
-                                        <Link
-                                          onClick={[Function]}
+                                        <HashLink
+                                          key="CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL"
+                                          smooth={true}
                                           to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                         >
-                                          <a
-                                            href="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                          <Link
                                             onClick={[Function]}
+                                            to="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
                                           >
-                                            Filter by affected systems
-                                          </a>
-                                        </Link>
-                                      </HashLink>
-                                    </small>
-                                  </Text>
+                                            <a
+                                              href="/insights/vulnerability/cves/CVE-2019-11135/?rule=CVE_2019_11135_cpu_taa|CVE_2019_11135_CPU_TAA_KERNEL#systems-exposed-table-header"
+                                              onClick={[Function]}
+                                            >
+                                              Filter by affected systems
+                                            </a>
+                                          </Link>
+                                        </HashLink>
+                                      </button>
+                                    </ButtonBase>
+                                  </Button>
                                 </div>
                               </TextContent>
                             </div>
@@ -2377,7 +2433,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                             >
                                               <p
                                                 className="pf-u-mt-xs"
-                                                data-ouia-component-id="OUIA-Generated-Text-3"
+                                                data-ouia-component-id="OUIA-Generated-Text-2"
                                                 data-ouia-component-type="PF4/Text"
                                                 data-ouia-safe={true}
                                                 data-pf-content={true}
@@ -2455,7 +2511,7 @@ An unprivileged user can use this flaw to gain read access to privileged memory 
                                     >
                                       <p
                                         className="pf-u-mt-xs associated-cves"
-                                        data-ouia-component-id="OUIA-Generated-Text-4"
+                                        data-ouia-component-id="OUIA-Generated-Text-3"
                                         data-ouia-component-type="PF4/Text"
                                         data-ouia-safe={true}
                                         data-pf-content={true}

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
@@ -11,7 +11,9 @@ const CVEDetailsPageSummary = ({
     data,
     canEditStatusOrBusinessRisk,
     showStatusModal,
-    showBusinessRiskModal
+    showBusinessRiskModal,
+    setHeaderFilters,
+    headerFilters
 }) => {
     return (
         <Grid hasGutter>
@@ -34,10 +36,14 @@ const CVEDetailsPageSummary = ({
             <CSAwRuleBox
                 synopsis={data.data.synopsis}
                 rules={data.data.rules}
+                setHeaderFilters={setHeaderFilters}
+                headerFilters={headerFilters}
             />
             <NotVulnerableBox
                 synopsis={data.data.synopsis}
                 notVulnerableSystemCount={data.data.affected_but_not_vulnerable}
+                setHeaderFilters={setHeaderFilters}
+                headerFilters={headerFilters}
             />
         </Grid>
     );
@@ -47,7 +53,9 @@ CVEDetailsPageSummary.propTypes = {
     data: propTypes.object,
     canEditStatusOrBusinessRisk: propTypes.bool,
     showStatusModal: propTypes.func,
-    showBusinessRiskModal: propTypes.func
+    showBusinessRiskModal: propTypes.func,
+    setHeaderFilters: propTypes.func,
+    headerFilters: propTypes.object
 };
 
 export default CVEDetailsPageSummary;

--- a/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
+++ b/src/Components/PresentationalComponents/CVEDetailsPageSummary/CVEDetailsPageSummary.js
@@ -9,7 +9,6 @@ import NotVulnerableBox from '../CSAwRuleBox/NotVulnerableBox';
 
 const CVEDetailsPageSummary = ({
     data,
-    changeExposedSystemsParameters,
     canEditStatusOrBusinessRisk,
     showStatusModal,
     showBusinessRiskModal
@@ -33,7 +32,6 @@ const CVEDetailsPageSummary = ({
             }
 
             <CSAwRuleBox
-                changeExposedSystemsParameters={changeExposedSystemsParameters}
                 synopsis={data.data.synopsis}
                 rules={data.data.rules}
             />
@@ -47,7 +45,6 @@ const CVEDetailsPageSummary = ({
 
 CVEDetailsPageSummary.propTypes = {
     data: propTypes.object,
-    changeExposedSystemsParameters: propTypes.func,
     canEditStatusOrBusinessRisk: propTypes.bool,
     showStatusModal: propTypes.func,
     showBusinessRiskModal: propTypes.func

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -5,7 +5,6 @@ import { createCveDetailsPage } from '../../../Helpers/CVEHelper';
 import { useDispatch, useSelector } from 'react-redux';
 import {
     fetchCveDetails,
-    changeExposedSystemsParameters,
     clearInventoryStore,
     clearCveStore
 } from '../../../Store/Actions/Actions';
@@ -151,7 +150,6 @@ const CVEDetailsPage = (props) => {
                             ]}
                         >
                             <CVEDetailsPageSummary
-                                changeExposedSystemsParameters={changeExposedSystemsParameters}
                                 canEditStatusOrBusinessRisk={canEditStatusOrBusinessRisk}
                                 data={cveDetails}
                                 showStatusModal={() => showStatusModal([cveStatusDetails])}

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -30,6 +30,7 @@ const CVEDetailsPage = (props) => {
     const dispatch = useDispatch();
     const inventoryRef = React.createRef();
     const { cve: cveName } = useParams();
+    const [headerFilters, setHeaderFilters] = useState({});
     const intl = useIntl();
 
     const [[canEditPairStatus, canEditStatusOrBusinessRisk, canExport, canReadVulnerabilityResults], isRbacLoading] = useRbac([
@@ -154,6 +155,8 @@ const CVEDetailsPage = (props) => {
                                 data={cveDetails}
                                 showStatusModal={() => showStatusModal([cveStatusDetails])}
                                 showBusinessRiskModal={() => showBusinessRiskModal([cveBusinessRiskDetails])}
+                                setHeaderFilters={setHeaderFilters}
+                                headerFilters={headerFilters}
                             />
                             <StatusModal />
                             <BusinessModal />
@@ -173,6 +176,7 @@ const CVEDetailsPage = (props) => {
                                         canExport={canExport}
                                         inventoryRef={inventoryRef}
                                         refreshInventory={refreshInventory}
+                                        headerFilters={headerFilters}
                                         {...props}
                                     />
                                 </StackItem>

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { useUrlParams } from '../../../../Helpers/MiscHelper';
-import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import ReducerRegistry from '../../../../Utilities/ReducerRegistry';
 import { createExposedDevicesRows } from '../../../../Helpers/CVEHelper';
@@ -14,13 +14,14 @@ import {
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
     PERMISSIONS,
     DEFAULT_PAGE_SIZE,
-    RULE_PRESENCE_OPTIONS
+    RULE_PRESENCE_OPTIONS,
+    CVE_DETAILS_FILTER_PARAMS
 } from '../../../../Helpers/constants';
 import ErrorHandler from '../../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { EmptyStateNoSystems } from '../../../PresentationalComponents/EmptyStates/EmptyStates';
 import { useGetEntities, mergeAppColumns } from './helpers.js';
 import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
-import { buildActiveFilters, removeFilters } from '../../../../Helpers/TableToolbarHelper';
+import { buildActiveFilters, removeFilters, isFilterInDefaultState } from '../../../../Helpers/TableToolbarHelper';
 import useSearchFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import useOsVersionFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
 import useSecurityRuleFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter';
@@ -28,9 +29,7 @@ import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncCompo
 import { useRbac } from '../../../../Helpers/Hooks';
 import messages from '../../../../Messages';
 
-const ImmutableDevices = ({
-    intl, cveName, filterRuleValues, inventoryRef
-}) => {
+const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, headerFilters }) => {
     const [[canReadHostsInventory], isLoadingInventory] = useRbac([
         PERMISSIONS.readHosts
     ], 'inventory');
@@ -42,15 +41,13 @@ const ImmutableDevices = ({
     const error = useSelector(({ entities }) => entities?.error || {});
 
     const parameters = useSelector(
-        ({ ImmutableDevicesStore }) => ImmutableDevicesStore.parameters,
-        shallowEqual
-    );
+        ({ ImmutableDevicesStore }) => ImmutableDevicesStore.parameters);
 
     const apply = (params) => dispatch(changeExposedDevicesParameters(params));
 
     useEffect(() => apply(urlParameters), []);
 
-    useEffect(() => setUrlParams({ ...parameters }), [parameters]);
+    useEffect(() => setUrlParams({ ...parameters, ...headerFilters }), [parameters, headerFilters]);
 
     const getEntities = useGetEntities(
         {
@@ -58,6 +55,10 @@ const ImmutableDevices = ({
             createRows: createExposedDevicesRows
         }
     );
+
+    useEffect(() => {
+        apply(headerFilters);
+    }, [headerFilters]);
 
     const searchFilter = useSearchFilter(
         'filter',
@@ -92,8 +93,9 @@ const ImmutableDevices = ({
 
     const activeFilters = {
         filters: buildActiveFilters({ ...parameters }, filterRuleValues),
-        onDelete: (_, chips) => removeFilters(chips, apply),
-        deleteTitle: intl.formatMessage(messages.resetFilters)
+        onDelete: (_, chips, reset) => removeFilters(chips, apply, reset, {}),
+        deleteTitle: intl.formatMessage(messages.resetFilters),
+        showDeleteButton: !isFilterInDefaultState(parameters, {}, CVE_DETAILS_FILTER_PARAMS)
     };
 
     return isLoadingInventory ? <Spinner centered /> :
@@ -150,7 +152,8 @@ ImmutableDevices.propTypes = {
     cveName: propTypes.string,
     intl: propTypes.object,
     filterRuleValues: propTypes.object,
-    inventoryRef: propTypes.object
+    inventoryRef: propTypes.object,
+    headerFilters: propTypes.object
 };
 
 export default injectIntl(ImmutableDevices);

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -13,7 +13,8 @@ import {
 import {
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
     PERMISSIONS,
-    DEFAULT_PAGE_SIZE
+    DEFAULT_PAGE_SIZE,
+    RULE_PRESENCE_OPTIONS
 } from '../../../../Helpers/constants';
 import ErrorHandler from '../../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { EmptyStateNoSystems } from '../../../PresentationalComponents/EmptyStates/EmptyStates';
@@ -22,13 +23,13 @@ import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { buildActiveFilters, removeFilters } from '../../../../Helpers/TableToolbarHelper';
 import useSearchFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import useOsVersionFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/OsVersionFilter';
+import useSecurityRuleFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useRbac } from '../../../../Helpers/Hooks';
 import messages from '../../../../Messages';
 
 const ImmutableDevices = ({
-    cveName,
-    intl
+    intl, cveName, filterRuleValues, inventoryRef
 }) => {
     const [[canReadHostsInventory], isLoadingInventory] = useRbac([
         PERMISSIONS.readHosts
@@ -79,8 +80,18 @@ const ImmutableDevices = ({
         apply
     );
 
+    const securityRuleFilter = useSecurityRuleFilter(
+        apply,
+        parameters,
+        filterRuleValues,
+        {
+            isDynamic: true,
+            dropdownItems: RULE_PRESENCE_OPTIONS.filter(item => item.value !== 'true')
+        }
+    );
+
     const activeFilters = {
-        filters: buildActiveFilters({ ...parameters }),
+        filters: buildActiveFilters({ ...parameters }, filterRuleValues),
         onDelete: (_, chips) => removeFilters(chips, apply),
         deleteTitle: intl.formatMessage(messages.resetFilters)
     };
@@ -89,6 +100,7 @@ const ImmutableDevices = ({
         error?.hasError && !canReadHostsInventory    ? <ErrorHandler code={error?.errorCode} />
             : (<AsynComponent
                 appName="inventory"
+                ref={inventoryRef}
                 module="./ImmutableDevices"
                 fallback={<div />}
                 store={ReducerRegistry.getStore()}
@@ -109,10 +121,11 @@ const ImmutableDevices = ({
                         )
                     });
                 }}
-                key="inventory"
+                key="immutableDevices"
                 customFilters={{
                     edgeParams: {
-                        ...parameters
+                        ...parameters,
+                        host_type: 'edge'
                     }
                 }}
                 getEntities={getEntities}
@@ -123,6 +136,7 @@ const ImmutableDevices = ({
                 filterConfig={{
                     items: [
                         searchFilter,
+                        securityRuleFilter,
                         advisoryNameFilter,
                         ...osVersionFilter
                     ]
@@ -134,7 +148,9 @@ const ImmutableDevices = ({
 
 ImmutableDevices.propTypes = {
     cveName: propTypes.string,
-    intl: propTypes.object
+    intl: propTypes.object,
+    filterRuleValues: propTypes.object,
+    inventoryRef: propTypes.object
 };
 
 export default injectIntl(ImmutableDevices);

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -51,7 +51,7 @@ import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 
 const SystemsExposedTable = ({
     intl, cveName, cveStatusDetails, filterRuleValues,
-    hasSecurityRule, canEditPairStatus, canExport, inventoryRef, refreshInventory
+    hasSecurityRule, canEditPairStatus, canExport, inventoryRef, refreshInventory, headerFilters
 }) => {
     const [[canReadHostsInventory], isLoadingInventory] = useRbac([
         PERMISSIONS.readHosts
@@ -96,6 +96,10 @@ const SystemsExposedTable = ({
             dispatch(clearInventoryStore());
         };
     }, [dispatch]);
+
+    useEffect(() => {
+        apply(headerFilters);
+    }, [headerFilters]);
 
     useEffect(() => {
         if (meta?.cves_without_errata === true) {
@@ -335,7 +339,8 @@ SystemsExposedTable.propTypes = {
     canEditPairStatus: propTypes.bool,
     canExport: propTypes.bool,
     inventoryRef: propTypes.object,
-    refreshInventory: propTypes.func
+    refreshInventory: propTypes.func,
+    headerFilters: propTypes.object
 };
 
 export default injectIntl(SystemsExposedTable);

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -270,10 +270,11 @@ const SystemsExposedTable = ({
                         isFullView
                         ref={inventoryRef}
                         autoRefresh
-                        key="inventory"
+                        key="conventionalSystems"
                         customFilters={{
                             vulnerabilityParams: {
-                                ...parameters
+                                ...parameters,
+                                host_type: 'rpmdnf'
                             }
                         }}
                         columnsCounter={columnCounter}

--- a/src/Store/Reducers/ImmutableDevicesStore.js
+++ b/src/Store/Reducers/ImmutableDevicesStore.js
@@ -38,13 +38,17 @@ export const ImmutableDevicesStore = (state = initialState, action) => {
             newState = newState.setIn(['cveDetails', 'isLoading'], false);
             return newState;
 
-        case ActionTypes.CHANGE_EXPOSED_DEVICES_PARAMETERS:
+        case ActionTypes.CHANGE_EXPOSED_DEVICES_PARAMETERS: {
+            const { reset, ...params } = action.payload;
+
             newState = state.setIn(['parameters'], {
-                ...state.parameters,
-                ...action.payload,
+                ...!reset ? state.parameters : {},
+                ...params,
                 page_size: action.payload.page_size || state.parameters.page_size
             });
             return newState;
+        }
+
         case ActionTypes.SET_GLOBAL_FILTER:
             newState = state.setIn(['parameters'], {
                 ...applyGlobalFilter(state.parameters, action.payload)


### PR DESCRIPTION
This PR enables the security rule filter and No vulnerable systems filter to be applied for both Conventional and immutable devices.

To test:

1. find a cve that has known exloits and also a security rule associated
2. Click on it and go to CVE detail page
3. Click on the filter for Security rule header card
4. observe that both tabs are filtered with it
5. Repeat the same thing with No vulnerable systems card