### PR TITLE
chore(VulnerabilityRoutes): Remove duplicate Route element

### DIFF
--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -183,17 +183,6 @@ export const VulnerabilityRoutes = () => {
                 />
 
                 <Route
-                    path={PATHS.home.to}
-                    element={
-                        <InsightsElement
-                            element={LandingPage}
-                            title={intl.formatMessage(messages.cvesHeader)}
-                            globalFilterEnabled
-                        />
-                    }
-                />
-
-                <Route
                     path={PATHS.cvesPage.to}
                     element={
                         <InsightsElement


### PR DESCRIPTION
I have noticed that this Route element is the exact same as the 'cvesPage' one, so this PR removes the duplicate

They both get the same path string and present the same element 'LandingPage' so there is no need for both Routes