### PR TITLE
fix(RHINENG-3072): pass correct system count to report sub-header

### DIFF
--- a/src/Helpers/ReportsHelper.js
+++ b/src/Helpers/ReportsHelper.js
@@ -175,8 +175,8 @@ export const getAffectingFilterTexts = (systemCount, systemCountPerType) => ({
 
     //hybrid inventory filter texts
     none: `${getNotImpactingText(systemCount)}, ${getConsistingText(systemCountPerType)}.`,
-    edge: `${getImpactingAtLeastText(systemCount, 'immutable')}.`,
-    rpmdnf: `${getImpactingAtLeastText(systemCount, 'conventional')}.`,
+    edge: `${getImpactingAtLeastText(systemCountPerType.edge, 'immutable')}.`,
+    rpmdnf: `${getImpactingAtLeastText(systemCountPerType.rpmdnf, 'conventional')}.`,
     'rpmdnf, edge': `${getImpactingAtLeastText(systemCount)}, ${getConsistingText(systemCountPerType)}.`,
     'rpmdnf, none': `${getImpactingOrNotText(systemCount)}, ${getConsistingText(systemCountPerType)}.`,
     'edge, none': `${getImpactingOrNotText(systemCount)}, ${getConsistingText(systemCountPerType)}.`


### PR DESCRIPTION
This fixes the reported bug in https://issues.redhat.com/browse/RHINENG-3072.

The advanced CVE report has different wording according to the systems affecting filter state. The issue was that when the pdf result was filtered by only edge or conventional systems, the system counts in the report sub-header showed the total count of both edge and conventional systems which is incorrect. This fixes it by showing the correct edge/conventional count when it is an edge-only report or conventional-only report.

To test:
1. Navigate to /reports page
2. Open advanced CVE report modal
3. Filter the pdf result by edge systems 
4. Generate the report
5. Observe that the edge system count in the report header matches the value in the `meta.system_count_per_type` object from `/vulnerabilities/cves`endpoint 