### PR TITLE
fix(RHINENG-3072): remove obsolete dot in cve pdf report

### DIFF
--- a/src/Helpers/ReportsHelper.js
+++ b/src/Helpers/ReportsHelper.js
@@ -162,7 +162,7 @@ const getImpactingOrNotText = (systemCount) =>
     `Not impacting or impacting at least one of your analyzed ${systemCount} RHEL systems`;
 
 const getConsistingText = ({ rpmdnf: conventionalCount, edge: immutableCount }) =>
-    `consisting of ${conventionalCount} conventional and ${immutableCount} immutable.`;
+    `consisting of ${conventionalCount} conventional and ${immutableCount} immutable`;
 
 const getImpactingAtLeastText = (systemCount, hostType = '') =>
     `impacting at least one of your analyzed ${systemCount} RHEL ${hostType} systems`;


### PR DESCRIPTION
Removes unnecessary dot inside CVE pdf report

1. Visit reports page
2. generate a report with both conventional immutable systems
3. observe that there is only one dot in the subheader: 'vulnerability service identified 2,606 CVEs within this criteria, impacting at least one of your analyzed 3 RHEL systems, consisting of 2 conventional and 1 immutable.' 