### PR TITLE
Improve CVEs page loading and general page loading user experience

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -242,7 +242,7 @@
   "osFilterPlaceholder": "Filter by operating system",
   "ovalPopoverBody": "The Vulnerability service identifies CVEs that may affect your Insights-connected RHEL systems",
   "ovalPopoverHeader": "About CVEs in Red Hat Insights",
-  "pageTitleSuffix": "Vulnerability | Red Hat Insights",
+  "pageTitleSuffix": "Vulnerability",
   "pdf.reportName": "Insights Vulnerability CVE report",
   "pdf.systemName": "Insights Vulnerability Systems report",
   "playbook": "Playbook",

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -138,8 +138,10 @@ export const SystemCVEs = ({
     useEffect(() => {
         if (isFirstLoad) {
             if (setPageTitle) {
-                chrome.updateDocumentTitle(`${entity.display_name}
-                - ${intl.formatMessage(messages.systemsHeader)} - ${intl.formatMessage(messages.pageTitleSuffix)}`);
+                chrome.updateDocumentTitle(
+                    `${entity.display_name} - Systems - Vulnerability | RHEL`,
+                    true
+                );
             }
 
             setFirstLoad(false);

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -139,8 +139,7 @@ export const SystemCVEs = ({
         if (isFirstLoad) {
             if (setPageTitle) {
                 chrome.updateDocumentTitle(
-                    `${entity.display_name} - Systems - Vulnerability | RHEL`,
-                    true
+                    `${entity.display_name} - Systems - Vulnerability`
                 );
             }
 

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1628,7 +1628,7 @@ export default defineMessages({
     pageTitleSuffix: {
         id: 'pageTitleSuffix',
         description: 'Suffix to all page titles, preceded by page name',
-        defaultMessage: 'Vulnerability | Red Hat Insights'
+        defaultMessage: 'Vulnerability'
     },
     knownExploitHeader: {
         id: 'knownExploitHeader',

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -101,8 +101,7 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
 
     useEffect(() => {
         chrome.updateDocumentTitle(
-            `${subPath ? `${subPath} - ` : ''} ${title} - ${intl.formatMessage(messages.pageTitleSuffix)}`,
-            true
+            `${subPath ? `${subPath} - ` : ''} ${title} - ${intl.formatMessage(messages.pageTitleSuffix)}`
         );
     }, [chrome, intl, subPath]);
 

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -100,8 +100,10 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
     const subPath = location.pathname && location.pathname.split('/')[4];
 
     useEffect(() => {
-        chrome.updateDocumentTitle(`${subPath ? `${subPath} - ` : ''} ${title} -
-         ${intl.formatMessage(messages.pageTitleSuffix)}`);
+        chrome.updateDocumentTitle(
+            `${subPath ? `${subPath} - ` : ''} ${title} - ${intl.formatMessage(messages.pageTitleSuffix)}`,
+            true
+        );
     }, [chrome, intl, subPath]);
 
     useEffect(() => {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8" />
-        <title>Vulnerability | Red Hat Insights</title>
+        <title>Vulnerability</title>
         <esi:include src="/@@env/chrome/snippets/head.html" />
     </head>
     <body>


### PR DESCRIPTION
Essentially, this is an effort to improve the perceived performance of CVEs page. Before this change, the whole table was triggered loading and once the request to fetch cves for the table resolves, according to the advisor_availability info in the metadata, a new filter 'Advisor availability filter' was added. This would result in complete re-render of the table and the same API request to be triggered once more. Now, the advisory availability info is fetched on the very first page load with `limit:1` and provided across components using react context.

Furthermore, there is another improvement for the general page loading user experience. Before, for example, while CVEs page was loading, the spinner would be displayed first in the center, then on top smaller, then on top bigger. This was not very pretty. Now, as one component is shared, the spinner is displayed only in the center. This improvement needs to be tested with this fix in the fec-components package: https://github.com/RedHatInsights/frontend-components/pull/2010