### PR TITLE
chore(VulnerabilityRoutes): introduce loading state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -53,7 +53,7 @@ const App = () => {
     window.setReadOnlyBannerVisible = setVisible => setReadOnlyBannerVisible(setVisible);
 
     return (
-        isLoading ? <Spinner centered /> : isUserAuthorized ?
+        isLoading ? <Spinner size="lg" /> : isUserAuthorized ?
             <Fragment>
                 <NotificationPortal />
                 {isReadOnlyBannerVisible && <ReadOnlyBanner />}

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -49,7 +49,7 @@ export const AccountStatContext = createContext({
     hasEdgeDevices: false
 });
 
-const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elementProps }) => {
+export const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elementProps }) => {
     let location = useLocation();
     const [isLoading, setLoading] = useState(true);
     const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
@@ -61,10 +61,12 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
         const fetchData = async () => {
             const result = await getSystems();
 
+            if (isEdgeParityEnabled) {
             //if there is at least 1 edge device in the account level, not only in vulnerability
-            const edgeDevicePresent = await checkEdgePresence();
+                const edgeDevicePresent = await checkEdgePresence();
+                setHasEdgeDevices(edgeDevicePresent);
+            }
 
-            setHasEdgeDevices(edgeDevicePresent);
             setHasConventionalSystems(result?.meta?.total_items > 0);
             setLoading(false);
         };
@@ -89,7 +91,7 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
     if (isLoading) {
         return (
             <Bullseye>
-                <Spinner size="lg"/>
+                <Spinner size="lg" aria-label="Spinner"/>
             </Bullseye>
         );
     }
@@ -100,6 +102,7 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
                 {...elementProps}
                 hasEdgeDevices={hasEdgeDevices}
                 hasConventionalSystems={hasEdgeDevices}
+                aria-label="Insights element"
             />
         </AccountStatContext.Provider>
         :
@@ -110,6 +113,7 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
             scope="dashboard"
             ErrorComponent={<ErrorState />}
             app="Vulnerability"
+            aria-label="Zero state"
         />;
 
 };

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -9,6 +9,7 @@ import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComp
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import useFeatureFlag from './useFeatureFlag';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
 const SystemsPage = lazy(() =>
     import(
@@ -50,6 +51,7 @@ export const AccountStatContext = createContext({
 
 const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elementProps }) => {
     let location = useLocation();
+    const [isLoading, setLoading] = useState(true);
     const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
     const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
@@ -58,13 +60,17 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
     useEffect(() => {
         const fetchData = async () => {
             const result = await getSystems();
+
+            //if there is at least 1 edge device in the account level, not only in vulnerability
+            const edgeDevicePresent = await checkEdgePresence();
+
+            setHasEdgeDevices(edgeDevicePresent);
             setHasConventionalSystems(result?.meta?.total_items > 0);
+            setLoading(false);
         };
 
         fetchData();
 
-        //if there is at least 1 edge device in the account level, not only in vulnerability
-        checkEdgePresence().then(edgeDevicePresent => setHasEdgeDevices(edgeDevicePresent));
     }, []);
 
     const subPath = location.pathname && location.pathname.split('/')[4];
@@ -80,25 +86,32 @@ const InsightsElement = ({ element: Element, title, globalFilterEnabled, ...elem
 
     const accountHasSystem = isEdgeParityEnabled && (hasEdgeDevices || hasConventionalSystems) || hasConventionalSystems;
 
-    return (
-        !accountHasSystem ?
-            <AsyncComponent
-                appId="vulnerability_zero_state"
-                appName="dashboard"
-                module="./AppZeroState"
-                scope="dashboard"
-                ErrorComponent={<ErrorState />}
-                app="Vulnerability"
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner size="lg"/>
+            </Bullseye>
+        );
+    }
+
+    return accountHasSystem ?
+        <AccountStatContext.Provider value={{ hasConventionalSystems, hasEdgeDevices }}>
+            <Element
+                {...elementProps}
+                hasEdgeDevices={hasEdgeDevices}
+                hasConventionalSystems={hasEdgeDevices}
             />
-            : (
-                <AccountStatContext.Provider value={{ hasConventionalSystems, hasEdgeDevices }}>
-                    <Element
-                        {...elementProps}
-                        hasEdgeDevices={hasEdgeDevices}
-                        hasConventionalSystems={hasEdgeDevices}
-                    />
-                </AccountStatContext.Provider>)
-    );
+        </AccountStatContext.Provider>
+        :
+        <AsyncComponent
+            appId="vulnerability_zero_state"
+            appName="dashboard"
+            module="./AppZeroState"
+            scope="dashboard"
+            ErrorComponent={<ErrorState />}
+            app="Vulnerability"
+        />;
+
 };
 
 InsightsElement.propTypes = {

--- a/src/Utilities/VulnerabilityRoutes.test.js
+++ b/src/Utilities/VulnerabilityRoutes.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import { ComponentWithContext } from './TestingUtilities';
+import { render } from '@testing-library/react';
+import { InsightsElement } from "./VulnerabilityRoutes";
+import useFeatureFlag from './useFeatureFlag';
+import { getSystems, checkEdgePresence } from '../Helpers/APIHelper';
+
+jest.mock('./useFeatureFlag', () => ({
+    ...jest.requireActual('./useFeatureFlag'),
+    __esModule: true,
+    default: jest.fn(() => false)
+}))
+ 
+jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
+    __esModule: true,
+    default: jest.fn((props) => (
+        <div {...props} aria-label="Zero state">
+            AsyncComponent
+        </div>
+    )),
+}));
+
+jest.mock('../Helpers/APIHelper', () => ({
+    ...jest.requireActual('../Helpers/APIHelper'),
+    getSystems: jest.fn(() => Promise.resolve({ meta: { total_items: 1 } })),
+    checkEdgePresence: jest.fn(() => Promise.resolve(true)),
+}));
+
+const TestElement = (props) => <div {...props} />;
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+describe('VulnerabilityRoutes', () => {
+    describe('InsightsElement', () => {
+        it('Should show loading state while account stats are being loaded', () =>{
+            render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+
+            expect(
+                screen.getByLabelText('Spinner')
+            ).toBeTruthy();
+        });
+
+        describe(('edge parit disabled'), () => {
+            it('Should show zero state when there is no conventional, regardless of edge system', async () =>{
+                getSystems.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 0 } }));
+                render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+    
+                await waitFor(() => {
+                    expect(
+                        screen.getByLabelText('Zero state')
+                    ).toBeTruthy();
+                });
+            });
+            it('Should element when there is a conventional system, regardless of edge system', async () =>{
+                render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+    
+                await waitFor(() => {
+                    expect(
+                        screen.getByLabelText('Insights element')
+                    ).toBeTruthy();
+                });
+            });
+        });
+
+        describe(('edge parit enabled'), () => {
+            beforeEach(() => {
+                useFeatureFlag.mockReturnValue(true);
+            });
+            it('Should show zero state when there is no conventional and edge systems', async () =>{
+                getSystems.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 0 } }));
+                checkEdgePresence.mockReturnValueOnce(Promise.resolve(false));
+                render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+    
+                await waitFor(() => {
+                    expect(
+                        screen.getByLabelText('Zero state')
+                    ).toBeTruthy();
+                });
+            });
+            it('Should element when there is no conventional, but there is an edge systems', async () =>{
+                getSystems.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 0 } }));
+                render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByLabelText('Insights element')
+                    ).toBeTruthy();
+                });
+            });
+            it('Should element when there is conventional, but there is no edge systems', async () =>{
+                getSystems.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 1 } }));
+                render(<ComponentWithContext>
+                    <InsightsElement element={TestElement} />
+                </ComponentWithContext>);
+
+                await waitFor(() => {
+                    expect(
+                        screen.getByLabelText('Insights element')
+                    ).toBeTruthy();
+                });
+            });
+        })
+
+
+    });
+})


### PR DESCRIPTION
This PR is intended to show a loading state while a zero state is being checked. This solves the issues that happen when API calls are in progress and zero state is shown by default for a milli-second. This will improve the UX and slick page transition. There should no be any change to zero state itself.

The PR also adds test coverage to zero-state logic.

To test:
1. Make sure that the zero state is not shown in the following cases:

-   edge is enabled and there are both conventional and edge systems
- edge is enabled and there is at least one type of system
- edge is disabled, if there is a conventional system, regardless of edge system
