### PR TITLE
fix(RHINENG-3653): Update Groups column default text

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -643,7 +643,9 @@ export const SYSTEMS_EXPOSED_HEADER = [
         inventoryGroupsFeatureFlag: true,
         renderFunc: (data, value, { inventory_group: group }) =>
             <span>
-                {isEmpty(group) ? 'N/A' : group[0].name} {/* currently, one group at maximum is supported */}
+                {isEmpty(group) ?
+                    <span className="pf-v5-u-disabled-color-200">No group</span>
+                    : group[0].name} {/* currently, one group at maximum is supported */}
             </span>
     },
     {
@@ -749,7 +751,11 @@ export const SYSTEMS_HEADER = [
         inventoryGroupsFeatureFlag: true,
         isShownByDefault: true,
         renderFunc: (data, value, { inventory_group: group }) =>
-            isEmpty(group) ? 'N/A' : group[0].name // currently, one group at maximum is supported
+            <span>
+                {isEmpty(group) ?
+                    <span className="pf-v5-u-disabled-color-200">No group</span>
+                    : group[0].name} {/* currently, one group at maximum is supported */}
+            </span>
     },
     {
         key: 'tags',


### PR DESCRIPTION
This changes the text for when a system has no group from 'N/A' to 'No group' in grey wording. 

https://issues.redhat.com/browse/RHINENG-3653 