### PR TITLE
chore(HybridTabs): provide edge flag to federated module

### DIFF
--- a/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
+++ b/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
@@ -2,7 +2,7 @@ import React, { Suspense, Fragment, lazy } from 'react';
 import propTypes from 'prop-types';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useParams } from 'react-router-dom';
-
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 const ImmutableDevices = lazy(() =>
     import(
         /* webpackChunkName: "ImmutableDevices" */ './ImmutableDevicesTab/ImmutableDevices'
@@ -17,6 +17,8 @@ const SystemsExposedTable = lazy(() =>
 
 const HybridInventory = (props) => {
     const { cve } = useParams();
+    const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
+
     return (
         <AsynComponent
             key="hybridInventory"
@@ -32,6 +34,7 @@ const HybridInventory = (props) => {
             isImmutableTabOpen={props.isImmutableTabOpen}
             fallback={<div />}
             columns
+            isEdgeParityEnabled={isEdgeParityEnabled}
         />
     );
 };

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import unionBy from 'lodash/unionBy';
 import ColumnManagementModal from '../Components/SmartComponents/Modals/ColumnManagementModal';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 
 export const useNotification = (config = {}) => {
     const dispatch = useDispatch();
@@ -244,4 +245,10 @@ export const useColumnManagement = (columns, onApply) => {
             setModalOpen={setModalOpen}
             key="column-mgmt-modal"
         />), setModalOpen];
+};
+
+export const useFeatureFlag = (flag) => {
+    const { flagsReady } = useFlagsStatus();
+    const isFlagEnabled = useFlag(flag);
+    return flagsReady ? isFlagEnabled : false;
 };


### PR DESCRIPTION
This PR allows passing edge flags so that each edge parity work is hidden behind the vulnerability only flag **vulnerability.edge_parity.**