### PR TITLE
feat(RHINENG-16846): Add operating systems report card

### DIFF
--- a/src/Components/SmartComponents/Modals/ReportConfigModal.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.js
@@ -28,7 +28,8 @@ import SelectCustomSorter from '../../PresentationalComponents/Sorters/CustomSor
 import TagFilter from '../../PresentationalComponents/Filters/CustomFilters/TagFilter';
 import { fetchOperatingSystems } from '../../../Store/Actions/Actions';
 import buildOSGroups from '../Reports/Common/buildOSGroups';
-import { useHybridSystemFilterFlag, useFeatureFlag } from '../../../Helpers/Hooks';
+import { useHybridSystemFilterFlag } from '../../../Helpers/Hooks';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 const ReportConfigModal = ({

--- a/src/Components/SmartComponents/Modals/ReportConfigModal.test.js
+++ b/src/Components/SmartComponents/Modals/ReportConfigModal.test.js
@@ -25,8 +25,13 @@ const customMiddleWare = store => next => action => {
 
 jest.mock('../../../Helpers/Hooks', () => ({
     ...jest.requireActual('../../../Helpers/Hooks'),
-    useFeatureFlag: () => false,
     useHybridSystemFilterFlag: () => false 
+}));
+
+jest.mock('../../../Utilities/useFeatureFlag', () => ({
+    ...jest.requireActual('../../../Utilities/useFeatureFlag'),
+    __esModule: true,
+    default: jest.fn(() => false)
 }));
 
 const mockStore = configureStore([customMiddleWare]);

--- a/src/Components/SmartComponents/Reports/DownloadExecutive.js
+++ b/src/Components/SmartComponents/Reports/DownloadExecutive.js
@@ -6,9 +6,10 @@ import { getExecutiveReport } from '../../../Helpers/APIHelper';
 import messages from '../../../Messages';
 import buildExecReport from './BuildExecReport';
 import { Fragment } from 'react';
-import { useNotification, useFeatureFlag } from '../../../Helpers/Hooks';
+import { useNotification } from '../../../Helpers/Hooks';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import FooterPDF from './Common/FooterPDF';
-import { NotAuthorizedNotification } from '../../../Helpers/constants';
+import { EXECUTIVE_REPORT_CARD_BUTTON, NotAuthorizedNotification } from '../../../Helpers/constants';
 
 const DownloadExecutive = () => {
     const intl = useIntl();
@@ -64,7 +65,7 @@ const DownloadExecutive = () => {
             {isLoading
                 ? intl.formatMessage(messages.loading)
                 : <a onClick={() => onDownloadButtonClick()}>
-                    {intl.formatMessage(messages.executiveReportCardButton)}
+                    {EXECUTIVE_REPORT_CARD_BUTTON}
                 </a>
             }
             {

--- a/src/Components/SmartComponents/Reports/ReportsCards.js
+++ b/src/Components/SmartComponents/Reports/ReportsCards.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { GridItem, Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
+import styles from './Common/styles';
+
+const ReportsCards = ({ title, icon, body, footer, hasPermissions }) => {
+    return (
+        hasPermissions &&
+            <GridItem>
+                <Card className="report-card">
+                    <CardTitle>
+                        {icon}
+                        <span className="pf-v5-u-ml-sm" style={styles.cardTitle}>
+                            {title}
+                        </span>
+                    </CardTitle>
+                    <CardBody>
+                        {body}
+                    </CardBody>
+                    <CardFooter>
+                        {footer}
+                    </CardFooter>
+                </Card>
+            </GridItem>
+    );
+};
+
+ReportsCards.propTypes = {
+    title: PropTypes.string,
+    icon: PropTypes.node,
+    body: PropTypes.string,
+    footer: PropTypes.node,
+    hasPermissions: PropTypes.bool
+};
+
+export default ReportsCards;

--- a/src/Components/SmartComponents/Reports/ReportsPage.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.js
@@ -1,26 +1,40 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Grid, GridItem, Card, CardTitle, CardBody, CardFooter, Icon } from '@patternfly/react-core';
+import { Grid, Icon } from '@patternfly/react-core';
 import { FileAltIcon } from '@patternfly/react-icons';
 import DownloadExecutive from './DownloadExecutive';
 import ReportConfigModal from '../Modals/ReportConfigModal';
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';
-import { ChartPieSolid } from '../../PresentationalComponents/CustomIcons/CustomIcons';
 import Header from '../../PresentationalComponents/Header/Header';
 import DownloadCVEsReport from '../Reports/DownloadCVEsReport';
 import { buildFilters, constructReportParameters, getDefaultFilterData } from '../../../Helpers/ReportsHelper';
-import { getCveReportFilters, CUSTOM_REPORT_DEFAULT_SORT, PERMISSIONS } from '../../../Helpers/constants';
+import {
+    getCveReportFilters,
+    CUSTOM_REPORT_DEFAULT_SORT,
+    PERMISSIONS,
+    EXECUTIVE_REPORT_CARD_DESCRIPTION,
+    CUSTOM_REPORT_CARD_DESCRIPTION,
+    EXECUTIVE_REPORT_CARD_TITLE,
+    CUSTOM_REPORT_CARD_TITLE,
+    CUSTOM_REPORT_CARD_BUTTON,
+    OPERATING_SYSTEM_REPORT_TITLE,
+    OPERATING_SYSTEM_REPORT_DESCRIPTION
+} from '../../../Helpers/constants';
 import styles from './Common/styles';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useHybridSystemFilterFlag, useRbac } from '../../../Helpers/Hooks';
 import NoAccessPage from '../../PresentationalComponents/StaticPages/NoAccessPage';
 import { getCveListByAccount } from '../../../Helpers/APIHelper';
 import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
+import ReportsCards from './ReportsCards';
+import { ChartPieSolid } from '../../PresentationalComponents/CustomIcons/CustomIcons';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 
 const ReportsPage = () => {
     const [[canDoAdvancedReporting, canReadVulnerabilities, canReadInventory], isLoading]
         = useRbac([PERMISSIONS.advancedReporting, PERMISSIONS.readVulnerabilityResults, PERMISSIONS.readHosts], '');
+    const isOsExposureEnabled = useFeatureFlag('vulnerability.exposure-by-os-minor.enabled');
 
     const shouldUseHybridSystemFilter = useHybridSystemFilterFlag();
     const CVE_REPORT_FILTERS = getCveReportFilters(shouldUseHybridSystemFilter);
@@ -74,6 +88,49 @@ const ReportsPage = () => {
         return { string: tag, namespace, key, value };
     };
 
+    const fileIcon = <Icon size="lg">
+        <FileAltIcon color="var(--pf-v5-global--link--Color)" />
+    </Icon>;
+
+    const cards = [
+        {
+            key: 'executive-report-card',
+            title: EXECUTIVE_REPORT_CARD_TITLE,
+            icon: <ChartPieSolid style={styles.pieChartIcon} />,
+            body: EXECUTIVE_REPORT_CARD_DESCRIPTION,
+            footer: <DownloadExecutive />,
+            hasPermissions: true
+        },
+        {
+            key: 'report-by-cves-card',
+            title: CUSTOM_REPORT_CARD_TITLE,
+            icon: fileIcon,
+            body: CUSTOM_REPORT_CARD_DESCRIPTION,
+            footer: <a
+                className="create-report"
+                aria-label="Custom report button"
+                onClick={() => setModalOpen(true)}
+            >
+                {CUSTOM_REPORT_CARD_BUTTON}
+            </a>,
+            hasPermissions: canReadVulnerabilities
+        },
+        {
+            key: 'operating-system-report-card',
+            title: OPERATING_SYSTEM_REPORT_TITLE,
+            icon: fileIcon,
+            body: OPERATING_SYSTEM_REPORT_DESCRIPTION,
+            footer: <a
+                className="create-report"
+                aria-label="OS report button"
+                //onClick={() => setModalOpen(true)}
+            >
+                {CUSTOM_REPORT_CARD_BUTTON}
+            </a>,
+            hasPermissions: canReadVulnerabilities && isOsExposureEnabled
+        }
+    ];
+
     return (
         isLoading ? <PageLoading /> :
             (canDoAdvancedReporting && canReadInventory) ? (
@@ -81,48 +138,16 @@ const ReportsPage = () => {
                     <Header title={intl.formatMessage(messages.reportsPageTitle)} showBreadcrumb={false} />
                     <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
                         <Grid hasGutter lg={3} md={4} sm={12}>
-                            <GridItem>
-                                <Card className="report-card">
-                                    <CardTitle>
-                                        <ChartPieSolid style={styles.pieChartIcon} />
-                                        <span className="pf-v5-u-ml-sm" style={styles.cardTitle}>
-                                            {intl.formatMessage(messages.executiveReportCardTitle)}
-                                        </span>
-                                    </CardTitle>
-                                    <CardBody>
-                                        {intl.formatMessage(messages.executiveReportCardDescription)}
-                                    </CardBody>
-                                    <CardFooter>
-                                        <DownloadExecutive />
-                                    </CardFooter>
-                                </Card>
-                            </GridItem>
-                            {canReadVulnerabilities &&
-                                <GridItem>
-                                    <Card className="report-card">
-                                        <CardTitle>
-                                            <Icon size="lg">
-                                                <FileAltIcon color="var(--pf-v5-global--link--Color)" />
-                                            </Icon>
-                                            <span className="pf-v5-u-ml-sm" style={styles.cardTitle}>
-                                                {intl.formatMessage(messages.customReportCardTitle)}
-                                            </span>
-                                        </CardTitle>
-                                        <CardBody>
-                                            {intl.formatMessage(messages.customReportCardDescription)}
-                                        </CardBody>
-                                        <CardFooter>
-                                            <a
-                                                className="create-report"
-                                                aria-label="Custom report button"
-                                                onClick={() => setModalOpen(true)}
-                                            >
-                                                {intl.formatMessage(messages.customReportCardButton)}
-                                            </a>
-                                        </CardFooter>
-                                    </Card>
-                                </GridItem>
-                            }
+                            {cards.map((card) =>
+                                <ReportsCards
+                                    key={card.key}
+                                    title={card.title}
+                                    icon={card.icon}
+                                    body={card.body}
+                                    footer={card.footer}
+                                    hasPermissions={card.hasPermissions}
+                                />
+                            )}
                         </Grid>
                     </section>
                     <ReportConfigModal

--- a/src/Components/SmartComponents/Reports/ReportsPage.test.js
+++ b/src/Components/SmartComponents/Reports/ReportsPage.test.js
@@ -3,16 +3,15 @@ import configureStore from 'redux-mock-store';
 import ReportsPage from './ReportsPage';
 import { useSelector } from 'react-redux';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { useHybridSystemFilterFlag, useFeatureFlag } from '../../../Helpers/Hooks';
+import { useHybridSystemFilterFlag } from '../../../Helpers/Hooks';
 import { buildFilters } from '../../../Helpers/ReportsHelper';
 import TestWrapper from '../../../Utilities/TestWrapper';
 import '@testing-library/jest-dom';
-//import { initialState } from '../../../Store/Reducers/ReportsPageStore';
+import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 
 jest.mock('../../../Helpers/Hooks', () => ({
     ...jest.requireActual('../../../Helpers/Hooks'),
     useRbac: () => [[true, true, true], false],
-    useFeatureFlag: jest.fn(() => false),
     useHybridSystemFilterFlag: jest.fn(() => false)
 }));
 
@@ -31,6 +30,12 @@ jest.mock("../../../Helpers/APIHelper.js", () => ({
     ...jest.requireActual("../../../Helpers/APIHelper.js"),
     getOperatingSystems: () => ({}),
     getCveListByAccount: () => new Promise(() => {}, () => {})
+}));
+
+jest.mock('../../../Utilities/useFeatureFlag', () => ({
+    ...jest.requireActual('../../../Utilities/useFeatureFlag'),
+    __esModule: true,
+    default: jest.fn(() => true)
 }));
 
 let state = {
@@ -52,6 +57,7 @@ beforeEach(() => {
     useSelector.mockImplementation(callback => {
         return callback({ ReportsPageStore: state });
     });
+    useFeatureFlag.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -77,7 +83,7 @@ describe('Reports page component', () => {
         );
 
         await waitFor(() => {
-            fireEvent.click(screen.getByText(/create report/i));
+            fireEvent.click(screen.getAllByText(/create report/i)[0]);
         });
 
         expect(screen.getByRole('heading', { name: 'Report by CVEs' })).toBeVisible();
@@ -97,7 +103,7 @@ describe('Reports page component', () => {
         );
 
         await waitFor(() => {
-            fireEvent.click(screen.getByText(/create report/i));
+            fireEvent.click(screen.getAllByText(/create report/i)[0]);
         });
 
         expect(screen.getByRole('heading', { name: 'Report by CVEs' })).toBeVisible();
@@ -144,6 +150,7 @@ describe('Reports page component', () => {
     });
 
     it('Should hide Systems filter when edge parity feature is disabled', async () => {
+        useFeatureFlag.mockReturnValue(false);
         render(<TestWrapper store={ store }> 
             <ReportsPage />
         </TestWrapper>);
@@ -158,7 +165,6 @@ describe('Reports page component', () => {
     });
 
     it('Should show Systems filter when edge parity feature is enabled, but hybrid filtering is not enabled', async () => {
-        useFeatureFlag.mockReturnValue(true);
         useHybridSystemFilterFlag.mockReturnValue(false);
         render(<TestWrapper store={ store }> 
             <ReportsPage />
@@ -174,7 +180,6 @@ describe('Reports page component', () => {
     });
 
     it('Should show Systems filter when edge parity feature is enabled, and hybrid filtering is enabled', async () => {
-        useFeatureFlag.mockReturnValue(true);
         useHybridSystemFilterFlag.mockReturnValue(true);
         render(<TestWrapper store={ store }> 
             <ReportsPage />
@@ -191,7 +196,6 @@ describe('Reports page component', () => {
 
 
     it('Should show Systems filter when edge parity feature is enabled, and hybrid filtering is enabled', async () => {
-        useFeatureFlag.mockReturnValue(true);
         useHybridSystemFilterFlag.mockReturnValue(true);
         render(<TestWrapper store={ store }> 
             <ReportsPage />
@@ -215,10 +219,19 @@ describe('Reports page component', () => {
         );
 
         await waitFor(() => {
-            fireEvent.click(screen.getByText(/create report/i));
+            fireEvent.click(screen.getAllByText(/create report/i)[0]);
         });
 
         expect(screen.getByText(/tags: aaanikhdbt: lorntsjort = wrtmpbyfq, bmcrfrl: kgwdqqypt = kvdlie/i)).toBeVisible();
         expect(screen.queryByText(/tags: all/i)).toBeFalsy();
+    });
+
+    it('Should not show the operating systems reports card with feature flag off', () => {
+        useFeatureFlag.mockReturnValue(false);
+        render(<TestWrapper store={ store }> 
+            <ReportsPage />
+        </TestWrapper>);
+
+        expect(screen.queryByText(/report by operating system versions/i)).toBeFalsy();
     });
 });

--- a/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
+++ b/src/Components/SmartComponents/Reports/__snapshots__/ReportsPage.test.js.snap
@@ -79,7 +79,7 @@ exports[`Reports page component Should match snapshots 1`] = `
           <div
             class="pf-v5-c-card__body"
           >
-            An executive summary of vulnerabilities  identified by Red Hat across workloads that may impact your RHEL servers.
+            An executive summary of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.
           </div>
           <div
             class="pf-v5-c-card__footer"
@@ -146,6 +146,69 @@ exports[`Reports page component Should match snapshots 1`] = `
           >
             <a
               aria-label="Custom report button"
+              class="create-report"
+            >
+              Create report
+            </a>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-v5-l-grid__item"
+      >
+        <div
+          class="pf-v5-c-card report-card"
+          data-ouia-component-id="OUIA-Generated-Card-3"
+          data-ouia-component-type="PF5/Card"
+          data-ouia-safe="true"
+          id=""
+        >
+          <div
+            class="pf-v5-c-card__title"
+          >
+            <div
+              class="pf-v5-c-card__title-text"
+            >
+              <span
+                class="pf-v5-c-icon pf-m-lg"
+              >
+                <span
+                  class="pf-v5-c-icon__content"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v5-svg"
+                    color="var(--pf-v5-global--link--Color)"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 384 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm64 236c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-64c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12v8zm0-72v8c0 6.6-5.4 12-12 12H108c-6.6 0-12-5.4-12-12v-8c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm96-114.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              <span
+                class="pf-v5-u-ml-sm"
+                style="vertical-align: 0.3rem;"
+              >
+                Report by operating system versions
+              </span>
+            </div>
+          </div>
+          <div
+            class="pf-v5-c-card__body"
+          >
+            A breakdown of vulnerabilities affecting the minor operating system versions of your RHEL systems. Intended to assist with informed upgrade decisions.
+          </div>
+          <div
+            class="pf-v5-c-card__footer"
+          >
+            <a
+              aria-label="OS report button"
               class="create-report"
             >
               Create report

--- a/src/Helpers/Hooks.js
+++ b/src/Helpers/Hooks.js
@@ -11,10 +11,10 @@ import { NotAuthorizedNotification, ReadOnlyNotification } from './constants';
 import { useState } from 'react';
 import unionBy from 'lodash/unionBy';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 import { AccountStatContext } from '../Utilities/VulnerabilityRoutes';
 import { getRhelSystems, checkEdgePresence, getCveListByAccount } from './APIHelper';
 import { ColumnManagementModal } from '@patternfly/react-component-groups';
+import useFeatureFlag from '../Utilities/useFeatureFlag';
 
 export const useNotification = (config = {}) => {
     const dispatch = useDispatch();
@@ -266,12 +266,6 @@ export const useColumnManagement = (columns, onApply) => {
             onClose={() => setModalOpen(false)}
             key="column-mgmt-modal"
         />), setModalOpen];
-};
-
-export const useFeatureFlag = (flag) => {
-    const { flagsReady } = useFlagsStatus();
-    const isFlagEnabled = useFlag(flag);
-    return flagsReady ? isFlagEnabled : false;
 };
 
 export const useHybridSystemFilterFlag = () => {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -1054,3 +1054,13 @@ export const PERMISSIONS = {
     toggleCvesWithoutErrata: 'vulnerability:toggle_cves_without_errata:write',
     readHosts: 'inventory:hosts:read'
 };
+
+/*eslint-disable max-len*/
+export const CUSTOM_REPORT_CARD_TITLE = 'Report by CVEs';
+export const CUSTOM_REPORT_CARD_DESCRIPTION = 'A customizable PDF report of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.';
+export const CUSTOM_REPORT_CARD_BUTTON = 'Create report';
+export const EXECUTIVE_REPORT_CARD_TITLE = 'Executive report';
+export const EXECUTIVE_REPORT_CARD_DESCRIPTION = 'An executive summary of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.';
+export const EXECUTIVE_REPORT_CARD_BUTTON = 'Download PDF';
+export const OPERATING_SYSTEM_REPORT_TITLE = 'Report by operating system versions';
+export const OPERATING_SYSTEM_REPORT_DESCRIPTION = 'A breakdown of vulnerabilities affecting the minor operating system versions of your RHEL systems. Intended to assist with informed upgrade decisions.';

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1447,37 +1447,6 @@ export default defineMessages({
         description: 'Header title for the Reports page',
         defaultMessage: 'Reports'
     },
-    executiveReportCardTitle: {
-        id: 'executiveReportCardTitle',
-        description: 'Header title for the card with pre-made executive report',
-        defaultMessage: 'Executive report'
-    },
-    executiveReportCardDescription: {
-        id: 'executiveReportCardDescription',
-        description: 'Description for the card with pre-made executive report',
-        defaultMessage: 'An executive summary of vulnerabilities  identified by Red Hat across workloads that may impact your RHEL servers.'
-    },
-    executiveReportCardButton: {
-        id: 'executiveReportCardButton',
-        description: 'Label for button inside card with pre-made executive report',
-        defaultMessage: 'Download PDF'
-    },
-    customReportCardTitle: {
-        id: 'customReportCardTitle',
-        description: 'Header title for the card with custom executive report',
-        defaultMessage: 'Report by CVEs'
-    },
-    customReportCardDescription: {
-        id: 'customReportCardDescription',
-        description: 'Description title for the card with pre-made executive report',
-        defaultMessage: 'A customizable PDF report of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.'
-    },
-    customReportCardButton: {
-        id: 'customReportCardButton',
-        description: 'Label for button inside card with custom executive report',
-        defaultMessage: 'Create report'
-    },
-
     configModalExportReport: {
         id: 'configModalExportReport',
         description: 'Label for button for exporting report',


### PR DESCRIPTION
This PR adds a new card to the Reports page. It is hiddent behind a feature flag, `vulnerability.exposure-by-os-minor.enabled`. To test, simply go to Vulnerability -> Reports and check for the existence of the OS report card when the flag is flipped on or off. The link on the card should not be functional.

This PR also refactors the rendering of the cards as well as removes a redundant useFeatureFlag hook. It also removes some intl usage.