### PR TITLE
fix(RHINENG-3366): apply OS filter into URL, show reset filters button

### DIFF
--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -52,7 +52,8 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
     const getEntities = useGetEntities(
         {
             id: cveName,
-            createRows: createExposedDevicesRows
+            createRows: createExposedDevicesRows,
+            apply
         }
     );
 
@@ -86,7 +87,7 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
     );
 
     const activeFilters = {
-        filters: buildActiveFilters({ ...parameters }, filterRuleValues),
+        filters: buildActiveFilters(parameters, filterRuleValues),
         onDelete: (_, chips, reset) => removeFilters(chips, apply, reset, {}),
         deleteTitle: intl.formatMessage(messages.resetFilters),
         showDeleteButton: !isFilterInDefaultState(parameters, {}, CVE_DETAILS_FILTER_PARAMS)

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
@@ -16,7 +16,7 @@ export const fetchFullDeviceInfo = async (parameters, fetchImagesData) => {
     return vulnerableSystems;
 };
 
-export const useGetEntities = ({ id, setUrlParams, createRows }) => {
+export const useGetEntities = ({ id, apply, createRows }) => {
     const fetchImagesData = useGetImageData();
     const getEntities = async (
         _items,
@@ -31,12 +31,15 @@ export const useGetEntities = ({ id, setUrlParams, createRows }) => {
             ...filters?.hostGroupFilter ? {
                 group_names: filters.hostGroupFilter.join(',')
             } : {},
+            ...filters?.osFilter?.length > 0 ? {
+                rhel_version: filters.osFilter.map(({ value }) => value).join(',')
+            } : {},
             page,
             page_size: perPage,
             sort
         };
 
-        setUrlParams?.({ ...params });
+        apply?.({ ...params });
 
         const items = await fetchFullDeviceInfo(
             {

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -144,7 +144,8 @@ const SystemsExposedTable = ({
         APIHelper.getAffectedSystemsByCVE,
         {
             id: cveName,
-            createRows: createExposedSystemsRows
+            createRows: createExposedSystemsRows,
+            apply
         }
     );
 

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -114,7 +114,7 @@ const SystemsPage = () => {
     };
 
     const doOptOut = useOptOutSystems(onRefreshInventory);
-    const getEntities = useGetEntities(APIHelper.getSystems, {});
+    const getEntities = useGetEntities(APIHelper.getSystems, { apply });
 
     const [columnCounter, setColumnCount] = useState(0);
     useEffect(() => setColumnCount(columnCounter + 1), [columns]);

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -50,7 +50,7 @@ const getSortValue = (orderBy, orderDirection) => {
     return `${orderDirection === 'ASC' ? '' : '-'}${orderBy === 'group_name' ? 'inventory_group' : orderBy}`;
 };
 
-export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
+export const useGetEntities = (fetchApi, { id, apply, createRows }) => {
 
     const getEntities = async (
         _items,
@@ -69,7 +69,7 @@ export const useGetEntities = (fetchApi, { id, setUrlParams, createRows }) => {
             } : {}
         };
 
-        setUrlParams?.({ ...params });
+        apply?.({ ...params });
 
         const items = await fetchApi(
             {

--- a/src/Helpers/TableToolbarHelper.js
+++ b/src/Helpers/TableToolbarHelper.js
@@ -59,17 +59,7 @@ export const buildActiveFilters = (currentFilters, filterRuleValues = []) => {
                 array.push({ key, category: FILTERS[key].title, chips: [{ name: `${cvssFrom} - ${cvssTo}` }] });
             }
         }
-        else if (key === 'rhel_version' && hasValue(currentFilters, 'rhel_version')) {
-            array.push({
-                key,
-                multiValue: currentFilters.rhel_version.split(','),
-                category: 'Operating system',
-                chips: currentFilters.rhel_version
-                    .split(',')
-                    .map((v) => ({ value: v, name: `RHEL ${v}` }))
-            });
-        }
-        else if (hasValue(currentFilters, key)) {
+        else if (hasValue(currentFilters, key) && key !== 'rhel_version') {
             const multiValue = typeof currentFilters[key] === 'string' && currentFilters[key].split(',');
             const filteredValues = (multiValue && multiValue.length > 1)
                 && buildChips(multiValue, key)


### PR DESCRIPTION
This fixes existing bugs related to the recent OS refactor. Issues are, when an OS filter is applied, it does not get reflected in the URL. Also, the 'Reset filter' does not get shown next to the OS filter. 

Marking blocker as this blocks QA verification of edge part work.