### PR TITLE
fix(RHINENG-3106): fix reset filter button after hide/show advisory f…

### DIFF
--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -52,7 +52,7 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
 
     const defaultFilters = getCveDefaultFilters(
         shouldUseHybridSystemFilter,
-        includesCvesWithoutErrata
+        includesCvesWithoutErrata || showCvesWithoutErrata
     );
 
     const selectOptions = selectAllCheckbox({
@@ -165,7 +165,11 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
                     filters: buildActiveFilters(params, [], shouldUseHybridSystemFilter),
                     onDelete: (_, chips, reset) => removeFilters(chips, methods.apply, reset, defaultFilters),
                     deleteTitle: intl.formatMessage(messages.resetFilters),
-                    showDeleteButton: !isFilterInDefaultState(params, defaultFilters, CVES_FILTER_PARAMS)
+                    showDeleteButton: !isFilterInDefaultState(
+                        params, 
+                        defaultFilters, 
+                        CVES_FILTER_PARAMS
+                    )
                 }}
                 exportConfig={canExport && {
                     isDisabled: cves.meta.total_items === 0,

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -166,8 +166,8 @@ const CVEsTableToolbarWithContext = ({ context, canEditStatusOrBusinessRisk, can
                     onDelete: (_, chips, reset) => removeFilters(chips, methods.apply, reset, defaultFilters),
                     deleteTitle: intl.formatMessage(messages.resetFilters),
                     showDeleteButton: !isFilterInDefaultState(
-                        params, 
-                        defaultFilters, 
+                        params,
+                        defaultFilters,
                         CVES_FILTER_PARAMS
                     )
                 }}


### PR DESCRIPTION
This is to fix the last comment in https://issues.redhat.com/browse/RHINENG-3106.

To test:
1. visit https://console.stage.redhat.com/preview/insights/vulnerability/cves?affecting=rpmdnf%2Cedge&page=1 when cves without errata are hidden (modal has option of "Show CVEs without advisories")
2. Click "Show CVEs without advisories"
3. Filter will now have chip of "Advisory=Available" but also option to "reset filters" This is incorrect because 3. 
"Advisory=Available" is a default filter when Show CVEs without advisories is enabled.
4. If I click "reset filters" then  "Advisory=Available" is removed and there is no option to "reset filters" but if I refresh browser (F5) then the filters persist correct but there is now an option to "reset filters"