### PR TITLE
fix(sysdetails): Fixes css issue on sysDetails page

### DIFF
--- a/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
+++ b/src/Components/SmartComponents/SystemDetailsPage/SystemDetailsPage.js
@@ -85,54 +85,57 @@ const InventoryDetail = () => {
     };
 
     return (
-        <DetailWrapper
-            inventoryId={inventoryId}
-            onLoad={({ mergeWithDetail }) => {
-                ReducerRegistry.register({
-                    ...mergeWithDetail()
-                });
-            }}
-        >
-            <section className="inventory">
-                <Header
-                    title=""
-                    breadcrumbs={[
-                        {
-                            title: PATHS.systemsPage.title,
-                            to: PATHS.systemsPage.to,
-                            isLoaded: true
-                        },
-                        {
-                            title: entity?.display_name || intl.formatMessage(messages.invalidSystem),
-                            isActive: true,
-                            isLoaded: loaded
-                        }
-                    ]}
-                >
-                    {!errors && (
-                        <InventoryDetailHead
-                            hideBack
-                            actions={
-                                entity && canSetExcludedIncluded && [
-                                    isOptOut
-                                        ? {
-                                            title: intl.formatMessage(messages.inventoryKebabOptionsEnable),
-                                            onClick: () => handleOptOutSystem(entity?.display_name, false)
-                                        }
-                                        : {
-                                            title: intl.formatMessage(messages.inventoryKebabOptionsDisable),
-                                            onClick: () => handleOptOutSystem(entity?.display_name, true)
-                                        }
-                                ]
+        <>
+
+            <DetailWrapper
+                inventoryId={inventoryId}
+                onLoad={({ mergeWithDetail }) => {
+                    ReducerRegistry.register({
+                        ...mergeWithDetail()
+                    });
+                }}
+            >
+                <section>
+                    <Header
+                        title=""
+                        breadcrumbs={[
+                            {
+                                title: PATHS.systemsPage.title,
+                                to: PATHS.systemsPage.to,
+                                isLoaded: true
+                            },
+                            {
+                                title: entity?.display_name || intl.formatMessage(messages.invalidSystem),
+                                isActive: true,
+                                isLoaded: loaded
                             }
-                        />
-                    )}
-                </Header>
-            </section>
+                        ]}
+                    >
+                        {!errors && (
+                            <InventoryDetailHead
+                                hideBack
+                                actions={
+                                    entity && canSetExcludedIncluded && [
+                                        isOptOut
+                                            ? {
+                                                title: intl.formatMessage(messages.inventoryKebabOptionsEnable),
+                                                onClick: () => handleOptOutSystem(entity?.display_name, false)
+                                            }
+                                            : {
+                                                title: intl.formatMessage(messages.inventoryKebabOptionsDisable),
+                                                onClick: () => handleOptOutSystem(entity?.display_name, true)
+                                            }
+                                    ]
+                                }
+                            />
+                        )}
+                    </Header>
+                </section>
+            </DetailWrapper>
             <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                 <SystemDetails optOutSystemHandler={handleOptOutSystem} />
             </section>
-        </DetailWrapper>
+        </>
     );
 };
 


### PR DESCRIPTION
There was an issue on sysdetails page where when navigating from inventory, and going to vulnerability systems details page, a large gap would appear in between the detail header and the table. 

This is a result of double inventory classes. Ive removed the class is this PR as its redundant, and gone in here, removed the class, and seperated the table from the header component. 

https://github.com/RedHatInsights/insights-inventory-frontend/pull/2235
