### PR TITLE
feat(RHIF-303): convert system name in CVE report to a link

### DIFF
--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
@@ -1147,7 +1147,7 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   >
                     Important
                   </TEXT>,
-                  <TEXT
+                  <VIEW
                     style={
                       [
                         {
@@ -1162,8 +1162,23 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    0
-                  </TEXT>,
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          aria-label="Affected systems column"
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                          style={
+                            {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
+                            }
+                          }
+                        >
+                          0
+                        </LINK>
+                      </TEXT>
+                    </VIEW>
+                  </VIEW>,
                   <TEXT
                     style={
                       [
@@ -1325,7 +1340,7 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   >
                     Moderate
                   </TEXT>,
-                  <TEXT
+                  <VIEW
                     style={
                       [
                         {
@@ -1340,8 +1355,23 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    0
-                  </TEXT>,
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          aria-label="Affected systems column"
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                          style={
+                            {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
+                            }
+                          }
+                        >
+                          0
+                        </LINK>
+                      </TEXT>
+                    </VIEW>
+                  </VIEW>,
                   <TEXT
                     style={
                       [
@@ -1503,7 +1533,7 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                   >
                     Low
                   </TEXT>,
-                  <TEXT
+                  <VIEW
                     style={
                       [
                         {
@@ -1518,8 +1548,23 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    0
-                  </TEXT>,
+                    <VIEW>
+                      <TEXT>
+                        <LINK
+                          aria-label="Affected systems column"
+                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                          style={
+                            {
+                              "color": "#0066CC",
+                              "textDecoration": "none",
+                            }
+                          }
+                        >
+                          0
+                        </LINK>
+                      </TEXT>
+                    </VIEW>
+                  </VIEW>,
                   <TEXT
                     style={
                       [

--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/firstPagePDF.test.js.snap
@@ -303,21 +303,19 @@ exports[`FirstPagePDF component Should match dynamic CVE report snapshot with cu
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-23969
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-23969
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -413,21 +411,19 @@ exports[`FirstPagePDF component Should match dynamic CVE report snapshot with cu
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-20250
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-20250
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -523,21 +519,19 @@ exports[`FirstPagePDF component Should match dynamic CVE report snapshot with cu
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-1998
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-1998
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -1037,21 +1031,19 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-23969
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-23969
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -1162,22 +1154,20 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          aria-label="Affected systems column"
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          0
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
                   </VIEW>,
                   <TEXT
                     style={
@@ -1230,21 +1220,19 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-20250
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-20250
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -1355,22 +1343,20 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          aria-label="Affected systems column"
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          0
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
                   </VIEW>,
                   <TEXT
                     style={
@@ -1423,21 +1409,19 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          CVE-2021-1998
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        CVE-2021-1998
+                      </LINK>
+                    </TEXT>
                     <CVElabels
                       hasExploit={false}
                       hasRule={false}
@@ -1548,22 +1532,20 @@ exports[`FirstPagePDF component Should match static CVE report snapshot with and
                       ]
                     }
                   >
-                    <VIEW>
-                      <TEXT>
-                        <LINK
-                          aria-label="Affected systems column"
-                          src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                          style={
-                            {
-                              "color": "#0066CC",
-                              "textDecoration": "none",
-                            }
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
                           }
-                        >
-                          0
-                        </LINK>
-                      </TEXT>
-                    </VIEW>
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
                   </VIEW>,
                   <TEXT
                     style={

--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
@@ -1305,7 +1305,7 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 >
                   Important
                 </TEXT>,
-                <TEXT
+                <VIEW
                   style={
                     [
                       {
@@ -1320,8 +1320,23 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  0
-                </TEXT>,
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
+                          }
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
+                  </VIEW>
+                </VIEW>,
                 <TEXT
                   style={
                     [
@@ -1483,7 +1498,7 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 >
                   Moderate
                 </TEXT>,
-                <TEXT
+                <VIEW
                   style={
                     [
                       {
@@ -1498,8 +1513,23 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  0
-                </TEXT>,
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
+                          }
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
+                  </VIEW>
+                </VIEW>,
                 <TEXT
                   style={
                     [
@@ -1661,7 +1691,7 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                 >
                   Low
                 </TEXT>,
-                <TEXT
+                <VIEW
                   style={
                     [
                       {
@@ -1676,8 +1706,23 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  0
-                </TEXT>,
+                  <VIEW>
+                    <TEXT>
+                      <LINK
+                        aria-label="Affected systems column"
+                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                        style={
+                          {
+                            "color": "#0066CC",
+                            "textDecoration": "none",
+                          }
+                        }
+                      >
+                        0
+                      </LINK>
+                    </TEXT>
+                  </VIEW>
+                </VIEW>,
                 <TEXT
                   style={
                     [

--- a/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/Common/__snapshots__/tablePage.test.js.snap
@@ -502,21 +502,19 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-23969
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-23969
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -629,21 +627,19 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-20250
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-20250
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -756,21 +752,19 @@ exports[`TablePage component Should match dynamic CVE report snapshot with custo
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-1998
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-1998
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -1195,21 +1189,19 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-23969
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-23969
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -1320,22 +1312,20 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        aria-label="Affected systems column"
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      aria-label="Affected systems column"
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-23969"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        0
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      0
+                    </LINK>
+                  </TEXT>
                 </VIEW>,
                 <TEXT
                   style={
@@ -1388,21 +1378,19 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-20250
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-20250
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -1513,22 +1501,20 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        aria-label="Affected systems column"
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      aria-label="Affected systems column"
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-20250"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        0
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      0
+                    </LINK>
+                  </TEXT>
                 </VIEW>,
                 <TEXT
                   style={
@@ -1581,21 +1567,19 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        CVE-2021-1998
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      CVE-2021-1998
+                    </LINK>
+                  </TEXT>
                   <CVElabels
                     hasExploit={false}
                     hasRule={false}
@@ -1706,22 +1690,20 @@ exports[`TablePage component Should match static CVE report snapshot with defaul
                     ]
                   }
                 >
-                  <VIEW>
-                    <TEXT>
-                      <LINK
-                        aria-label="Affected systems column"
-                        src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
-                        style={
-                          {
-                            "color": "#0066CC",
-                            "textDecoration": "none",
-                          }
+                  <TEXT>
+                    <LINK
+                      aria-label="Affected systems column"
+                      src="http://localhost/insights/vulnerability/cves/CVE-2021-1998"
+                      style={
+                        {
+                          "color": "#0066CC",
+                          "textDecoration": "none",
                         }
-                      >
-                        0
-                      </LINK>
-                    </TEXT>
-                  </VIEW>
+                      }
+                    >
+                      0
+                    </LINK>
+                  </TEXT>
                 </VIEW>,
                 <TEXT
                   style={

--- a/src/Components/SmartComponents/Reports/Common/tablePage.js
+++ b/src/Components/SmartComponents/Reports/Common/tablePage.js
@@ -93,16 +93,14 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
         ...data.map(({ attributes: cve, id }) => {
             const synopsisCell = (
                 <View style={[styles.bodyCell, styles.cveCell]}>
-                    <View>
-                        <Text>
-                            <Link
-                                style={styles.link}
-                                src={`${CVES_PATH}/${cve.synopsis}`}
-                            >
-                                {cve.synopsis}
-                            </Link>
-                        </Text>
-                    </View>
+                    <Text>
+                        <Link
+                            style={styles.link}
+                            src={`${CVES_PATH}/${cve.synopsis}`}
+                        >
+                            {cve.synopsis}
+                        </Link>
+                    </Text>
                     <CVElabels hasExploit={hasExploit(cve)} hasRule={hasRules(cve)} intl={intl} isSmall />
                 </View>
             );
@@ -116,17 +114,15 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
 
             const affectedCell = (
                 <View style={[styles.bodyCell, styles.cveCell]}>
-                    <View>
-                        <Text>
-                            <Link
-                                aria-label="Affected systems column"
-                                style={styles.link}
-                                src={`${CVES_PATH}/${id}`}
-                            >
-                                {cve.systems_affected}
-                            </Link>
-                        </Text>
-                    </View>
+                    <Text>
+                        <Link
+                            aria-label="Affected systems column"
+                            style={styles.link}
+                            src={`${CVES_PATH}/${id}`}
+                        >
+                            {cve.systems_affected}
+                        </Link>
+                    </Text>
                 </View>
             );
             return [

--- a/src/Components/SmartComponents/Reports/Common/tablePage.js
+++ b/src/Components/SmartComponents/Reports/Common/tablePage.js
@@ -90,7 +90,7 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
     );
 
     const cveRows = [
-        ...data.map(({ attributes: cve }) => {
+        ...data.map(({ attributes: cve, id }) => {
             const synopsisCell = (
                 <View style={[styles.bodyCell, styles.cveCell]}>
                     <View>
@@ -114,10 +114,29 @@ const tablePage = ({ data, page, intl, header, type, isReportDynamic = false }) 
                 </Text>
             );
 
+            const affectedCell = (
+                <View style={[styles.bodyCell, styles.cveCell]}>
+                    <View>
+                        <Text>
+                            <Link
+                                aria-label="Affected systems column"
+                                style={styles.link}
+                                src={`${CVES_PATH}/${id}`}
+                            >
+                                {cve.systems_affected}
+                            </Link>
+                        </Text>
+                    </View>
+                </View>
+            );
             return [
                 synopsisCell,
                 publishDateCell,
-                ...hitColumns.map(item => columnBuilder({ value: cve[item], style: [styles.bodyCell, styles.cveCell] }))
+                ...hitColumns.map(item => {
+                    return item === 'systems_affected'
+                        ? affectedCell
+                        : columnBuilder({ value: cve[item], style: [styles.bodyCell, styles.cveCell] });
+                })
             ];
         })
     ];


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHIF-303

The system name in CVE report on the Reports page should be converted into a link so that it takes the user to the corresponding CVE details page on the UI.

 

Acceptance criteria:

The system row is linkable to the CVE details
The link will go to the conventional tab if there are any conventional systems.
The link will go to the immutable tab if there are no conventional systems.