### PR TITLE
chore: Remove deprecated Main component

### DIFF
--- a/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
+++ b/src/Components/PresentationalComponents/StaticPages/NoAccessPage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import messages from '../../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
 import { NotAuthorized } from '../EmptyStates/EmptyStates';
@@ -13,11 +12,11 @@ const NoAccessPage = ({ intl, title = intl.formatMessage(messages.vulnerabilitie
                 title={title}
                 showBreadcrumb={false}
             />
-            <Main>
+            <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <NotAuthorized
                     title={emptyStateTitle}
                 />
-            </Main>
+            </section>
         </React.Fragment>
     );
 };

--- a/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
+++ b/src/Components/PresentationalComponents/StaticPages/UpgradePage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { CloudServerIcon } from '@patternfly/react-icons';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import {
     Bullseye,
     Button,
@@ -22,7 +21,7 @@ const UpgradePage = ({ intl }) =>
             showBreadcrumb={false}
             title={intl.formatMessage(messages.vulnerabilitiesHeader)}
         />
-        <Main>
+        <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
             <Bullseye>
                 <EmptyState>
                     <EmptyStateHeader
@@ -42,7 +41,7 @@ const UpgradePage = ({ intl }) =>
                         </Button>
                     </EmptyStateFooter></EmptyState>
             </Bullseye>
-        </Main>
+        </section>
     </React.Fragment>;
 
 UpgradePage.propTypes = {

--- a/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
+++ b/src/Components/SmartComponents/CVEDetailsPage/CVEDetailsPage.js
@@ -1,4 +1,3 @@
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import React, { useMemo, useState, useEffect, Fragment } from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { createCveDetailsPage } from '../../../Helpers/CVEHelper';
@@ -179,7 +178,7 @@ const CVEDetailsPage = (props) => {
                             <StatusModal />
                             <BusinessModal />
                         </Header>
-                        <Main>
+                        <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                             <Stack hasGutter>
                                 <StackItem>
                                     <CVEDetailTableTitle />
@@ -199,7 +198,7 @@ const CVEDetailsPage = (props) => {
                                     />
                                 </StackItem>
                             </Stack>
-                        </Main>
+                        </section>
                     </Fragment>
                 )) : (
                 <React.Fragment>

--- a/src/Components/SmartComponents/Dashbar/Dashbar.js
+++ b/src/Components/SmartComponents/Dashbar/Dashbar.js
@@ -13,7 +13,6 @@ import {
     Tooltip,
     Icon
 } from '@patternfly/react-core';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { SecurityIcon } from '@patternfly/react-icons';
 import { impactList } from '../../../Helpers/constants';
 import { constructFilterParameters, sanitizeLinks } from '../../../Helpers/MiscHelper';
@@ -127,7 +126,7 @@ const Dashbar = () => {
     const CVES_DEFAULT_FILTERS = getCveDefaultFilters(shouldUseHybridSystemFilter);
 
     return (
-        <Main style={{ paddingBottom: 0 }}>
+        <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section" style={{ paddingBottom: 0 }}>
             <Stack hasGutter>
                 <StackItem>
                     {!isDashbarLoading ? (
@@ -224,7 +223,7 @@ const Dashbar = () => {
                     </StackItem>
                 )}
             </Stack>
-        </Main>
+        </section>
     );
 };
 

--- a/src/Components/SmartComponents/LandingPage/LandingPage.js
+++ b/src/Components/SmartComponents/LandingPage/LandingPage.js
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl';
 import { Icon, Popover } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import messages from '../../../Messages';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import Header from '../../PresentationalComponents/Header/Header';
 import CVEs from '../CVEs/CVEs';
 import Dashbar from '../Dashbar/Dashbar';
@@ -41,9 +40,9 @@ const LandingPage = () => {
         <Fragment>
             <Header title={title} showBreadcrumb={false} />
             <Dashbar />
-            <Main>
+            <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <CVEs />
-            </Main>
+            </section>
         </Fragment>
     );
 };

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Grid, GridItem, Card, CardTitle, CardBody, CardFooter, Icon } from '@patternfly/react-core';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { FileAltIcon } from '@patternfly/react-icons';
 import DownloadExecutive from './DownloadExecutive';
 import ReportConfigModal from '../Modals/ReportConfigModal';
@@ -79,7 +78,7 @@ const ReportsPage = () => {
             (canDoAdvancedReporting && canReadInventory) ? (
                 <React.Fragment>
                     <Header title={intl.formatMessage(messages.reportsPageTitle)} showBreadcrumb={false} />
-                    <Main>
+                    <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                         <Grid hasGutter lg={3} md={4} sm={12}>
                             <GridItem>
                                 <Card className="report-card">
@@ -124,7 +123,7 @@ const ReportsPage = () => {
                                 </GridItem>
                             }
                         </Grid>
-                    </Main>
+                    </section>
                     <ReportConfigModal
                         aria-label="Report Config Modal"
                         isOpen={isModalOpen}

--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -1,4 +1,3 @@
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { addNotification, clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -130,9 +129,9 @@ const InventoryDetail = () => {
                     )}
                 </Header>
             </section>
-            <Main>
+            <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <SystemDetails optOutSystemHandler={handleOptOutSystem} />
-            </Main>
+            </section>
         </DetailWrapper>
     );
 };

--- a/src/Components/SmartComponents/SystemsPage/SystemsPage.js
+++ b/src/Components/SmartComponents/SystemsPage/SystemsPage.js
@@ -10,7 +10,6 @@ import {
     SYSTEMS_FILTER_PARAMS
 } from '../../../Helpers/constants';
 import ReducerRegistry from '../../../Utilities/ReducerRegistry';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { systemTableRowActions } from '../../../Helpers/CVEHelper';
 import Header from '../../PresentationalComponents/Header/Header';
 import { inventoryEntitiesReducer } from '../../../Store/Reducers/InventoryEntitiesReducer';
@@ -183,7 +182,7 @@ const SystemsPage = () => {
                 {ColumnManagementModal}
 
                 <Header title={intl.formatMessage(messages.vulnerabilitySystemsHeader)} showBreadcrumb={false} />
-                <Main>
+                <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                     <EdgeDevicesWarning/>
                     {isLoadingInventory ? <Spinner centered /> :
                         hasError && !canReadHostsInventory
@@ -256,7 +255,7 @@ const SystemsPage = () => {
                                     } : null}
                                 />
                             )}
-                </Main>
+                </section>
             </Fragment> : <NoAccessPage />
     );
 };


### PR DESCRIPTION
This should not change anything about the app, only that the console errors with deprecation warnings go away, not even snapshots were affected.