### PR TITLE
fix(RHINENG-1838): groups sorting is fixed in Immtable devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/pluginutils": "^5.0.2",
+        "@testing-library/react-hooks": "^8.0.1",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
@@ -5292,6 +5293,36 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -19203,6 +19234,22 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -28093,6 +28140,16 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@testing-library/user-event": {
@@ -38579,6 +38636,15 @@
         "file-selector": "^0.1.8",
         "prop-types": "^15.6.2",
         "prop-types-extra": "^1.1.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/pluginutils": "^5.0.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -6,20 +6,18 @@ import { useDispatch, useSelector } from 'react-redux';
 import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import ReducerRegistry from '../../../../Utilities/ReducerRegistry';
 import { createExposedDevicesRows } from '../../../../Helpers/CVEHelper';
-import { inventoryEntitiesReducer } from '../../../../Store/Reducers/InventoryEntitiesReducer';
 import {
     changeExposedDevicesParameters
 } from '../../../../Store/Actions/Actions';
 import {
     SYSTEMS_EXPOSED_ALLOWED_PARAMS,
     PERMISSIONS,
-    DEFAULT_PAGE_SIZE,
     RULE_PRESENCE_OPTIONS,
     CVE_DETAILS_FILTER_PARAMS
 } from '../../../../Helpers/constants';
 import ErrorHandler from '../../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { EmptyStateNoSystems } from '../../../PresentationalComponents/EmptyStates/EmptyStates';
-import { useGetEntities, mergeAppColumns } from './helpers.js';
+import { useGetEntities, mergeAppColumns, useOnLoad } from './helpers.js';
 import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { buildActiveFilters, removeFilters, isFilterInDefaultState } from '../../../../Helpers/TableToolbarHelper';
 import useSearchFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
@@ -97,6 +95,8 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
         navigate(`/${systemId}?appName=vulnerabilities`);
     };
 
+    const onLoad = useOnLoad(parameters);
+
     if (isLoadingInventory) {
         return <Spinner size="lg" />;
     }
@@ -111,23 +111,7 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
         module="./ImmutableDevices"
         fallback={<div />}
         store={ReducerRegistry.getStore()}
-        onLoad={({ mergeWithEntities }) => {
-            ReducerRegistry.register({
-                ...mergeWithEntities(
-                    inventoryEntitiesReducer([]),
-                    {
-                        page: Number(parameters.page || 1),
-                        perPage: DEFAULT_PAGE_SIZE,
-                        ...(parameters.sort && {
-                            sortBy: {
-                                key: parameters.sort.replace(/^-/, ''),
-                                direction: parameters.sort.match(/^-/) ? 'desc' : 'asc'
-                            }
-                        })
-                    }
-                )
-            });
-        }}
+        onLoad={onLoad}
         key="immutableDevices"
         customFilters={{
             edgeParams: {

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
@@ -1,5 +1,10 @@
 import { getAffectedSystemsByCVE, useGetImageData } from '../../../../Helpers/APIHelper';
-import { SYSTEMS_EXPOSED_HEADER } from '../../../../Helpers/constants';
+import { SYSTEMS_EXPOSED_HEADER, DEFAULT_PAGE_SIZE } from '../../../../Helpers/constants';
+import { getSortValue } from '../../../../Helpers/Hooks';
+import ReducerRegistry from '../../../../Utilities/ReducerRegistry';
+import { inventoryEntitiesReducer } from '../../../../Store/Reducers/InventoryEntitiesReducer';
+import { useCallback } from 'react';
+import { translateUrlSortParameter } from '../../../../Helpers/MiscHelper';
 
 export const fetchFullDeviceInfo = async (parameters, fetchImagesData) => {
     const vulnerableSystems = await getAffectedSystemsByCVE(parameters);
@@ -23,7 +28,6 @@ export const useGetEntities = ({ id, apply, createRows }) => {
         { orderBy, orderDirection, page, per_page: perPage, edgeParams, filters }
     ) => {
         const { hostnameOrId: filter } = filters;
-        const sort = `${orderDirection === 'ASC' ? '' : '-'}${orderBy}`;
 
         const params = {
             filter,
@@ -36,7 +40,7 @@ export const useGetEntities = ({ id, apply, createRows }) => {
             } : {},
             page,
             page_size: perPage,
-            sort
+            sort: getSortValue(orderBy, orderDirection)
         };
 
         apply?.({ ...params });
@@ -81,3 +85,18 @@ export const mergeAppColumns = (defaultColumns) => {
 
     return [...defaultColumns, ...[advisoryColumn || []]];
 };
+
+export const useOnLoad = (parameters) => useCallback(({ mergeWithEntities }) => {
+    ReducerRegistry.register({
+        ...mergeWithEntities(
+            inventoryEntitiesReducer([]),
+            {
+                page: Number(parameters.page || 1),
+                perPage: DEFAULT_PAGE_SIZE,
+                ...(parameters.sort && {
+                    sortBy: translateUrlSortParameter(parameters.sort)
+                })
+            }
+        )
+    });
+}, []);

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
@@ -1,0 +1,36 @@
+import { useOnLoad } from "./helpers";
+import { renderHook } from '@testing-library/react-hooks';
+
+jest.mock('../../../../Utilities/ReducerRegistry', () => ({
+    __esModule: true,
+    ...jest.requireActual('../../../../Utilities/ReducerRegistry'),
+    default: { register: jest.fn(() => {}) }
+}));
+
+jest.mock('../../../../Store/Reducers/InventoryEntitiesReducer', () => ({
+    ...jest.requireActual('../../../../Store/Reducers/InventoryEntitiesReducer'),
+    inventoryEntitiesReducer: jest.fn(() => ['test-reducers'])
+}));
+
+const parameters = { sort: '-inventory_group'}
+const mergeWithEntities = jest.fn();
+
+describe('useOnLoad', () => {
+    it('Should change "inventory_group" sort key to "group_name" from parameters.', () => {
+        const { result } = renderHook(() => useOnLoad(parameters));
+
+        result.current({ mergeWithEntities });
+    
+        expect(mergeWithEntities).toHaveBeenCalledWith(
+            ['test-reducers'], 
+            {
+                page: 1, 
+                perPage: 20, 
+                sortBy: {
+                    direction: "desc",
+                    key: "group_name",
+                },
+            }
+        );
+    });
+});

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -45,7 +45,7 @@ export const useNotification = (config = {}) => {
     return [addNotification, clearNotifications];
 };
 
-const getSortValue = (orderBy, orderDirection) => {
+export const getSortValue = (orderBy, orderDirection) => {
     // vulnerability API service uses different key to sort by groups
     return `${orderDirection === 'ASC' ? '' : '-'}${orderBy === 'group_name' ? 'inventory_group' : orderBy}`;
 };


### PR DESCRIPTION
This fixes existing issues related to group column sorting in the immutable devices tab. Currently, if that column is sorted the UI breaks doe to API error.

To test:
1. Find a CVE with immutable devices
2. Open the details page
3. try sorting by group column
4. Observe that the UI does not brake and sorting works