### PR TITLE
feat(RHINENG-3415): enforces groups info to be fetched from edge cond…

### DIFF
--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -37,7 +37,7 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
 
     const totalItems = useSelector(({ entities }) => entities?.total);
     const error = useSelector(({ entities }) => entities?.error || {});
-
+    const meta = useSelector(({ entities }) => entities?.meta || {});
     const parameters = useSelector(
         ({ ImmutableDevicesStore }) => ImmutableDevicesStore.parameters);
 
@@ -120,9 +120,9 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
         }}
         getEntities={getEntities}
         showActions={totalItems !== 0}
-        hideFilters={{ all: true, hostGroupFilter: false, operatingSystem: false }}
+        hideFilters={{ all: true, hostGroupFilter: meta.enforceEdgeGroups, operatingSystem: false }}
         noSystemsTable={<EmptyStateNoSystems />}
-        mergeAppColumns={mergeAppColumns}
+        mergeAppColumns={(defaultColumns) => mergeAppColumns(defaultColumns, meta.enforceEdgeGroups)}
         filterConfig={{
             items: [
                 searchFilter,

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -120,7 +120,7 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
         }}
         getEntities={getEntities}
         showActions={totalItems !== 0}
-        hideFilters={{ all: true, hostGroupFilter: meta.enforceEdgeGroups, operatingSystem: false }}
+        hideFilters={{ all: true, hostGroupFilter: meta.enforceEdgeGroups || false, operatingSystem: false }}
         noSystemsTable={<EmptyStateNoSystems />}
         mergeAppColumns={(defaultColumns) => mergeAppColumns(defaultColumns, meta.enforceEdgeGroups)}
         filterConfig={{

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.test.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.test.js
@@ -113,8 +113,8 @@ describe('ImmutableDevices', () => {
     );
   });
 
-
-  test('should display hostGroupFilter and os filter from the ImmutableDevices federated module', async () => {
+  test('should display os and group filter from the ImmutableDevices federated module by default', async () => {
+    useSelector.mockReturnValue({ enforceEdgeGroups: false })
     render(
       <ComponentWithContext
         renderOptions={defaultRenderOptions}
@@ -130,6 +130,30 @@ describe('ImmutableDevices', () => {
         hideFilters: {
           all: true,
           hostGroupFilter: false,
+          operatingSystem: false,
+        },
+      }),
+      {}
+    );
+  });
+
+  test('should hide group filter from the ImmutableDevices federated module when enforce_edge_group is true', async () => {
+    useSelector.mockReturnValue({ enforceEdgeGroups: true })
+    render(
+      <ComponentWithContext
+        renderOptions={defaultRenderOptions}
+      >
+        <ImmutableDevices />
+      </ComponentWithContext>
+    );
+
+    await waitAsyncComponent();
+
+    expect(AsynComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hideFilters: {
+          all: true,
+          hostGroupFilter: true,
           operatingSystem: false,
         },
       }),

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.test.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.test.js
@@ -138,7 +138,7 @@ describe('ImmutableDevices', () => {
   });
 
   test('should hide group filter from the ImmutableDevices federated module when enforce_edge_group is true', async () => {
-    useSelector.mockReturnValue({ enforceEdgeGroups: true })
+    useSelector.mockReturnValue({ enforceEdgeGroups: true, total: 10 })
     render(
       <ComponentWithContext
         renderOptions={defaultRenderOptions}

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.js
@@ -9,16 +9,18 @@ import { translateUrlSortParameter } from '../../../../Helpers/MiscHelper';
 export const fetchFullDeviceInfo = async (parameters, fetchImagesData) => {
     const vulnerableSystems = await getAffectedSystemsByCVE(parameters);
     const deviceIds = vulnerableSystems?.data.map(data => data.id);
+    let enforceEdgeGroups = false;
 
     if (deviceIds.length) {
         const deviceData = await fetchImagesData({ devices_uuid: deviceIds });
+        enforceEdgeGroups = deviceData?.data?.enforce_edge_groups || false;
         vulnerableSystems.data?.forEach(system => {
             const systemDevice = deviceData?.data?.devices?.find(device => device.DeviceUUID === system.id);
             return system.attributes = { ...system.attributes, ...systemDevice };
         });
     }
 
-    return vulnerableSystems;
+    return { vulnerableSystems, enforceEdgeGroups };
 };
 
 export const useGetEntities = ({ id, setUrlParams, createRows }) => {
@@ -45,7 +47,7 @@ export const useGetEntities = ({ id, setUrlParams, createRows }) => {
 
         setUrlParams?.({ ...params });
 
-        const items = await fetchFullDeviceInfo(
+        const { vulnerableSystems: items, enforceEdgeGroups } = await fetchFullDeviceInfo(
             {
                 ...id && { id },
                 ...params
@@ -55,7 +57,7 @@ export const useGetEntities = ({ id, setUrlParams, createRows }) => {
 
         return {
             results: typeof createRows === 'function'
-                ? createRows(items || {})
+                ? createRows(items || {}, enforceEdgeGroups)
                 : items?.data?.map(row => ({ id: row.id, ...row.attributes })),
             total: items?.meta?.total_items,
             page: items?.meta?.page,
@@ -64,7 +66,8 @@ export const useGetEntities = ({ id, setUrlParams, createRows }) => {
                 page: items?.meta?.page,
                 sort: items?.meta?.sort,
                 page_size: items?.meta?.page_size,
-                cves_without_errata: items?.meta?.cves_without_errata
+                cves_without_errata: items?.meta?.cves_without_errata,
+                enforceEdgeGroups
             }
         };
     };
@@ -72,7 +75,7 @@ export const useGetEntities = ({ id, setUrlParams, createRows }) => {
     return getEntities;
 };
 
-export const mergeAppColumns = (defaultColumns) => {
+export const mergeAppColumns = (defaultColumns, enforcEdgeGroups = false) => {
     const osColumn = SYSTEMS_EXPOSED_HEADER.find((column) => column.key === 'os');
     const advisoryColumn = SYSTEMS_EXPOSED_HEADER.find((column) => column.key === 'advisories_list');
 
@@ -81,6 +84,13 @@ export const mergeAppColumns = (defaultColumns) => {
     });
     if (osIndex !== -1) {
         defaultColumns[osIndex] = osColumn;
+    }
+
+    const groupsIndex = defaultColumns.findIndex(column =>{
+        return column.key === 'groups';
+    });
+    if (groupsIndex !== -1) {
+        defaultColumns[groupsIndex].props = { ...defaultColumns[groupsIndex].props, isStatic: enforcEdgeGroups };
     }
 
     return [...defaultColumns, ...[advisoryColumn || []]];

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
@@ -51,7 +51,7 @@ const defaultColumns = [
       );
       expect(osColumn).toEqual(SYSTEMS_EXPOSED_HEADER.find((column) => column.key === 'os'));
     });
-    test('Should disable sorting when edge groups are enforced', () => {
+    test('Should disable sorting when edge groups are enforced  by extending incoming column props from default columns', () => {
         const enforce_edge_groups = true;
         const result = mergeAppColumns(defaultColumns, enforce_edge_groups);
     
@@ -60,7 +60,7 @@ const defaultColumns = [
         );
         expect(groupsColumn).toEqual(expect.objectContaining({ props: { width: 15, isStatic: true } }));
     });
-    test('Should enable sorting by default', () => {
+    test('Should enable sorting by default by extending incoming column props from default columns', () => {
         const result = mergeAppColumns(defaultColumns);
     
         const groupsColumn = result.find(

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/helpers.test.js
@@ -1,5 +1,6 @@
-import { useOnLoad } from "./helpers";
+import { useOnLoad, mergeAppColumns } from "./helpers";
 import { renderHook } from '@testing-library/react-hooks';
+import { SYSTEMS_EXPOSED_HEADER } from '../../../../Helpers/constants';
 
 jest.mock('../../../../Utilities/ReducerRegistry', () => ({
     __esModule: true,
@@ -32,5 +33,47 @@ describe('useOnLoad', () => {
                 },
             }
         );
+    });
+});
+
+const defaultColumns = [
+    { key: 'updated', renderFunc: jest.fn() },
+    { key: 'system_profile', props: { width: 15 } },
+    { key: 'groups', props: { width: 15 } },
+  ];
+  
+  describe('mergeAppColumns', () => {
+    test('Should replace default OS column to vulnerabilty OS column', () => {
+      const result = mergeAppColumns(defaultColumns);
+  
+      const osColumn = result.find(
+        (column) => column.key === 'os'
+      );
+      expect(osColumn).toEqual(SYSTEMS_EXPOSED_HEADER.find((column) => column.key === 'os'));
+    });
+    test('Should disable sorting when edge groups are enforced', () => {
+        const enforce_edge_groups = true;
+        const result = mergeAppColumns(defaultColumns, enforce_edge_groups);
+    
+        const groupsColumn = result.find(
+          (column) => column.key === 'groups'
+        );
+        expect(groupsColumn).toEqual(expect.objectContaining({ props: { width: 15, isStatic: true } }));
+    });
+    test('Should enable sorting by default', () => {
+        const result = mergeAppColumns(defaultColumns);
+    
+        const groupsColumn = result.find(
+          (column) => column.key === 'groups'
+        );
+        expect(groupsColumn).toEqual(expect.objectContaining({ props: { width: 15, isStatic: false } }));
+    });
+    test('Should add advisory column  to default columns', () => {
+      const result = mergeAppColumns(defaultColumns);
+  
+      const advisories_list = result.find(
+        (column) => column.key === 'advisories_list'
+      );
+      expect(advisories_list).toEqual(SYSTEMS_EXPOSED_HEADER.find((column) => column.key === 'advisories_list'));
     });
 });

--- a/src/Helpers/CVEHelper.js
+++ b/src/Helpers/CVEHelper.js
@@ -207,10 +207,12 @@ export const systemTableRowActions = (rowData, optOutFunc) => [
  * @param {Array} cveId CVE id
  *
  */
-export const createExposedDevicesRows = ({ data }) => {
+export const createExposedDevicesRows = ({ data }, enforceEdgeGroups) => {
     return data?.map(row => ({
         id: row.id,
         ...row.attributes,
-        groups: row.attributes.inventory_group
+        groups: enforceEdgeGroups
+            ? (row.attributes.DeviceGroups?.map(group => ({ id: group.ID, name: group.Name })) || [])
+            : row.attributes.inventory_group
     }));
 };


### PR DESCRIPTION
Implements: https://issues.redhat.com/browse/RHINENG-3415

According to the state of enforce_edge_group from /api/edge/v1/devices/devicesview endpoint, we should show groups info from edge endpoint or vulnerability endpoint. 

When enforce_edge_group is set to true: 
1. groups column uses `DeviceGroups` from /api/edge/v1/devices/devicesview
2. groups column sorting is disabled as vulnerability endpoint is main data source
3. groups filter is hidden as vulnerability endpoint is main data source

When enforce_edge_group is set to false: 
1. groups column uses `DeviceGroups` from v1/cves/{cveName}/affected_systems
2. groups column sorting is enabled as vulnerability endpoint is main data source
3. groups filter is shown as vulnerability endpoint is main data source