### PR TITLE
Fix duplicate OS versions in CVE report modal dropdown

### DIFF
--- a/src/Components/SmartComponents/Reports/Common/buildOSGroups.js
+++ b/src/Components/SmartComponents/Reports/Common/buildOSGroups.js
@@ -1,7 +1,7 @@
 import { compareVersions } from '../../../../Helpers/MiscHelper';
 
 const buildOSGroups = (osVersions = []) => {
-    let groups = osVersions.reduce((acc, version) => {
+    let groups = osVersions.filter(os => os.name === 'RHEL').reduce((acc, version) => {
         const { major, minor } = version;
         const groupName = `RHEL ${major}`;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-10956

The endpoint was returning CentOS versions as well