### PR TITLE
fix(RHINENG-2741): disables zero state when there is edge devices

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -9,7 +9,25 @@ const proxyConfiguration = {
     deployment: process.env.BETA ? 'beta/apps' : 'apps',
     env: process.env.BETA ? 'stage-beta' : 'stage-stable',
     proxyVerbose: true,
-    debug: true
+    debug: true,
+    useFileHash: false,
+    routes: {
+        ...(process.env.LOCAL_API && {
+            ...(process.env.LOCAL_API.split(',') || []).reduce((acc, curr) => {
+                const [appName, appConfig] = (curr || '').split(':');
+                const [appPort = 8003, protocol = 'http'] = appConfig.split('~');
+                return {
+                    ...acc,
+                    [`/apps/${appName}`]: {
+                        host: `${protocol}://localhost:${appPort}`
+                    },
+                    [`/beta/apps/${appName}`]: {
+                        host: `${protocol}://localhost:${appPort}`
+                    }
+                };
+            }, {})
+        })
+    }
 };
 
 const { config: webpackConfig, plugins } = config(proxyConfiguration);

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailTableTitle.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailTableTitle.js
@@ -1,24 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Skeleton, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import { getAffectedSystemsByCVE } from '../../../Helpers/APIHelper';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 const CVEDetailTableTitle = ({ cveName }) => {
     const [isLoading, setLoading] = useState(true);
-    const [edgeDeviceExist, setEdgeDeviceExist] = useState(false);
     const [totalSystems, setTotalSystems] = useState(0);
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
+    const { hasEdgeDevices } = useContext(AccountStatContext);
 
     useEffect(() => {
         getAffectedSystemsByCVE({ id: cveName, host_type: 'edge', limit: 1 }).then(edgeDevice => {
-            setEdgeDeviceExist(edgeDevice?.meta.total_items > 0);
-            getAffectedSystemsByCVE({ id: cveName }).then(result => {
-                setTotalSystems(result?.meta?.total_items || 0);
+            getAffectedSystemsByCVE({ id: cveName, host_type: 'rpmdnf', limit: 1 }).then(conventional => {
+                const totalItems = edgeDevice?.meta?.total_items + conventional?.meta?.total_items;
+                setTotalSystems(totalItems || 0);
                 setLoading(false);
             });
         }).catch(() => {
-            setEdgeDeviceExist(false);
             setTotalSystems(0);
             setLoading(false);
         });
@@ -29,7 +29,7 @@ const CVEDetailTableTitle = ({ cveName }) => {
         <Skeleton width="25%" screenreaderText="Loading contents" />
         : (<TextContent aria-label="Affected systems table title">
             <Text component={TextVariants.h2} id="systems-exposed-table-header">
-                {edgeDeviceExist && isEdgeParityEnabled
+                {hasEdgeDevices && isEdgeParityEnabled
                     ? `${totalSystems} Total ${totalSystems > 1 ? 'systems' : 'system' } affected`
                     : 'Systems'
                 }

--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailTableTitle.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailTableTitle.test.js
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom';
-import { render, screen, act, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { getAffectedSystemsByCVE } from '../../../Helpers/APIHelper';
 import CVEDetailTableTitle from './CVEDetailTableTitle';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 jest.mock('@unleash/proxy-client-react', () => ( {
     ...jest.requireActual('@unleash/proxy-client-react'),
@@ -20,8 +21,15 @@ afterEach(() => {
 
 getAffectedSystemsByCVE.mockImplementation(() => () => Promise.resolve({}))
 
-const waitComponent = async () => {
-    render(<CVEDetailTableTitle cveName={'test-cve'}  />);
+const accountContextValue = {     
+    hasConventionalSystems: true,
+    hasEdgeDevices: true
+};
+
+const waitComponent = async (contextValue) => {
+    render(<AccountStatContext.Provider value={contextValue}>
+        <CVEDetailTableTitle cveName={'test-cve'}  />
+    </AccountStatContext.Provider>);
 
     await waitFor(() => {
         expect(screen.getByLabelText('Affected systems table title')).toBeDefined();
@@ -31,34 +39,36 @@ const waitComponent = async () => {
 describe('CVE detail table title:', () => {
     test('Should show total number of affected systems when there is an edge device in an account', async () => {
         getAffectedSystemsByCVE.mockImplementation(() => Promise.resolve({ meta: { total_items: 10 } }));
-        await waitComponent();
+        await waitComponent(accountContextValue);
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
-            '10 Total systems affected'
+            '20 Total systems affected'
         );
     });
     test('Should show only Systems as title when there is no edge device in an account', async () => {
         getAffectedSystemsByCVE.mockImplementation(() => Promise.resolve({ meta: { total_items: 0 } }));
 
-        await waitComponent();
+        await waitComponent({...accountContextValue, hasEdgeDevices: false });
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             'Systems'
         );
     });
     test('Should show only systems text in singular when there is a single edge device', async () => {
-        getAffectedSystemsByCVE.mockImplementation(() => Promise.resolve({ meta: { total_items: 1 } }));
+        getAffectedSystemsByCVE.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 1 } }));
+        getAffectedSystemsByCVE.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 0 } }));
 
-        await waitComponent();
+
+        await waitComponent(accountContextValue);
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             '1 Total system affected'
         );
     });
-    test('Should show default label Systems when there is am api error', async () => {
+    test('Should show default label Systems when there is an api error', async () => {
         getAffectedSystemsByCVE.mockImplementation(() => Promise.reject(new Error('API error')));
 
-        await waitComponent();
+        await waitComponent({...accountContextValue, hasEdgeDevices: false });
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             'System'

--- a/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
+++ b/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
@@ -3,6 +3,8 @@ import propTypes from 'prop-types';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useParams } from 'react-router-dom';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+import { useContext } from 'react';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 const ImmutableDevices = lazy(() =>
     import(
         /* webpackChunkName: "ImmutableDevices" */ './ImmutableDevicesTab/ImmutableDevices'
@@ -18,6 +20,7 @@ const SystemsExposedTable = lazy(() =>
 const HybridInventory = (props) => {
     const { cve } = useParams();
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
+    const { hasConventionalSystems, hasEdgeDevices } = useContext(AccountStatContext);
 
     return (
         <AsynComponent
@@ -35,6 +38,8 @@ const HybridInventory = (props) => {
             fallback={<div />}
             columns
             isEdgeParityEnabled={isEdgeParityEnabled}
+            hasConventionalSystems={hasConventionalSystems}
+            accountHasEdgeImages={hasEdgeDevices}
         />
     );
 };

--- a/src/Components/SmartComponents/SystemsPage/EdgeDevicesWarning.js
+++ b/src/Components/SmartComponents/SystemsPage/EdgeDevicesWarning.js
@@ -1,30 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { Alert } from '@patternfly/react-core';
-import { useGetSingleDevice } from '../../../Helpers/APIHelper';
 import messages from '../../../Messages';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 const EdgeDevicesWarning = () => {
     const intl = useIntl();
-    const [isLoading, setLoading] = useState(true);
-    const [edgeDeviceExist, setEdgeDeviceExist] = useState(false);
-    const getEdgeDevice = useGetSingleDevice();
-    useEffect(() => {
-        getEdgeDevice().then(edgeDevice => {
-            setEdgeDeviceExist(edgeDevice?.count === 1);
-            setLoading(false);
-        });
-    }, []);
+    const { hasEdgeDevices } = useContext(AccountStatContext);
 
-    return isLoading && !edgeDeviceExist
-        ?
-        null
-        : <Alert
+    return hasEdgeDevices
+        ? <Alert
             variant="info"
             isInline
             style={{ marginBottom: '1.5rem' }}
             title={intl.formatMessage(messages.edgeWarning)}
-        />;
+        />  : null;
 };
 
 export default EdgeDevicesWarning;

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, lazy, Suspense, Fragment } from 'react';
+import React, { useEffect, useState, lazy, Suspense, Fragment, createContext } from 'react';
 import PropTypes from 'prop-types';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { getSystems } from '../Helpers/APIHelper';
@@ -8,6 +8,7 @@ import messages from '../Messages';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { useGetSingleDevice } from '../Helpers/APIHelper';
 
 const SystemsPage = lazy(() =>
     import(
@@ -42,18 +43,28 @@ const Reports = lazy(() =>
     import(/* webpackChunkName: "Reports" */ '../Components/SmartComponents/Reports/ReportsPage')
 );
 
+export const AccountStatContext = createContext({
+    hasConventionalSystems: true,
+    hasEdgeDevices: false
+});
+
 const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elementProps }) => {
     let location = useLocation();
-    const [hasSystems, setHasSystems] = useState(true);
+    const getEdgeDevice = useGetSingleDevice();
+    const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
+    const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
     const chrome = useChrome();
 
     useEffect(() => {
         const fetchData = async () => {
             const result = await getSystems();
-            setHasSystems(result?.meta?.total_items > 0);
+            setHasConventionalSystems(result?.meta?.total_items > 0);
         };
 
         fetchData();
+
+        //if there is at least 1 edge device in the account level, not only in vulnerability
+        getEdgeDevice().then(result => setHasEdgeDevices(result?.count > 0));
     }, []);
 
     const subPath = location.pathname && location.pathname.split('/')[4];
@@ -68,7 +79,7 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
     }, [location.pathname]);
 
     return (
-        !hasSystems ?
+        !(hasEdgeDevices || hasConventionalSystems) ?
             <AsyncComponent
                 appId="vulnerability_zero_state"
                 appName="dashboard"
@@ -77,7 +88,14 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
                 ErrorComponent={<ErrorState />}
                 app="Vulnerability"
             />
-            : <Element {...elementProps}/>
+            : (
+                <AccountStatContext.Provider value={{ hasConventionalSystems, hasEdgeDevices }}>
+                    <Element
+                        {...elementProps}
+                        hasEdgeDevices={hasEdgeDevices}
+                        hasConventionalSystems={hasEdgeDevices}
+                    />
+                </AccountStatContext.Provider>)
     );
 };
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHINENG-2741

As we have 2 types of systems, we need to show zero state only when there are not any conventional and edge systems.

Also, this improves the handling of API requests to fetch the number of conventional and edge devices in multiple components by moving all of the existing calls into a top level where a zero state is displayed. 

To test ( I am preparing accounts to test the PR):
1. Open first the account without any system
2. Observe that Zero state is shown
3. Open another account with edge system
4. Observe that Zero state is not shown
5. Open another account with conventional system
6. Observe that Zero state is not shown
