### PR TITLE
feat(RHINENG-1838): Make group column sortable

### DIFF
--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -1,7 +1,7 @@
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
-import { useUrlParams } from '../../../Helpers/MiscHelper';
+import { translateUrlSortParameter, useUrlParams } from '../../../Helpers/MiscHelper';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import React, { Fragment, useEffect, useState } from 'react';
 import CvePairStatusModal from '../Modals/CvePairStatusModal';
@@ -89,7 +89,7 @@ const SystemsExposedTable = ({
 
     useEffect(() => apply(urlParameters), []);
 
-    useEffect(() => setUrlParams({ ...parameters }), [parameters]);
+    useEffect(() => setUrlParams({ ...parameters, ...meta }), [setUrlParams, parameters, meta]);
 
     useEffect(() => {
         return () => {
@@ -247,10 +247,7 @@ const SystemsExposedTable = ({
                                         page: Number(parameters.page || 1),
                                         perPage: DEFAULT_PAGE_SIZE,
                                         ...(parameters.sort && {
-                                            sortBy: {
-                                                key: parameters.sort.replace(/^-/, ''),
-                                                direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
-                                            }
+                                            sortBy: translateUrlSortParameter(parameters.sort)
                                         })
                                     }
                                 )

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -23,7 +23,7 @@ import {
     fetchSystems,
     fetchSystemsIds
 } from '../../../Store/Actions/Actions';
-import { useUrlParams } from '../../../Helpers/MiscHelper';
+import { translateUrlSortParameter, useUrlParams } from '../../../Helpers/MiscHelper';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { TableVariant } from '@patternfly/react-table';
@@ -211,10 +211,7 @@ const SystemsPage = () => {
                                                     page: Number(parameters.page || 1),
                                                     perPage: Number(parameters.page_size || DEFAULT_PAGE_SIZE),
                                                     ...(parameters.sort && {
-                                                        sortBy: {
-                                                            key: parameters.sort.replace(/^-/, ''),
-                                                            direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
-                                                        }
+                                                        sortBy: translateUrlSortParameter(parameters.sort)
                                                     })
                                                 }
                                             )

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -45,19 +45,22 @@ export const useNotification = (config = {}) => {
     return [addNotification, clearNotifications];
 };
 
+const getSortValue = (orderBy, orderDirection) => {
+    // vulnerability API service uses different key to sort by groups
+    return `${orderDirection === 'ASC' ? '' : '-'}${orderBy === 'group_name' ? 'inventory_group' : orderBy}`;
+};
+
 export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
 
     const getEntities = async (
         _items,
         { orderBy, orderDirection, page, per_page: perPage, vulnerabilityParams, filters }
     ) => {
-        const sort = `${orderDirection === 'ASC' ? '' : '-'}${orderBy}`;
-
         const params = {
             ...vulnerabilityParams,
             page,
             page_size: perPage,
-            sort,
+            sort: getSortValue(orderBy, orderDirection),
             ...filters?.hostGroupFilter ? {
                 group_names: filters.hostGroupFilter.join(',')
             } : {}

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -261,3 +261,17 @@ export const sanitizeLinks = html => {
 
 export const compareVersions = (a, b, asc = true) =>
     asc ? compare(coerce(a), coerce(b)) : rcompare(coerce(a), coerce(b));
+
+export const translateUrlSortParameter = (value) => {
+    let key = value.replace(/^-/, '');
+    let direction = value.match(/^-/) ? 'desc' : 'asc';
+
+    if (key === 'inventory_group') {
+        return {
+            key: 'group_name',
+            direction
+        };
+    }
+
+    return { key, direction };
+};

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -639,6 +639,7 @@ export const SYSTEMS_EXPOSED_HEADER = [
     },
     {
         key: 'os',
+        sortKey: 'os',
         dataLabel: intl.formatMessage(messages.systemsColumnHeaderOS),
         title: (
             <Tooltip content={intl.formatMessage(messages.systemsColumnHeaderOSFull)}>
@@ -653,6 +654,7 @@ export const SYSTEMS_EXPOSED_HEADER = [
     },
     {
         key: 'advisories_list',
+        sortKey: 'advisories_list',
         title: intl.formatMessage(messages.advisory),
         renderFunc: (
             value,
@@ -664,6 +666,7 @@ export const SYSTEMS_EXPOSED_HEADER = [
     },
     {
         key: 'status',
+        sortKey: 'status',
         title: intl.formatMessage(messages.status),
         transforms: [sortable],
         renderFunc: (
@@ -682,6 +685,7 @@ export const SYSTEMS_EXPOSED_HEADER = [
     },
     {
         key: 'remediation',
+        sortKey: 'remediation',
         title: (
             <span>
                 {intl.formatMessage(messages.systemsExposedColumnRemediation)}
@@ -740,6 +744,7 @@ export const SYSTEMS_HEADER = [
     },
     {
         key: 'os',
+        sortKey: 'os',
         dataLabel: intl.formatMessage(messages.systemsColumnHeaderOS),
         title: (
             <Tooltip content={intl.formatMessage(messages.systemsColumnHeaderOSFull)}>
@@ -753,6 +758,7 @@ export const SYSTEMS_HEADER = [
     },
     {
         key: 'cve_count',
+        sortKey: 'cve_count',
         title: intl.formatMessage(messages.systemsColumnHeaderCveCount),
         renderFunc: value => (value !== null ? String(value) : intl.formatMessage(messages.systemsTableDisabled)),
         isShownByDefault: true


### PR DESCRIPTION
## Description

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-1838.

This makes the "Group" column sortable on two views: /vulnerability/systems and /vulnerability/cves/%id.

## How to test the PR

The Inventory change is not yet merged to ensure that the tenant apps support sorting first and avoid breaking change.

1. Pull this Inventory PR locally https://github.com/RedHatInsights/insights-inventory-frontend/pull/2070.
2. Run Vulnerability with this PR `npm run start -- --port=8004`
3. Run Inventory with `LOCAL_APPS=vulnerability:8004~http npm run start:proxy`
4. Navigate to the updated views (in stage-stable environment) and make sure you can sort by system groups.
5. Check the URL search parameters too: while sorting the table, and then refreshing the page - the same sorting must be applied.

## Screenshots

<img width="1512" alt="Screenshot 2023-11-03 at 12 47 44" src="https://github.com/RedHatInsights/vulnerability-ui/assets/31385370/5f619acf-1c54-4343-a54c-e2e00b8cf009">

<img width="1512" alt="Screenshot 2023-11-03 at 12 48 00" src="https://github.com/RedHatInsights/vulnerability-ui/assets/31385370/04233a30-f92a-473a-8a4c-9eecb6e8b1e8">