### PR TITLE
fix(RHINENG-7963): Bug with select all CVEs option on CVEs page

### DIFF
--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -78,7 +78,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
         selectedItems: selectedCves,
         selectorHandler: methods.selectCves,
         items: cves,
-        fetchResource: ops => fetchCvesIds({ ...params, ...ops }),
+        fetchResource: ops => fetchCvesIds({ ...params, ...ops }, shouldUseHybridSystemFilter),
         multiRow: true
     });
 

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -44,7 +44,7 @@ const ReportsPage = () => {
     useEffect(() => {
         // this dummy request is to get the value of cves_without_errata feature flag
         // we only care about meta section of this response so the limit is 1
-        getCveListByAccount({ limit: 1 }).then(response => {
+        getCveListByAccount({ limit: 1 }, shouldUseHybridSystemFilter).then(response => {
             response?.meta?.cves_without_errata && setCvesWithoutErrata(true);
         });
 

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -100,25 +100,22 @@ export function getCveListByAccount(apiProps, shouldUseHybridSystemFilter = fals
         'affectingHostType'
     ];
 
-    const apiPropsWithFlag = {
-        ...apiProps,
-        ...shouldUseHybridSystemFilter ? { affecting: undefined, affectingHostType: apiProps.affecting } : {}
-    };
-    let parameterArray = constructParameters(apiPropsWithFlag, parameterNames);
+    let parameterArray = constructParameters(apiProps, parameterNames, shouldUseHybridSystemFilter);
     let result = api.getCveList(...parameterArray);
     return result;
 }
 
-export function getCveIdsList(apiProps) {
+export function getCveIdsList(apiProps, shouldUseHybridSystemFilter) {
     let parameterNames = [
         ...defaultParams,
         ...cveParams,
         'ansible',
         'mssql',
-        'advisory_available'
+        'advisory_available',
+        'affectingHostType'
     ];
 
-    let parameterArray = constructParameters(apiProps, parameterNames);
+    let parameterArray = constructParameters(apiProps, parameterNames, shouldUseHybridSystemFilter);
     let result = api.getCveIdsList(...parameterArray);
     return result;
 }

--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -6,12 +6,18 @@ import React from 'react';
 import { impactList, PUBLIC_DATE_OPTIONS } from './constants';
 import qs from 'query-string';
 import { coerce, compare, rcompare } from 'semver';
+import cloneDeep from 'lodash/cloneDeep';
 
 export const dataShape = propTypes.shape({
     data: propTypes.oneOfType([propTypes.object, propTypes.array]),
     meta: propTypes.object,
     isLoaded: propTypes.bool
 });
+
+const replaceAffectingFilter = (apiProps) => {
+    apiProps.affectingHostType = apiProps.affecting;
+    apiProps.affecting = undefined;
+};
 
 /**
  * Based on the  allowedParams it will construct the arguments for the API call
@@ -21,17 +27,25 @@ export const dataShape = propTypes.shape({
  * @param {Object} apiProps
  * @param {Array} allowedParams - order should align with the params in the vulnerabilities-client
  */
-export function constructParameters(apiProps, allowedParams) {
+export function constructParameters(apiProps, allowedParams, shouldUseHybridSystemFilter = false) {
     if (apiProps) {
-        Object.keys(apiProps).forEach(
+
+        const clonedApiProps = cloneDeep(apiProps);
+
+        if (shouldUseHybridSystemFilter)
+        {
+            replaceAffectingFilter(clonedApiProps);
+        }
+
+        Object.keys(clonedApiProps).forEach(
             key => (
-                apiProps[key] === undefined
-                || apiProps[key] === ''
+                clonedApiProps[key] === undefined
+                || clonedApiProps[key] === ''
             )
-                && delete apiProps[key]
+                && delete clonedApiProps[key]
         );
 
-        const params = allowedParams.map(item => apiProps[item]);
+        const params = allowedParams.map(item => clonedApiProps[item]);
 
         return params;
     }

--- a/src/Store/Actions/Actions.js
+++ b/src/Store/Actions/Actions.js
@@ -186,12 +186,12 @@ export const fetchSystemsIds = (apiProps) => ({
     payload: APIHelper.getSystemsIds(apiProps)
 });
 
-export const fetchCvesIds = (apiProps) => ({
+export const fetchCvesIds = (apiProps, shouldUseHybridSystemFilter) => ({
     type: ActionTypes.FETCH_CVE_LIST_IDS,
     meta: {
         noNotificationOnStatus: [403]
     },
-    payload: APIHelper.getCveIdsList(apiProps)
+    payload: APIHelper.getCveIdsList(apiProps, shouldUseHybridSystemFilter)
 });
 
 export const fetchCveIdsBySystem = (apiProps) => ({


### PR DESCRIPTION
This PR addresses issue [#RHINENG-7963](https://issues.redhat.com/browse/RHINENG-7963)

When attempting to "select all" CVEs in the CVEs Page, none are selected
With this code selecting all CVEs works

The reason why this bug occurres:
If a user has Edge systems in their account, we need to convert the affecting param to be in affectingHostType 
So, we use hybrid system filter to determine this.
- If the user have both Conventional & Edge systems, we convert the affecting params to be in affectingHostType params because affecting is no longer being used in the backend in this case.
- If the user has only Conventional systems, the backend still uses affecting param, so there is no need for the conversion.

Because affecting param is no longer being used in the backend in the first case, sending it in the request would make the request fail, or in case the request does not fail, it would return bad results

Location where this 'selectAllCVEs' option is located:
![Location where this 'selectAllCVEs' option is located](https://github.com/RedHatInsights/vulnerability-ui/assets/93318917/a050ee60-d81c-4dbf-9f13-1ebce0cd90c4)
