### PR TITLE
fix(SystemsExposed): remove extra sort icons in the table

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -667,7 +667,6 @@ export const SYSTEMS_EXPOSED_HEADER = [
             </Tooltip>
         ),
         cellTransforms: [nowrap],
-        transforms: [sortable],
         isShownByDefault: true
     },
     {
@@ -684,14 +683,12 @@ export const SYSTEMS_EXPOSED_HEADER = [
                 linkToCustomerPortal={remediation === MANUAL_REMEDIATION || immutable}
             />
         ),
-        transforms: [sortable],
         isShownByDefault: true
     },
     {
         key: 'status',
         sortKey: 'status',
         title: intl.formatMessage(messages.status),
-        transforms: [sortable],
         renderFunc: (
             value,
             _id,


### PR DESCRIPTION
Removes the extra icon on initial table load in inventory pages by removing sortable table transformer. The table columns are by default made sortable in inventory module and advisor should not another transformer that is causing the extra icon.