### PR TITLE
fix(HybridInventoryTabs): auto switch to edge conditionally

### DIFF
--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailTableTitle.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailTableTitle.js
@@ -1,43 +1,27 @@
-import React, { useContext, useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
+import React, { useContext } from 'react';
 import { Skeleton, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { getAffectedSystemsByCVE } from '../../../Helpers/APIHelper';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
+import { CVEPageContext } from './CVEDetailsPage';
 
-const CVEDetailTableTitle = ({ cveName }) => {
-    const [isLoading, setLoading] = useState(true);
-    const [totalSystems, setTotalSystems] = useState(0);
+const CVEDetailTableTitle = () => {
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
     const { hasEdgeDevices } = useContext(AccountStatContext);
+    const { conventionalCount, edgeCount, areCountsLoading } = useContext(CVEPageContext);
 
-    useEffect(() => {
-        getAffectedSystemsByCVE({ id: cveName, host_type: 'edge', limit: 1 }).then(edgeDevice => {
-            getAffectedSystemsByCVE({ id: cveName, host_type: 'rpmdnf', limit: 1 }).then(conventional => {
-                const totalItems = edgeDevice?.meta?.total_items + conventional?.meta?.total_items;
-                setTotalSystems(totalItems || 0);
-                setLoading(false);
-            });
-        }).catch(() => {
-            setTotalSystems(0);
-            setLoading(false);
-        });
-    }, []);
+    const totalCount = conventionalCount + edgeCount;
 
-    return isLoading
+    return areCountsLoading
         ?
-        <Skeleton width="25%" screenreaderText="Loading contents" />
+        <Skeleton width="25%" screenreaderText="Loading contents" aria-label="Table title skeleton" />
         : (<TextContent aria-label="Affected systems table title">
             <Text component={TextVariants.h2} id="systems-exposed-table-header">
                 {hasEdgeDevices && isEdgeParityEnabled
-                    ? `${totalSystems} Total ${totalSystems > 1 ? 'systems' : 'system' } affected`
+                    ? `${totalCount} Total ${totalCount > 1 ? 'systems' : 'system' } affected`
                     : 'Systems'
                 }
             </Text>
         </TextContent>);
 };
 
-CVEDetailTableTitle.propTypes = {
-    cveName: PropTypes.string.isRequired
-};
 export default CVEDetailTableTitle;

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -24,6 +24,9 @@ import { useIntl } from 'react-intl';
 import messages from '../../../Messages';
 import HybridInventory from '../HybridInventory/HybridInventoryTabs';
 import CVEDetailTableTitle from './CVEDetailTableTitle';
+import { fetchHybridSystemsCounts } from './cveDetailHelpers';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
+
 export const CVEPageContext = React.createContext({ isLoading: true });
 
 const CVEDetailsPage = (props) => {
@@ -31,6 +34,12 @@ const CVEDetailsPage = (props) => {
     const inventoryRef = React.createRef();
     const { cve: cveName } = useParams();
     const [headerFilters, setHeaderFilters] = useState({});
+    const [hybridSystemsCounts, setHybridSystemsCounts] = useState({
+        conventionalCount: 0,
+        edgeCount: 0,
+        areCountsLoading: true
+    });
+
     const intl = useIntl();
 
     const [[canEditPairStatus, canEditStatusOrBusinessRisk, canExport, canReadVulnerabilityResults], isRbacLoading] = useRbac([
@@ -49,8 +58,14 @@ const CVEDetailsPage = (props) => {
     const cveDetails = useMemo(() => createCveDetailsPage(details), [details]);
     const totalItems = useSelector(({ entities }) => entities?.total);
 
+    const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
     useEffect(() => {
         dispatch(fetchCveDetails(cveName));
+        fetchHybridSystemsCounts(
+            cveName,
+            isEdgeParityEnabled,
+            setHybridSystemsCounts
+        );
     }, [dispatch, cveName]);
 
     const refreshInventory = () => {
@@ -128,7 +143,9 @@ const CVEDetailsPage = (props) => {
         ];
 
     return (
-        <CVEPageContext.Provider value={cveDetails && { isLoading: cveDetails.isLoading || isRbacLoading }}>
+        <CVEPageContext.Provider value={
+            cveDetails && { isLoading: cveDetails.isLoading || isRbacLoading, ...hybridSystemsCounts }
+        }>
             {canReadVulnerabilityResults ? (
                 error?.hasError ? (
                     <React.Fragment>
@@ -164,7 +181,7 @@ const CVEDetailsPage = (props) => {
                         <Main>
                             <Stack hasGutter>
                                 <StackItem>
-                                    <CVEDetailTableTitle cveName={cveName}/>
+                                    <CVEDetailTableTitle />
                                 </StackItem>
                                 <StackItem>
                                     <HybridInventory

--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailTableTitle.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailTableTitle.test.js
@@ -1,77 +1,77 @@
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
-import { getAffectedSystemsByCVE } from '../../../Helpers/APIHelper';
 import CVEDetailTableTitle from './CVEDetailTableTitle';
 import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
+import { CVEPageContext } from './CVEDetailsPage';
 
 jest.mock('@unleash/proxy-client-react', () => ( {
     ...jest.requireActual('@unleash/proxy-client-react'),
     useFlag: () => true, 
     useFlagsStatus: () => ({ flagsReady: true })
-}))
-
-jest.mock('../../../Helpers/APIHelper', () => ({
-    ...jest.requireActual('../../../Helpers/APIHelper'),
-    getAffectedSystemsByCVE: jest.fn()
 }));
 
 afterEach(() => {
     jest.resetAllMocks()
 });
 
-getAffectedSystemsByCVE.mockImplementation(() => () => Promise.resolve({}))
-
 const accountContextValue = {     
     hasConventionalSystems: true,
     hasEdgeDevices: true
 };
 
-const waitComponent = async (contextValue) => {
-    render(<AccountStatContext.Provider value={contextValue}>
-        <CVEDetailTableTitle cveName={'test-cve'}  />
-    </AccountStatContext.Provider>);
+const hybridSystemsCounts = {
+    conventionalCount: 10,
+    edgeCount: 10,
+    areCountsLoading: false
+}
 
-    await waitFor(() => {
-        expect(screen.getByLabelText('Affected systems table title')).toBeDefined();
-    });
+const renderComponent = (accountContextValue = accountContextValue, cveContextValues = hybridSystemsCounts) => {
+    render(
+        <AccountStatContext.Provider value={accountContextValue}>
+            <CVEPageContext.Provider value={cveContextValues}>
+                <CVEDetailTableTitle cveName={'test-cve'}  />
+            </CVEPageContext.Provider>
+        </AccountStatContext.Provider>
+    );
 }
 
 describe('CVE detail table title:', () => {
     test('Should show total number of affected systems when there is an edge device in an account', async () => {
-        getAffectedSystemsByCVE.mockImplementation(() => Promise.resolve({ meta: { total_items: 10 } }));
-        await waitComponent(accountContextValue);
-
+        renderComponent(accountContextValue, hybridSystemsCounts);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Affected systems table title')).toBeDefined();
+        });
+        
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             '20 Total systems affected'
         );
     });
     test('Should show only Systems as title when there is no edge device in an account', async () => {
-        getAffectedSystemsByCVE.mockImplementation(() => Promise.resolve({ meta: { total_items: 0 } }));
-
-        await waitComponent({...accountContextValue, hasEdgeDevices: false });
+        renderComponent({...accountContextValue, hasEdgeDevices: false }, hybridSystemsCounts);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Affected systems table title')).toBeDefined();
+        });
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             'Systems'
         );
     });
     test('Should show only systems text in singular when there is a single edge device', async () => {
-        getAffectedSystemsByCVE.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 1 } }));
-        getAffectedSystemsByCVE.mockReturnValueOnce(Promise.resolve({ meta: { total_items: 0 } }));
-
-
-        await waitComponent(accountContextValue);
+        hybridSystemsCounts.conventionalCount = 0
+        hybridSystemsCounts.edgeCount = 1;
+        renderComponent(accountContextValue, hybridSystemsCounts);
+        await waitFor(() => {
+            expect(screen.getByLabelText('Affected systems table title')).toBeDefined();
+        });
 
         expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
             '1 Total system affected'
         );
     });
-    test('Should show default label Systems when there is an api error', async () => {
-        getAffectedSystemsByCVE.mockImplementation(() => Promise.reject(new Error('API error')));
+    test('Should show default label Systems when  counts are loading', async () => {
+        hybridSystemsCounts.areCountsLoading = true;
+        renderComponent({...accountContextValue, hasEdgeDevices: false }, );
 
-        await waitComponent({...accountContextValue, hasEdgeDevices: false });
-
-        expect(screen.getByLabelText('Affected systems table title')).toHaveTextContent(
-            'System'
-        );
+        expect(screen.getByLabelText('Table title skeleton')).toBeVisible();
     });
 });

--- a/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.js
@@ -1,0 +1,31 @@
+import { getAffectedSystemsByCVE } from '../../../Helpers/APIHelper';
+
+const getTotalItems = apiResult => (apiResult?.meta?.total_items || 0);
+
+export const fetchHybridSystemsCounts = async (
+    cveName,
+    isEdgeParityEnabled,
+    setHybridSystemsCounts
+) => {
+    try {
+        const conventionalCount = await getAffectedSystemsByCVE({ id: cveName, host_type: 'rpmdnf', limit: 1 })
+            .then(getTotalItems);
+
+        const edgeCount = isEdgeParityEnabled
+            ? await getAffectedSystemsByCVE({ id: cveName, host_type: 'edge', limit: 1 }).then(getTotalItems)
+            : 0;
+
+        setHybridSystemsCounts({
+            conventionalCount,
+            edgeCount,
+            areCountsLoading: false
+        });
+    }
+    catch {
+        setHybridSystemsCounts({
+            conventionalCount: 0,
+            edgeCount: 0,
+            areCountsLoading: false
+        });
+    }
+};

--- a/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.test.js
@@ -1,0 +1,54 @@
+import { fetchHybridSystemsCounts } from "./cveDetailHelpers";
+import { getAffectedSystemsByCVE } from "../../../Helpers/APIHelper";
+
+jest.mock('../../../Helpers/APIHelper', () => ({
+    ...jest.requireActual('../../../Helpers/APIHelper'),
+    getAffectedSystemsByCVE: jest.fn(() => Promise.resolve({ meta: { total_items: 10 } }))
+}));
+
+afterEach(() => {
+    jest.clearAllMocks()
+});
+
+const mockSetState = jest.fn();
+describe('cveDetailHelpers', () => {
+    it('Should not fetch edge counts if edge parity disabled', async () =>{
+        await fetchHybridSystemsCounts('testCve', false, mockSetState);
+        expect(mockSetState).toHaveBeenCalledWith({
+            areCountsLoading: false,
+            conventionalCount: 10,
+            edgeCount: 0,
+        });
+
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledTimes(1);
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            host_type: "rpmdnf",
+            id: "testCve",
+            limit: 1,
+        });
+    });
+
+    it('Should fetch counts and set result into state', async () =>{
+        await fetchHybridSystemsCounts('testCve', true, mockSetState);
+        expect(mockSetState).toHaveBeenCalledWith({
+            areCountsLoading: false,
+            conventionalCount: 10,
+            edgeCount: 10,
+        });
+
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledTimes(2);
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            host_type: "rpmdnf",
+            id: "testCve",
+            limit: 1,
+        });
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            host_type: "edge",
+            id: "testCve",
+            limit: 1,
+        });
+    });
+
+
+});
+

