### PR TITLE
fix(RHINENG-13960): Edit status/biz risk modal error

### DIFF
--- a/src/Components/SmartComponents/Modals/BusinessRiskModal.js
+++ b/src/Components/SmartComponents/Modals/BusinessRiskModal.js
@@ -11,7 +11,7 @@ import { CVETableContext } from '../CVEs/CVEs';
 import { clearCVEsStore } from '../../../Store/Actions/Actions';
 import { updateRef as updateRefHelper } from '../../../Helpers/MiscHelper';
 
-export const BusinessRiskModal = ({ cves, goToFirstPage, intl }) => {
+export const BusinessRiskModal = ({ cves, goToFirstPage, intl, updateRef }) => {
     const {
         cves: { meta } = {},
         params,
@@ -19,7 +19,7 @@ export const BusinessRiskModal = ({ cves, goToFirstPage, intl }) => {
     } = useContext(CVETableContext);
     const dispatch = useDispatch();
 
-    const updateRef = () => {
+    const handleUpdateRef = () => {
         dispatch(clearCVEsStore());
         updateRefHelper(goToFirstPage ? { ...meta, page: 1 } : meta, params, apply);
     };
@@ -57,7 +57,7 @@ export const BusinessRiskModal = ({ cves, goToFirstPage, intl }) => {
             business_risk_id: parseInt(businessRiskId),
             cve: cveList.map(item => item.id),
             business_risk_text: label
-        }).then(updateRef).catch(error => {
+        }).then(updateRef ? () => updateRef() : () => handleUpdateRef()).catch(error => {
             throw error; // propagate error to BaseModal
         });
     };
@@ -125,7 +125,8 @@ export const BusinessRiskModal = ({ cves, goToFirstPage, intl }) => {
 BusinessRiskModal.propTypes = {
     cves: propTypes.array,
     goToFirstPage: propTypes.bool,
-    intl: propTypes.any
+    intl: propTypes.any,
+    updateRef: propTypes.func
 };
 
 export default injectIntl(BusinessRiskModal);

--- a/src/Components/SmartComponents/Modals/CveStatusModal.js
+++ b/src/Components/SmartComponents/Modals/CveStatusModal.js
@@ -11,7 +11,7 @@ import { clearCVEsStore } from '../../../Store/Actions/Actions';
 import { useDispatch } from 'react-redux';
 import { updateRef as updateRefHelper } from '../../../Helpers/MiscHelper';
 
-export const CveStatusModal = ({ cves, intl, canEditPairStatus, goToFirstPage }) => {
+export const CveStatusModal = ({ cves, intl, canEditPairStatus, goToFirstPage, updateRef }) => {
     const {
         cves: { meta } = {},
         params,
@@ -19,7 +19,7 @@ export const CveStatusModal = ({ cves, intl, canEditPairStatus, goToFirstPage })
     } = useContext(CVETableContext);
     const dispatch = useDispatch();
 
-    const updateRef = () => {
+    const handleUpdateRef = () => {
         dispatch(clearCVEsStore());
         updateRefHelper(goToFirstPage ? { ...meta, page: 1 } : meta, params, apply);
     };
@@ -50,7 +50,7 @@ export const CveStatusModal = ({ cves, intl, canEditPairStatus, goToFirstPage })
                 })
             ]
         ])
-            .then(() => updateRef(!checkboxState))
+            .then(updateRef ? () => updateRef(!checkboxState) : () => handleUpdateRef(!checkboxState))
             .catch(error => { throw error; }); // propagate error to BaseModal
     };
 
@@ -156,7 +156,8 @@ CveStatusModal.propTypes = {
     cves: propTypes.array,
     intl: propTypes.any,
     canEditPairStatus: propTypes.bool.isRequired,
-    goToFirstPage: propTypes.bool
+    goToFirstPage: propTypes.bool,
+    updateRef: propTypes.func
 };
 
 export default injectIntl(CveStatusModal);


### PR DESCRIPTION
Submitting changes to the Edit Status and Edit Business Risk modals via the CVE details page causes an error notification. Changes from [RHINENG-11501](https://github.com/RedHatInsights/vulnerability-ui/pull/2148) caused the issue.

To repro:
- Go to CVEs page
- Select a CVE to go to its details page
- Click the "Actions" dropdown in the details header and select either edit option Apply change in modal

Upon submitting changes in the modal, you will get an error notification, but if you refresh, you'll notice the change was properly made.