### PR TITLE
Improve advisor availability filter and general page loading user experience

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,8 +16,8 @@ import './App.scss';
 import ReadOnlyBanner from './Components/PresentationalComponents/ReadOnlyBanner/ReadOnlyBanner';
 import { useRbac } from './Helpers/Hooks';
 import { PERMISSIONS } from './Helpers/constants';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import PageLoading from './Components/PresentationalComponents/Snippets/PageLoading';
 
 ReducerRegistry.register({ notifications });
 
@@ -53,7 +53,7 @@ const App = () => {
     window.setReadOnlyBannerVisible = setVisible => setReadOnlyBannerVisible(setVisible);
 
     return (
-        isLoading ? <Spinner size="lg" /> : isUserAuthorized ?
+        isLoading ? <PageLoading /> : isUserAuthorized ?
             <Fragment>
                 <NotificationPortal />
                 {isReadOnlyBannerVisible && <ReadOnlyBanner />}

--- a/src/App.scss
+++ b/src/App.scss
@@ -5,6 +5,7 @@
 
 .vuln-root {
     overflow: inherit !important;
+    height: 100% !important;
 
     .ins-c-conditional-filter {
         .ins-c-conditional-filter__group {

--- a/src/Components/PresentationalComponents/Snippets/PageLoading.js
+++ b/src/Components/PresentationalComponents/Snippets/PageLoading.js
@@ -2,8 +2,11 @@ import React from 'react';
 import { Bullseye } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core';
 
-export default () => (
+const PageLoading = () => (
     <Bullseye>
         <Spinner />
     </Bullseye>
 );
+
+export default PageLoading;
+

--- a/src/Components/PresentationalComponents/Snippets/PageLoading.js
+++ b/src/Components/PresentationalComponents/Snippets/PageLoading.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Bullseye } from '@patternfly/react-core';
+import { Spinner } from '@patternfly/react-core';
+
+export default () => (
+    <Bullseye>
+        <Spinner />
+    </Bullseye>
+);

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert, Stack, StackItem } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
@@ -28,6 +28,7 @@ import { useColumnManagement, useHybridSystemFilterFlag, useRbac } from '../../.
 import { NotAuthorized } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { getCveDefaultFilters } from './CVEsAssets';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 export const CVETableContext = React.createContext({});
 
@@ -36,6 +37,7 @@ export const CVEs = ({ rbac }) => {
     const [CveStatusModal, setStatusModal] = useState(() => () => null);
     const [CveBusinessRiskModal, setBusinessRiskModal] = useState(() => () => null);
     const [isFirstLoad, setFirstLoad] = useState(true);
+    const { isAdvisoryAvailable, includesCvesWithoutErrata } = useContext(AccountStatContext);
 
     const [[
         canEditStatusOrBusinessRisk,
@@ -175,7 +177,7 @@ export const CVEs = ({ rbac }) => {
 
                         <Stack>
                             <StackItem>
-                                {cves.meta.cves_without_errata && cves.meta.advisory_available !== 'True' &&
+                                {includesCvesWithoutErrata && isAdvisoryAvailable !== 'True' &&
                                     <Alert
                                         variant="info"
                                         isInline

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -23,12 +23,12 @@ import {
     clearNotifications
 } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
-import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import { useColumnManagement, useHybridSystemFilterFlag, useRbac } from '../../../Helpers/Hooks';
 import { NotAuthorized } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { getCveDefaultFilters } from './CVEsAssets';
 import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
+import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 
 export const CVETableContext = React.createContext({});
 
@@ -150,7 +150,7 @@ export const CVEs = ({ rbac }) => {
 
     if (!cves.errors) {
         return (
-            isRbacLoading ? <Spinner centered /> : canReadVulnerabilityResults ?
+            isRbacLoading ? <PageLoading /> : canReadVulnerabilityResults ?
                 (
                     <CVETableContext.Provider
                         value={{

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
@@ -36,42 +36,41 @@ import { fetchCvesIds } from '../../../Store/Actions/Actions';
 import { setCvesWithoutErrata } from '../../../Helpers/APIHelper';
 import { getCveDefaultFilters } from './CVEsAssets';
 import { useHybridSystemFilterFlag } from '../../../Helpers/Hooks';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, canExport, canToggleCvesWithoutErrata, intl }) => {
     const [exportPDF, setExportPDF] = useState(false);
 
     const { cves, params, methods, selectedCves } = context;
-    const { isLoading } = cves;
 
     const { filter } = params;
     const selectedCvesCount = selectedCves && selectedCves.length;
 
     const [showCvesWithoutErrata, setShowCvesWithoutErrata] = useState(null);
     const shouldUseHybridSystemFilter = useHybridSystemFilterFlag();
+    const { includesCvesWithoutErrata } = useContext(AccountStatContext);
 
     useEffect(() => {
-        if (!isLoading) {
-            // if the API response feature flag value differs currently saved one
-            if (showCvesWithoutErrata !== cves?.meta?.cves_without_errata) {
-                if (cves?.meta?.cves_without_errata === true) {
-                    if (!params.advisory_available) {
-                        methods.apply({ advisory_available: 'true' });
-                    }
-                }
-                else {
-                    if (params.advisory_available) {
-                        methods.apply({ advisory_available: undefined });
-                    }
+        // if the API response feature flag value differs currently saved one
+        if (showCvesWithoutErrata !== includesCvesWithoutErrata) {
+            if (includesCvesWithoutErrata === true) {
+                if (!params.advisory_available) {
+                    methods.apply({ advisory_available: 'true' });
                 }
             }
-
-            setShowCvesWithoutErrata(cves?.meta?.cves_without_errata);
+            else {
+                if (params.advisory_available) {
+                    methods.apply({ advisory_available: undefined });
+                }
+            }
         }
-    }, [cves?.meta?.cves_without_errata, isLoading]);
+
+        setShowCvesWithoutErrata(includesCvesWithoutErrata);
+    }, [includesCvesWithoutErrata]);
 
     const defaultFilters = {
         ...getCveDefaultFilters(shouldUseHybridSystemFilter),
-        ...cves?.meta?.cves_without_errata ? { advisory_available: 'true' } : {}
+        ...includesCvesWithoutErrata ? { advisory_available: 'true' } : {}
     };
 
     const selectOptions = selectAllCheckbox({

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -66,7 +66,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
         }
 
         setShowCvesWithoutErrata(includesCvesWithoutErrata);
-    }, [includesCvesWithoutErrata]);
+    }, [includesCvesWithoutErrata, showCvesWithoutErrata, params]);
 
     const defaultFilters = {
         ...getCveDefaultFilters(shouldUseHybridSystemFilter),

--- a/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
+++ b/src/Components/SmartComponents/HybridInventory/ImmutableDevicesTab/ImmutableDevices.js
@@ -18,13 +18,13 @@ import {
 import ErrorHandler from '../../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { EmptyStateNoSystems } from '../../../PresentationalComponents/EmptyStates/EmptyStates';
 import { useGetEntities, mergeAppColumns, useOnLoad } from './helpers.js';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { buildActiveFilters, removeFilters, isFilterInDefaultState } from '../../../../Helpers/TableToolbarHelper';
 import useSearchFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import useSecurityRuleFilter from '../../../PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter';
 import AsynComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { useRbac } from '../../../../Helpers/Hooks';
 import messages from '../../../../Messages';
+import PageLoading from '../../../PresentationalComponents/Snippets/PageLoading';
 
 const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, headerFilters }) => {
     const [[canReadHostsInventory], isLoadingInventory] = useRbac([
@@ -97,7 +97,7 @@ const ImmutableDevices = ({ intl, cveName, filterRuleValues, inventoryRef, heade
     const onLoad = useOnLoad(parameters);
 
     if (isLoadingInventory) {
-        return <Spinner size="lg" />;
+        return <PageLoading />;
     }
 
     if (error?.hasError || !canReadHostsInventory) {

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -16,8 +16,8 @@ import styles from './Common/styles';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useHybridSystemFilterFlag, useRbac } from '../../../Helpers/Hooks';
 import NoAccessPage from '../../PresentationalComponents/StaticPages/NoAccessPage';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { getCveListByAccount } from '../../../Helpers/APIHelper';
+import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 
 const ReportsPage = () => {
     const [[canDoAdvancedReporting, canReadVulnerabilities, canReadInventory], isLoading]
@@ -75,7 +75,7 @@ const ReportsPage = () => {
     };
 
     return (
-        isLoading ? <Spinner centered /> :
+        isLoading ? <PageLoading /> :
             (canDoAdvancedReporting && canReadInventory) ? (
                 <React.Fragment>
                     <Header title={intl.formatMessage(messages.reportsPageTitle)} showBreadcrumb={false} />

--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -49,12 +49,12 @@ const SystemCveToolbarWithContext = ({
     const isAdvisoryAvailableFilterAllowed = !Array.isArray(filters) || filters.includes('advisory_available');
 
     useEffect(() => {
-        if (isAdvisoryAvailableFilterAllowed && cves?.meta?.cves_without_errata === true) {
+        if (isAdvisoryAvailableFilterAllowed && showingCvesWithoutErrata) {
             if (!parameters.advisory_available) {
                 methods.apply({ advisory_available: 'true' });
             }
         }
-    }, [cves?.meta?.cves_without_errata]);
+    }, [showingCvesWithoutErrata]);
 
     const selectOptions = useMemo(() => selectAllCheckbox({
         selectedItems: selectedCves,
@@ -98,7 +98,7 @@ const SystemCveToolbarWithContext = ({
     ];
 
     const defaultFilters = {
-        ...(cves?.meta?.cves_without_errata && isAdvisoryAvailableFilterAllowed)
+        ...(showingCvesWithoutErrata && isAdvisoryAvailableFilterAllowed)
             ? { advisory_available: 'true' }
             : {}
     };

--- a/src/Components/SmartComponents/SystemCves/SystemCves.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCves.js
@@ -3,7 +3,8 @@ import React, {
     useEffect,
     Fragment,
     createContext,
-    useState
+    useState,
+    useContext
 } from 'react';
 import {
     fetchCveListBySystem,
@@ -44,6 +45,7 @@ import {
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import { useColumnManagement } from '../../../Helpers/Hooks';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { AccountStatContext } from '../../../Utilities/VulnerabilityRoutes';
 
 export const CVETableContext = createContext({});
 
@@ -92,6 +94,7 @@ export const SystemCVEs = ({
         entity.id, systemCVEs, columns, linkToCustomerPortal
     ), [systemCVEs, systemCVEs.isLoading, entity.id, columns]);
     const [urlParameters, setUrlParams] = useUrlParams(CVES_ALLOWED_PARAMS);
+    const { includesCvesWithoutErrata } = useContext(AccountStatContext);
 
     const downloadReport = format => {
         const params = { ...parameters, system: entity.id };
@@ -235,7 +238,7 @@ export const SystemCVEs = ({
                             canSelect={canSelect && canEditPairStatus}
                             canManageColumns={canManageColumns}
                             filters={filters}
-                            showingCvesWithoutErrata={cves?.meta?.cves_without_errata}
+                            showingCvesWithoutErrata={includesCvesWithoutErrata}
                         />
                     </StackItem>
                 </Stack>

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetails.js
@@ -6,11 +6,11 @@ import {
     EmptyStateExcludedSystem,
     NotAuthorized
 } from '../../PresentationalComponents/EmptyStates/EmptyStates';
-import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';
 import { PERMISSIONS, SERVICE_NAME } from '../../../Helpers/constants';
 import { useRbac } from '../../../Helpers/Hooks';
+import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 
 const SystemDetails = ({ optOutSystemHandler }) => {
     const { loaded, opt_out: isOptOut } = useSelector(({ SystemDetailsPageStore }) => SystemDetailsPageStore) ?? {};
@@ -29,7 +29,7 @@ const SystemDetails = ({ optOutSystemHandler }) => {
     );
 
     if (isRbacLoading) {
-        return <Spinner centered />;
+        return <PageLoading />;
     } else if (canReadVulnerabilityResults) {
         if (entity && loaded && isOptOut) {
             if (canReadExcluded) {
@@ -46,7 +46,7 @@ const SystemDetails = ({ optOutSystemHandler }) => {
                 canEditPairStatus={canEditPairStatus}
             />;
         } else {
-            return loaded ? null : <Spinner centered />;
+            return loaded ? null : <PageLoading />;
         }
     } else {
         return <NotAuthorized serviceName={SERVICE_NAME} />;

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -38,7 +38,6 @@ import {
 import { EmptyStateNoSystems } from '../../PresentationalComponents/EmptyStates/EmptyStates';
 import { useBulkSelect, useColumnManagement, useGetEntities, useRbac } from '../../../Helpers/Hooks';
 import * as APIHelper from '../../../Helpers/APIHelper';
-import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 import { buildActiveFilters, exportConfig, isFilterInDefaultState, removeFilters } from '../../../Helpers/TableToolbarHelper';
 import Remediation from '../Remediation/Remediation';
 import securityRuleFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SecurityRuleFilter';
@@ -46,6 +45,7 @@ import statusFilter from '../../PresentationalComponents/Filters/PrimaryToolbarF
 import useSearchFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import remediationFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/RemediationFilter';
 import advisoryAvailabilityFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/AdvisoryAvailabilityFilter';
+import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 
 const SystemsExposedTable = ({
     intl, cveName, cveStatusDetails, filterRuleValues,
@@ -225,7 +225,7 @@ const SystemsExposedTable = ({
         <Fragment>
             {StatusModal && <StatusModal />}
             {ColumnManagementModal}
-            {isLoadingInventory ? <Spinner centered /> :
+            {isLoadingInventory ? <PageLoading /> :
                 error?.hasError && !canReadHostsInventory
                     ? <ErrorHandler code={error?.errorCode} />
                     : <InventoryTable

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -38,6 +38,7 @@ import DownloadReport from '../../../Helpers/DownloadReport';
 import useSearchFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/SearchFilter';
 import excludedFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/ExcludedFilter';
 import EdgeDevicesWarning from './EdgeDevicesWarning';
+import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 
 const SystemsPage = () => {
     const [[
@@ -178,7 +179,7 @@ const SystemsPage = () => {
     const canSelect = canSetExcludedIncluded;
 
     return (
-        isLoading ? <Spinner centered /> :
+        isLoading ? <PageLoading /> :
             canReadVulnerabilityResults ? <Fragment>
                 {ColumnManagementModal}
 

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -131,6 +131,7 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
             app="Vulnerability"
             aria-label="Zero state"
             customFetchResults={checkForAccountSystems(isEdgeParityEnabled, hasEdgeDevices, hasConventionalSystems)}
+            className="pf-v5-u-h-100"
         >
             <AccountStatContext.Provider value={{
                 hasConventionalSystems,

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, lazy, Suspense, Fragment, createContext } from 'react';
+import React, { useEffect, useState, lazy, Suspense, createContext } from 'react';
 import PropTypes from 'prop-types';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { checkEdgePresence, getRhelSystems, getCveListByAccount } from '../Helpers/APIHelper';
@@ -9,9 +9,9 @@ import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComp
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import useFeatureFlag from './useFeatureFlag';
-import { Bullseye, Spinner } from '@patternfly/react-core';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { useNotification } from '../Helpers/Hooks';
+import PageLoading from '../Components/PresentationalComponents/Snippets/PageLoading';
 
 const SystemsPage = lazy(() =>
     import(
@@ -80,7 +80,7 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
                     {
                         cves_without_errata: cvesWithoutErrata, advisory_available: advisoryAvailable
                     } = {}
-                } =  await getCveListByAccount({ limit: 50 });
+                } =  await getCveListByAccount({ limit: 1 });
 
                 setHasConventionalSystems(rhelSystems);
                 setIncludesCvesWithoutErrata(cvesWithoutErrata);
@@ -119,11 +119,7 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
     }, [location.pathname]);
 
     if (isLoading) {
-        return (
-            <Bullseye>
-                <Spinner size="lg" aria-label="Spinner"/>
-            </Bullseye>
-        );
+        return <PageLoading />;
     }
 
     return hasAccess
@@ -131,7 +127,6 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
             appId="vulnerability_zero_state"
             appName="dashboard"
             module="./AppZeroState"
-            scope="dashboard"
             ErrorComponent={<ErrorState />}
             app="Vulnerability"
             aria-label="Zero state"
@@ -170,7 +165,7 @@ InsightsElement.propTypes = {
 
 export const VulnerabilityRoutes = () => {
     return (
-        <Suspense fallback={Fragment}>
+        <Suspense fallback={<PageLoading />}>
             <Routes>
                 <Route
                     path={PATHS.cveDetailsPage.to}

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, lazy, Suspense, Fragment, createContext } from 'react';
 import PropTypes from 'prop-types';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import { checkEdgePresence, getRhelSystems } from '../Helpers/APIHelper';
+import { checkEdgePresence, getRhelSystems, getCveListByAccount } from '../Helpers/APIHelper';
 import { PATHS } from '../Helpers/constants';
 import { intl } from './IntlProvider';
 import messages from '../Messages';
@@ -60,38 +60,47 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
     const [hasConventionalSystems, setHasConventionalSystems] = useState(true);
     const [hasEdgeDevices, setHasEdgeDevices] = useState(true);
     const [hasAccess, setHasAccess] = useState(true);
+    const [includesCvesWithoutErrata, setIncludesCvesWithoutErrata] = useState();
+    const [isAdvisoryAvailable, setAdvisoryAvailable] = useState();
     const [addNotification] = useNotification();
     const isEdgeParityEnabled = useFeatureFlag('vulnerability.edge_parity');
     const chrome = useChrome();
 
     useEffect(() => {
         const fetchData = async () => {
-            getRhelSystems()
-                .then(async result =>  {
-                    if (isEdgeParityEnabled) {
-                        //if there is at least 1 edge device in the account level, not only in vulnerability
-                        const edgeDevicePresent = await checkEdgePresence();
-                        setHasEdgeDevices(edgeDevicePresent);
-                    }
+            try {
+                const rhelSystems = await getRhelSystems();
+                if (isEdgeParityEnabled) {
+                    //if there is at least 1 edge device in the account level, not only in vulnerability
+                    const edgeDevicePresent = await checkEdgePresence();
+                    setHasEdgeDevices(edgeDevicePresent);
+                }
 
-                    setHasConventionalSystems(result);
-                    setLoading(false);
-                })
-                .catch(error => {
-                    if (error.status === '403') {
-                        setHasAccess(false);
-                    }
-                    else {
-                        addNotification({
-                            variant: 'danger',
-                            autoDismiss: false,
-                            msg: 'Failed to fetch systems',
-                            description: error.detail
-                        });
-                    }
+                const { meta:
+                    {
+                        cves_without_errata: cvesWithoutErrata, advisory_available: advisoryAvailable
+                    } = {}
+                } =  await getCveListByAccount({ limit: 50 });
 
-                    setLoading(false);
-                });
+                setHasConventionalSystems(rhelSystems);
+                setIncludesCvesWithoutErrata(cvesWithoutErrata);
+                setAdvisoryAvailable(advisoryAvailable);
+                setLoading(false);
+            } catch (error) {
+                if (error.status === '403') {
+                    setHasAccess(false);
+                }
+                else {
+                    addNotification({
+                        variant: 'danger',
+                        autoDismiss: false,
+                        msg: 'Failed to fetch systems',
+                        description: error.detail
+                    });
+                }
+
+                setLoading(false);
+            }
         };
 
         fetchData();
@@ -128,7 +137,12 @@ export const InsightsElement = ({ element: Element, title, globalFilterEnabled, 
             aria-label="Zero state"
             customFetchResults={checkForAccountSystems(isEdgeParityEnabled, hasEdgeDevices, hasConventionalSystems)}
         >
-            <AccountStatContext.Provider value={{ hasConventionalSystems, hasEdgeDevices }}>
+            <AccountStatContext.Provider value={{
+                hasConventionalSystems,
+                hasEdgeDevices,
+                includesCvesWithoutErrata,
+                isAdvisoryAvailable
+            }}>
                 <Element
                     {...elementProps}
                     hasEdgeDevices={hasEdgeDevices}

--- a/src/Utilities/VulnerabilityRoutes.test.js
+++ b/src/Utilities/VulnerabilityRoutes.test.js
@@ -35,7 +35,10 @@ describe('VulnerabilityRoutes', () => {
             </ComponentWithContext>);
 
             expect(
-                screen.getByLabelText('Spinner')
+                screen.getByRole(
+                    'progressbar', 
+                    { class: 'pf-v5-c-spinner pf-m-xl' }
+                )
             ).toBeVisible();
         });
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ import SystemCVEs from './Components/SmartComponents/SystemCves/SystemCves';
 import { SystemCvesStore } from './Store/Reducers/SystemCvesStore';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useRbac } from './Helpers/Hooks';
 import { PERMISSIONS } from './Helpers/constants';
+import PageLoading from './Components/PresentationalComponents/Snippets/PageLoading';
 
 const WrappedSystemCves = ({ getRegistry, ...props }) => {
     const [Wrapper, setWrapper] = useState();
@@ -21,11 +21,11 @@ const WrappedSystemCves = ({ getRegistry, ...props }) => {
     }, []);
 
     return (
-        Wrapper ? <Wrapper {...getRegistry && { store: getRegistry()?.getStore() }}>
-            <SystemCVEs canExport={canExport} canEditPairStatus={canEditPairStatus} {...props} />
-        </Wrapper> : <Bullseye>
-            <Spinner size="xl" />
-        </Bullseye>
+        Wrapper ?
+            <Wrapper {...getRegistry && { store: getRegistry()?.getStore() }}>
+                <SystemCVEs canExport={canExport} canEditPairStatus={canEditPairStatus} {...props} />
+            </Wrapper>
+            : <PageLoading />
     );
 };
 


### PR DESCRIPTION
Essentially, this is an effort to improve the perceived performance of CVEs page. Before this change, the whole table was triggered loading and once the request to fetch cves for the table resolves, according to the advisor_availability info in the metadata, a new filter 'Advisor availability filter' was added. This would result in complete re-render of the table and the same API request to be triggered once more. Now, the advisory availability info is fetched on the very first page load with limit:1 and provided across components using react context.

Furthermore, there is another improvement for the general page loading user experience. Before, for example, while CVEs page was loading, the spinner would be displayed first in the center, then on top smaller, then on top bigger. This was not very pretty. Now, as one component is shared, the spinner is displayed only in the center. This improvement needs to be tested with this fix in the fec-components package: https://github.com/RedHatInsights/frontend-components/pull/2010