--- a/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
+++ b/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.js
@@ -5,6 +5,9 @@ import { useParams } from 'react-router-dom';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { useContext } from 'react';
 import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { CVEPageContext } from '../CVEDetailsPage/CVEDetailsPage';
+
 const ImmutableDevices = lazy(() =>
     import(
         /* webpackChunkName: "ImmutableDevices" */ './ImmutableDevicesTab/ImmutableDevices'
@@ -17,31 +20,39 @@ const SystemsExposedTable = lazy(() =>
     )
 );
 
-const HybridInventory = (props) => {
+const HybridInventory = ({
+    isImmutableTabOpen,
+    ...tabProps
+}) => {
     const { cve } = useParams();
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
-    const { hasConventionalSystems, hasEdgeDevices } = useContext(AccountStatContext);
+    const { hasEdgeDevices } = useContext(AccountStatContext);
+    const { conventionalCount, edgeCount, areCountsLoading } = useContext(CVEPageContext);
 
-    return (
-        <AsynComponent
-            key="hybridInventory"
-            appName="inventory"
-            module="./HybridInventoryTabs"
-            ConventionalSystemsTab={<Suspense fallback={Fragment}>
-                <SystemsExposedTable {...props} />
-            </Suspense>}
-            ImmutableDevicesTab={<Suspense fallback={Fragment}>
-                <ImmutableDevices {...props} />
-            </Suspense>}
-            tabPathname={`/insights/vulnerability/cves/${cve}`}
-            isImmutableTabOpen={props.isImmutableTabOpen}
-            fallback={<div />}
-            columns
-            isEdgeParityEnabled={isEdgeParityEnabled}
-            hasConventionalSystems={hasConventionalSystems}
-            accountHasEdgeImages={hasEdgeDevices}
-        />
-    );
+    return areCountsLoading ?
+        <Bullseye>
+            <Spinner size="lg" />
+        </Bullseye>
+        : (
+            <AsynComponent
+                key="hybridInventory"
+                appName="inventory"
+                module="./HybridInventoryTabs"
+                ConventionalSystemsTab={<Suspense fallback={Fragment}>
+                    <SystemsExposedTable {...tabProps} />
+                </Suspense>}
+                ImmutableDevicesTab={<Suspense fallback={Fragment}>
+                    <ImmutableDevices {...tabProps} />
+                </Suspense>}
+                tabPathname={`/insights/vulnerability/cves/${cve}`}
+                isImmutableTabOpen={isImmutableTabOpen}
+                fallback={<div />}
+                columns
+                isEdgeParityEnabled={isEdgeParityEnabled}
+                hasConventionalSystems={conventionalCount > 0 || edgeCount <= 0}
+                accountHasEdgeImages={hasEdgeDevices}
+            />
+        );
 };
 
 HybridInventory.propTypes = {

--- a/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.test.js
+++ b/src/Components/SmartComponents/HybridInventory/HybridInventoryTabs.test.js
@@ -1,0 +1,125 @@
+import HybridInventory from "./HybridInventoryTabs";
+import { AccountStatContext } from "../../../Utilities/VulnerabilityRoutes";
+import { CVEPageContext } from "../CVEDetailsPage/CVEDetailsPage";
+import AsynComponent from "@redhat-cloud-services/frontend-components/AsyncComponent";
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from "@testing-library/react";
+import { useParams } from "react-router-dom";
+
+jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => ({
+    __esModule: true,
+    default: jest.fn((props) => (
+      <div {...props} aria-label="hybrid-inventory-mock">
+        AsyncComponent
+      </div>
+    )),
+}));
+
+jest.mock('../../../Utilities/useFeatureFlag', () => ({
+    ...jest.requireActual('../../../Utilities/useFeatureFlag'),
+    __esModule: true,
+    default: jest.fn(() => false)
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn(() => ({ cve: 'testCve' }))
+}))
+const accountContextValue = {     
+    hasConventionalSystems: true,
+    hasEdgeDevices: true
+};
+
+const hybridSystemsCounts = {
+    conventionalCount: 10,
+    edgeCount: 10,
+    areCountsLoading: false
+}
+
+const renderComponent = (props, accountContextValues = accountContextValue, cveContextValues = hybridSystemsCounts) => {
+    render(
+        <AccountStatContext.Provider value={accountContextValues}>
+            <CVEPageContext.Provider value={cveContextValues}>
+                <HybridInventory {...props} />
+            </CVEPageContext.Provider>
+        </AccountStatContext.Provider>
+    );
+};
+
+const waitAsyncComponent = async () => {
+    await waitFor(() => {
+        expect(
+            screen.getByLabelText('hybrid-inventory-mock')
+        ).toBeInTheDocument();
+    });
+};
+
+describe('HybridInventory', () => {
+    it('Should auto switch to edge tab  when there is no conventional systems, but there is edge device', async () => {
+        renderComponent({}, accountContextValue, {...hybridSystemsCounts, conventionalCount: 0 });
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                hasConventionalSystems: false
+            }),
+            {}
+          );
+    });
+    it('Should not auto switch to edge tab automatically when there is no conventional systems and no edge device', async () => {
+        renderComponent({}, accountContextValue, {...hybridSystemsCounts, conventionalCount: 0, edgeCount: 0 });
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                hasConventionalSystems: true
+            }),
+            {}
+          );
+    });
+    it('Should not auto switch to edge tab automatically when there are both conventional systems and edge device', async () => {
+        renderComponent({}, accountContextValue);
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                hasConventionalSystems: true
+            }),
+            {}
+          );
+    });
+    it('Should pass isImmutableTabOpen prop to fed-module', async () => {
+        renderComponent({ isImmutableTabOpen: true });
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                isImmutableTabOpen: true
+            }),
+            {}
+          );
+    });
+    it('Should pass accountHasEdgeImages prop to fed-module from accountContext', async () => {
+        renderComponent();
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                accountHasEdgeImages: true
+            }),
+            {}
+          );
+    });
+
+    it('Should pass correct tabPath prop to fed-module from accountContext', async () => {
+        renderComponent();
+
+        await waitAsyncComponent();
+        expect(AsynComponent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                "tabPathname": "/insights/vulnerability/cves/testCve"
+            }),
+            {}
+          );
+    });
+});


### PR DESCRIPTION
This fixes the issue on HybridInventoryTabs. The issue happened by the fact that I understood the PM requirement wrong and made hybrid tabs switch to edge automatically when there are no conventional systems at a vulnerability account level. Instead, the correct behavior is the tabs auto-switching to the edge when there are no conventional systems affected by a CVE. Also, the tab should not auto-switch when there are no both conventional and edge devices.

To test:
1. Go CVEs page
2. Find a CVE that has only edge devices affected.
3. Open details page 
4. Observe that edge tab is automatically activated
5. Find another CVE that has no conventional and edge degices.
6. Observe that tab does not auto switch to edge.