### PR TITLE
fix(RHINENG-13529): Make PDF export naming consistent

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -182,7 +182,7 @@
   "justificationNote": "Justification note",
   "kebab.editBusinnesRisk": "Edit business risk",
   "kebab.editStatus": "Edit status",
-  "kebab.exportAsPDF": "Export as PDF",
+  "kebab.exportToPDF": "Export to PDF",
   "knowledgebasearticle": "Knowledgebase article",
   "knownExploit": "Known exploit",
   "knownExploitDescription": "This CVE is identified with a “Known exploit” label because Red Hat has determined this CVE has a public exploit. This CVE is unpatched on your system. CVEs with this label should be addressed with high priority due to the risks posed by them. “Known exploit” does not mean we have taken steps to determine if the CVE has been exploited in your environment.",

--- a/src/Components/PresentationalComponents/Kebab/KebabItems.js
+++ b/src/Components/PresentationalComponents/Kebab/KebabItems.js
@@ -10,7 +10,7 @@ export const kebabItemDownloadPDF = (loading, downloadReport, props = {}) => (
             className="pf-v5-c-dropdown__menu-item"
             onClick={() => downloadReport(true)} {...props}
         >
-            {loading ? <FormattedMessage {...messages.loading} /> : <FormattedMessage {...messages.kebabExportAsPDF} />}
+            {loading ? <FormattedMessage {...messages.loading} /> : <FormattedMessage {...messages.kebabexportToPDF} />}
         </button>
     </DropdownItem>
 );

--- a/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReport.js
@@ -187,7 +187,7 @@ const DownloadCVEsReport = ({
 };
 
 DownloadCVEsReport.defaultProps = {
-    label: messages.kebabExportAsPDF,
+    label: messages.kebabexportToPDF,
     shouldUseHybridSystemFilter: false
 };
 

--- a/src/Components/SmartComponents/Reports/DownloadSystemsReport.js
+++ b/src/Components/SmartComponents/Reports/DownloadSystemsReport.js
@@ -110,7 +110,7 @@ const DownloadSystemsReport = ({
 };
 
 DownloadSystemsReport.defaultProps = {
-    label: messages.kebabExportAsPDF
+    label: messages.kebabexportToPDF
 };
 
 DownloadSystemsReport.propTypes = {

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1412,10 +1412,10 @@ export default defineMessages({
         description: 'Title label for systems PDF report',
         defaultMessage: 'Insights Vulnerability Systems report'
     },
-    kebabExportAsPDF: {
-        id: 'kebab.exportAsPDF',
+    kebabexportToPDF: {
+        id: 'kebab.exportToPDF',
         description: 'Kebab item',
-        defaultMessage: 'Export as PDF'
+        defaultMessage: 'Export to PDF'
     },
     kebabEditBusinessRisk: {
         id: 'kebab.editBusinnesRisk',


### PR DESCRIPTION
Changes "Export as PDF" to "Export to PDF" as we need to be consistent across apps