### PR TITLE
fix(RHINENG-10236): Edit status in System detail

### DIFF
--- a/src/Components/SmartComponents/Modals/CvePairStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CvePairStatusModal.js
@@ -8,13 +8,13 @@ import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
 
 export const CvePairStatusModal = ({ cveList, updateRef, inventoryList, intl, type }) => {
+    const [isOverallChecked, setOverallCheckbox] = useState(getDefaultCheckboxState());
     const {
         JustificationInput,
         justification,
         setJustification,
         setProps: setJustificationProps
     } = useJustificationInput(getJustification());
-    const [isOverallChecked, setOverallCheckbox] = useState(getDefaultCheckboxState());
     const { StatusSelect, statusId, setStatusId, setProps: setSelectProps } = useStatusSelect(getCveStatus());
     const inventoryIds = inventoryList.map(item => item.id || item.inventory_id);
     const inventoryNames = inventoryList.map(item => item.display_name);


### PR DESCRIPTION
[RHINENG-10236](https://issues.redhat.com/browse/RHINENG-10236)

State was ordered in the wrong way
![image](https://github.com/RedHatInsights/vulnerability-ui/assets/20592948/3bee9561-cfb2-4f58-9b12-f4c63b43fff5)

### How to test:
1. Go to systems and pick a system that has some CVEs
2. In the table click the kebab menu and click "Edit status"
3. There shouldn't be an error

### Before:
![image](https://github.com/RedHatInsights/vulnerability-ui/assets/20592948/539c703c-4025-4435-9bbe-4c5e84b6337d)


### After:
![image](https://github.com/RedHatInsights/vulnerability-ui/assets/20592948/743c06a0-3e8e-44e7-bf8f-ab97953aa327)

