### PR TITLE
fix(RHINENG-12310): Tag filter error on Reports page

### DIFF
--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -36,7 +36,8 @@ const ReportsPage = () => {
     const [inheritGlobalTags, setInheritGlobalTags] = useState(true);
     const [cvesWithoutErrata, setCvesWithoutErrata] = useState(false);
 
-    const globalFilterTags = useSelector(({ ReportsPageStore }) => ReportsPageStore.parameters.tags) ?? [];
+    const globalFilterTags = useSelector(({ ReportsPageStore }) =>
+        ReportsPageStore.parameters.tags?.length && ReportsPageStore.parameters.tags.split(',')) || [];
 
     const dispatch = useDispatch();
 

--- a/src/Components/SmartComponents/Reports/ReportsPage.test.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.test.js
@@ -33,7 +33,7 @@ jest.mock("../../../Helpers/APIHelper.js", () => ({
     getCveListByAccount: () => new Promise(() => {}, () => {})
 }));
 
-const state = {
+let state = {
     parameters: {}
 }
 
@@ -204,5 +204,23 @@ describe('Reports page component', () => {
         });
 
         expect(screen.getByText(/systems: 1 or more conventional \(rpm\-dnf\), 1 or more immutable \(ostree\)/i)).toBeVisible();
+    });
+
+    it('Should apply global tags.', async () => {
+        state.parameters = { tags: "AAaNIKhDBt/LorNtSjoRt=WRTmPByfQ,BMCRfrl/kgWDqQYPT=KVdLiE" };
+        render(
+            <TestWrapper store={ store }>
+                <ReportsPage />
+            </TestWrapper>
+        );
+
+        await waitFor(() => {
+            fireEvent.click(screen.getByText(/create report/i));
+        });
+
+        screen.logTestingPlaygroundURL();
+
+        expect(screen.getByText(/tags: aaanikhdbt: lorntsjort = wrtmpbyfq, bmcrfrl: kgwdqqypt = kvdlie/i)).toBeVisible();
+        expect(screen.queryByText(/tags: all/i)).toBeFalsy();
     });
 });


### PR DESCRIPTION
To reproduce:
1. Go to https://console.redhat.com/insights/vulnerability/cves
2. At top in 'Filter by tag' select a value with systems
3. Navigate to https://console.redhat.com/insights/vulnerability/reports#SIDs=&tags=
4. Select Create report
5. Error is displayed

The issue is that the `useSelector` on ReportsPage was not putting the tags into an array, AND if there were no tags, then it wasn't returning an empty array properly.

Make sure to apply multiple variations of workloads, SAP IDs, and tags to make sure this feature works correctly.