### PR TITLE
chore(Cypress): Fix Cypress config and failing tests

### DIFF
--- a/cypress/support/component.js
+++ b/cypress/support/component.js
@@ -53,3 +53,5 @@ window.insights = {
         isProd: false
     }
 };
+
+window.history.pushState({}, document.title, window.location.pathname);

--- a/cypress/support/component.js
+++ b/cypress/support/component.js
@@ -10,7 +10,7 @@ import ReducerRegistry from '../../src/Utilities/ReducerRegistry';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import messages from '../../locales/en.json';
-import { mount } from 'cypress/react';
+import { mount } from '@cypress/react18';
 
 Cypress.Commands.add('mountWithContext', (Component, options = {}, props) => {
     const { path, routerProps = { initialEntries: ['/'] } } = options;

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "babel-polyfill": "^6.26.0",
         "codecov": "^3.8.2",
         "css-loader": "^7.1.2",
-        "cypress": "^13.10.0",
+        "cypress": "^13.13.3",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-cypress": "^3.3.0",
@@ -4619,9 +4619,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-translations/node_modules/@types/node": {
-      "version": "16.18.97",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.97.tgz",
-      "integrity": "sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==",
+      "version": "16.18.105",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
+      "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA==",
       "optional": true,
       "peer": true
     },
@@ -7210,9 +7210,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
+      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA==",
       "devOptional": true
     },
     "node_modules/axios": {
@@ -9379,13 +9379,13 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.10.0.tgz",
-      "integrity": "sha512-tOhwRlurVOQbMduX+KonoMeQILs2cwR3yHGGENoFvvSoLUBHmJ8b9/n21gFSDqjlOJ+SRVcwuh+fG/JDsHsT6Q==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -9424,7 +9424,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -27262,9 +27262,9 @@
           }
         },
         "@types/node": {
-          "version": "16.18.97",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.97.tgz",
-          "integrity": "sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==",
+          "version": "16.18.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.105.tgz",
+          "integrity": "sha512-w2d0Z9yMk07uH3+Cx0N8lqFyi3yjXZxlbYappPj+AsOlT02OyxyiuNoNHdGt6EuiSm8Wtgp2YV7vWg+GMFrvFA==",
           "optional": true,
           "peer": true
         },
@@ -29286,9 +29286,9 @@
       "devOptional": true
     },
     "aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
+      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA==",
       "devOptional": true
     },
     "axios": {
@@ -30981,12 +30981,12 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "cypress": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.10.0.tgz",
-      "integrity": "sha512-tOhwRlurVOQbMduX+KonoMeQILs2cwR3yHGGENoFvvSoLUBHmJ8b9/n21gFSDqjlOJ+SRVcwuh+fG/JDsHsT6Q==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -31025,7 +31025,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-polyfill": "^6.26.0",
     "codecov": "^3.8.2",
     "css-loader": "^7.1.2",
-    "cypress": "^13.10.0",
+    "cypress": "^13.13.3",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-cypress": "^3.3.0",

--- a/src/Components/SmartComponents/CVEs/CVEs.cy.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.cy.js
@@ -38,7 +38,7 @@ describe('CVE list table', () => {
     });
 
     it('has "Reset filter" button hidden by default', () => {
-        cy.contains('Reset filter').should('not.exist');
+        cy.get('body').should('not.contain', 'Reset filter');
     });
 
     itHasActiveFilter('Systems', '1 or more');
@@ -148,12 +148,10 @@ describe('CVE list table', () => {
             cy.get('.ins-c-primary-toolbar__actions > .pf-v5-c-menu-toggle').click();
 
             cy.get('.pf-v5-c-menu__item')
-                .contains('Edit business risk')
-                .should('not.exist');
+                .should('not.contain', 'Edit business risk');
 
             cy.get('.pf-v5-c-menu__item')
-                .contains('Edit status')
-                .should('not.exist');
+                .should('not.contain', 'Edit status');
         });
 
         it('does not show row actions', () => {

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -85,6 +85,10 @@ export const CVEs = ({ rbac }) => {
     };
 
     useEffect(() => {
+        // this line removes the specPath parameter which is injected by Cypress during testing
+        // it should have no effect on the actual application outside of Cypress tests
+        delete urlParameters.specPath;
+
         apply(
             isEmpty(urlParameters)
                 ? getCveDefaultFilters(shouldUseHybridSystemFilter, includesCvesWithoutErrata)

--- a/src/Components/SmartComponents/CVEs/CVEs.js
+++ b/src/Components/SmartComponents/CVEs/CVEs.js
@@ -85,10 +85,6 @@ export const CVEs = ({ rbac }) => {
     };
 
     useEffect(() => {
-        // this line removes the specPath parameter which is injected by Cypress during testing
-        // it should have no effect on the actual application outside of Cypress tests
-        delete urlParameters.specPath;
-
         apply(
             isEmpty(urlParameters)
                 ? getCveDefaultFilters(shouldUseHybridSystemFilter, includesCvesWithoutErrata)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-10340

- use cypress/react package compatible with React 18
- update cypress package to the latest version
- fix failing tests by
  - using `cy.get('body').should('not.contain', 'Reset filter');` instead of `cy.contains('Reset filter').should('not.exist');` because the newer versions of cypress evaluate `cy.contains(<<text>>)` to `undefined`
  - removing `specPath` from the URL params, which is injected by cypress and interfearing with filter loading from URL params during page initialization