### PR TITLE
fix(RHINENG-10459): route SystemDetails page using InsightsElement

### DIFF
--- a/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
+++ b/src/Components/SmartComponents/SystemCves/SystemCveTableToolbar.js
@@ -54,7 +54,7 @@ const SystemCveToolbarWithContext = ({
                 methods.apply({ advisory_available: 'true' });
             }
         }
-    }, [showingCvesWithoutErrata]);
+    }, [showingCvesWithoutErrata, isAdvisoryAvailableFilterAllowed]);
 
     const selectOptions = useMemo(() => selectAllCheckbox({
         selectedItems: selectedCves,

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -190,7 +190,12 @@ export const VulnerabilityRoutes = () => {
                 />
                 <Route
                     path={PATHS.systemDetailsPage.to}
-                    element={<SystemDetailsPage />}
+                    element={<InsightsElement
+                        element={SystemDetailsPage}
+                        title={intl.formatMessage(messages.systemsHeader)}
+                        globalFilterEnabled
+                    />
+                    }
                 />
 
                 <Route


### PR DESCRIPTION
This fixes https://issues.redhat.com/browse/RHINENG-10459 by routing to SytemsCVEs using InsightsElement. Before this, as the component was not wrapped with InsightsElement, account context, and also other insights element component logic (e.g zero-state check) were not enabled on it. Now, account state context properly passes the required info `includesCvesWithoutErrata` to SystemCVEs and thus the filter is fixed.