### PR TITLE
fix(RHINENG-3205): Global filter kept after refresh

### DIFF
--- a/src/Helpers/MiscHelper.js
+++ b/src/Helpers/MiscHelper.js
@@ -179,7 +179,7 @@ export const useUrlParams = (allowedParams) => {
 
     const setUrlParams = (parameters) => {
         const searchParams = qs.stringify(constructURLParameters(parameters, allowedParams));
-        window.history.replaceState(null, null, `${url.origin}${url.pathname}?${searchParams}`);
+        window.history.replaceState(null, null, `${url.origin}${url.pathname}?${searchParams}${url.hash}`);
     };
 
     return [urlParams, setUrlParams];


### PR DESCRIPTION
[RHINENG-3205](https://issues.redhat.com/browse/RHINENG-3205)

Global filter is lost after reload because the hash is lost.

How to test:
1. Go to Systems page, apply some filters, apply a global filter and refresh
2. The data should be the same and the global filter chip should be visible
3. Repeat for CVE Details page