### PR TITLE
fix(RHINENG-5985): filter the API by advisory available to fetch cve …

### DIFF
--- a/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CveDetailsPage.test.js
@@ -210,4 +210,10 @@ describe('CVE details:', () => {
 
         expect(wrapper.find(CVEDetailTableTitle)).toHaveLength(1);
     });
+
+    it('Should count only advisory available cves in the table title by filter the API with "advisory_available: true"', async () => {
+        expect(getAffectedSystemsByCVE).toHaveBeenCalledWith(
+            expect.objectContaining({ advisory_available: true }),     
+        );
+    });
 });

--- a/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.js
@@ -7,12 +7,13 @@ export const fetchHybridSystemsCounts = async (
     isEdgeParityEnabled,
     setHybridSystemsCounts
 ) => {
+    const filters = { id: cveName, limit: 1, advisory_available: true };
     try {
-        const conventionalCount = await getAffectedSystemsByCVE({ id: cveName, host_type: 'rpmdnf', limit: 1 })
+        const conventionalCount = await getAffectedSystemsByCVE({ ...filters,  host_type: 'rpmdnf' })
             .then(getTotalItems);
 
         const edgeCount = isEdgeParityEnabled
-            ? await getAffectedSystemsByCVE({ id: cveName, host_type: 'edge', limit: 1 }).then(getTotalItems)
+            ? await getAffectedSystemsByCVE({ ...filters, host_type: 'edge' }).then(getTotalItems)
             : 0;
 
         setHybridSystemsCounts({

--- a/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.test.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/cveDetailHelpers.test.js
@@ -22,6 +22,7 @@ describe('cveDetailHelpers', () => {
 
         expect(getAffectedSystemsByCVE).toHaveBeenCalledTimes(1);
         expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            advisory_available: true,
             host_type: "rpmdnf",
             id: "testCve",
             limit: 1,
@@ -38,11 +39,13 @@ describe('cveDetailHelpers', () => {
 
         expect(getAffectedSystemsByCVE).toHaveBeenCalledTimes(2);
         expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            advisory_available: true,
             host_type: "rpmdnf",
             id: "testCve",
             limit: 1,
         });
         expect(getAffectedSystemsByCVE).toHaveBeenCalledWith({
+            advisory_available: true,
             host_type: "edge",
             id: "testCve",
             limit: 1,


### PR DESCRIPTION
…detail table title

Fixes: https://issues.redhat.com/browse/RHINENG-5985

For CVE detail page the request to endpoint /cves/{cve_id} for the total system count should include advisory_available=true so that the system count matches the cve list page and the system count should be only systems with advisory available

To test:
1. Run the PR locally
2. Navigate Cves page 
3. Choose a random row and note the number of systems in the systems column of that row
4. Navigate to CVE's detail page, by clicking on its name
5. Observe that the API requests to fetch systems counts are filtered by `advisoryAvailable: true`
6. Observe that the system count in the table title matches with the count you noted previously