### PR TITLE
feat(RHINENG-16848): Set up os exposure pdf-generator

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -43,7 +43,8 @@ module.exports = {
         ],
         exposes: {
             './RootApp': resolve(__dirname, './src/AppEntry'),
-            './SystemDetail': resolve(__dirname, './src/index.js')
+            './SystemDetail': resolve(__dirname, './src/index.js'),
+            './OsExposureReport': resolve(__dirname, './src/Components/SmartComponents/Reports/OsExposureReport')
         }
     },
     frontendCRDPath: 'deploy/frontend.yml',

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "fec dev",
     "start:proxy": "PROXY=true fec dev",
+    "static": "fec static",
     "ci:verify": "npm run test:coverage",
     "verify": "npm-run-all build lint test",
     "nightly": "npm run ci:verify",

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
@@ -8,6 +8,8 @@ import {
 } from '@patternfly/react-core';
 
 const LifecycleSelect = ({
+    exportLoading,
+    fetchLoading,
     minorVersion,
     minorVersionDetails
 }) => {
@@ -25,7 +27,10 @@ const LifecycleSelect = ({
                     onClick={() => setIsSelectOpen(!isSelectOpen)}
                     isExpanded={isSelectOpen}
                     style={{ width: '261px' }}
-                    isDisabled={!minorVersionDetails[minorVersion].eus && !minorVersionDetails[minorVersion].aus}
+                    isDisabled={
+                        (!minorVersionDetails[minorVersion].eus && !minorVersionDetails[minorVersion].aus)
+                        || fetchLoading || exportLoading
+                    }
                 >
                     {`RHEL ${minorVersion}: ${selectedValue}`}
                 </MenuToggle>
@@ -52,6 +57,8 @@ const LifecycleSelect = ({
 };
 
 LifecycleSelect.propTypes = {
+    exportLoading: propTypes.bool,
+    fetchLoading: propTypes.bool,
     minorVersion: propTypes.string,
     minorVersionDetails: propTypes.object
 };

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportExportPdfButton.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportExportPdfButton.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { exportNotifications } from '../../../../Helpers/constants';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useDispatch } from 'react-redux';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
+
+const OsExposureReportExportPdfButton = ({
+    exportLoading,
+    fetchLoading,
+    reportTitle,
+    selectedOsVersions,
+    setExportLoading,
+    setOsExposureModalOpen
+}) => {
+    const dispatch = useDispatch();
+    const { requestPdf } = useChrome();
+
+    const dataFetch = async () => {
+        setExportLoading(true);
+        dispatch(addNotification(exportNotifications.pending));
+
+        try {
+            await requestPdf({
+                filename: `${reportTitle}.pdf`,
+                payload: {
+                    manifestLocation: '/apps/vulnerability/fed-mods.json',
+                    scope: 'vulnerability',
+                    module: './OsExposureReport',
+                    additionalData: {
+                        selectedOsVersions
+                    }
+                }
+            });
+
+            dispatch(addNotification(exportNotifications.success));
+            setOsExposureModalOpen(false);
+        } catch (e) {
+            dispatch(addNotification(exportNotifications.error));
+        } finally {
+            setExportLoading(false);
+        }
+    };
+
+    return (
+        <Button
+            key="export-pdf"
+            variant="primary"
+            aria-label="Export to PDF"
+            onClick={dataFetch}
+            isDisabled={exportLoading || fetchLoading || selectedOsVersions.length === 0}
+        >
+            Export PDF
+        </Button>
+    );
+};
+
+OsExposureReportExportPdfButton.propTypes = {
+    exportLoading: PropTypes.bool,
+    fetchLoading: PropTypes.bool,
+    reportTitle: PropTypes.string,
+    selectedOsVersions: PropTypes.array,
+    setExportLoading: PropTypes.func,
+    setOsExposureModalOpen: PropTypes.func
+};
+
+export default OsExposureReportExportPdfButton;

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportModal.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportModal.js
@@ -24,6 +24,7 @@ import { getOSExposure } from '../../../../Helpers/APIHelper';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { NotAuthorizedNotification, ReadOnlyNotification } from '../../../../Helpers/constants';
+import OsExposureReportExportPdfButton from './OsExposureReportExportPdfButton';
 
 const OsExposureReportModal = ({
     isOsExposureModalOpen,
@@ -38,6 +39,8 @@ const OsExposureReportModal = ({
     });
     const [userNote, setUserNoteChange] = useState('');
     const [osExposureData, setOsExposureData] = useState();
+    const [fetchLoading, setFetchLoading] = useState(false);
+    const [exportLoading, setExportLoading] = useState(false);
     const CVE_REPORT_FILTERS = getCveReportFilters(false, true);
     const ACTIVE_FILTERS = [
         'impact',
@@ -56,6 +59,7 @@ const OsExposureReportModal = ({
 
     useEffect(() => {
         const fetchOsReportData = async () => {
+            setFetchLoading(true);
             try {
                 const data = await getOSExposure();
                 setOsExposureData(data.data);
@@ -70,6 +74,8 @@ const OsExposureReportModal = ({
                                 title: 'Couldn\'t fetch operating systems report data',
                                 description: 'Try again later'
                             }));
+            } finally {
+                setFetchLoading(false);
             }
         };
 
@@ -119,17 +125,15 @@ const OsExposureReportModal = ({
             isOpen={isOsExposureModalOpen}
             onClose={() => handleModalClose()}
             actions={[
-                <Button
+                <OsExposureReportExportPdfButton
                     key="export-pdf"
-                    variant="primary"
-                    aria-label="Export to PDF"
-                    onClick={() => {
-                        return null;
-                    }}
-                    isDisabled={selectedOsVersions.length === 0}
-                >
-                    Export PDF
-                </Button>,
+                    exportLoading={exportLoading}
+                    fetchLoading={fetchLoading}
+                    reportTitle="pdf title"
+                    selectedOsVersions={selectedOsVersions}
+                    setExportLoading={setExportLoading}
+                    setOsExposureModalOpen={setOsExposureModalOpen}
+                />,
                 <Button
                     key="export-csv"
                     variant="secondary"
@@ -137,7 +141,7 @@ const OsExposureReportModal = ({
                     onClick={() => {
                         return null;
                     }}
-                    isDisabled={selectedOsVersions.length === 0}
+                    isDisabled={fetchLoading || exportLoading || selectedOsVersions.length === 0}
                 >
                     Export CSV
                 </Button>,
@@ -158,6 +162,7 @@ const OsExposureReportModal = ({
                         type="text"
                         className="report-text-input"
                         id="horizontal-form-name"
+                        isDisabled={fetchLoading || exportLoading}
                     />
                 </FormGroup>
                 <FormGroup label="Select up to 5 major or minor operating system versions of RHEL you would like to see">
@@ -177,8 +182,9 @@ const OsExposureReportModal = ({
                                                         label={`RHEL ${osMinor}`}
                                                         isChecked={isMinorOsVersionSelected({ [osMinor]: minorValues })}
                                                         isDisabled={
-                                                            !isMinorOsVersionSelected({ [osMinor]: minorValues })
-                                                            && selectedOsVersions.length > 4
+                                                            (!isMinorOsVersionSelected({ [osMinor]: minorValues })
+                                                            && selectedOsVersions.length > 4)
+                                                            || fetchLoading || exportLoading
                                                         }
                                                         onChange={() => toggleArrayItem({ [osMinor]: minorValues })}
                                                     />
@@ -203,6 +209,8 @@ const OsExposureReportModal = ({
                                         <LifecycleSelect
                                             minorVersionDetails={selectedVersion}
                                             minorVersion={minorVersion}
+                                            fetchLoading={fetchLoading}
+                                            exportLoading={exportLoading}
                                         />
                                     </FlexItem>
                                 );
@@ -222,6 +230,7 @@ const OsExposureReportModal = ({
                                     className: 'pf-v5-u-mr-lg pf-v5-u-mb-sm',
                                     width: '261px',
                                     direction: 'up',
+                                    isDisabled: fetchLoading || exportLoading,
                                     ...CVE_REPORT_FILTERS[filterId].selectProps
                                 },
                                 options: CVE_REPORT_FILTERS[filterId].items,
@@ -237,6 +246,7 @@ const OsExposureReportModal = ({
                         onChange={(_event, value) => setUserNoteChange(value)}
                         id="horizontal-form-exp"
                         name="horizontal-form-exp"
+                        isDisabled={fetchLoading || exportLoading}
                     />
                 </FormGroup>
             </Form>

--- a/src/Components/SmartComponents/Reports/OsExposureReport.js
+++ b/src/Components/SmartComponents/Reports/OsExposureReport.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const OsExposureReport = ({ additionalData }) => {
+    const { selectedOsVersions } = additionalData;
+
+    return <div>{JSON.stringify(selectedOsVersions)}</div>;
+};
+
+OsExposureReport.propTypes = {
+    additionalData: PropTypes.object
+};
+
+export default OsExposureReport;

--- a/src/Helpers/APIHelper.js
+++ b/src/Helpers/APIHelper.js
@@ -7,7 +7,7 @@ import instance from '../Utilities/interceptors';
 import { constructParameters } from './MiscHelper';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 
-const BASE_ROUTE = '/api/vulnerability/v1';
+export const BASE_ROUTE = '/api/vulnerability/v1';
 const EDGE_API = '/api/edge/v1';
 
 export const useGetImageData = () => {

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -132,6 +132,22 @@ export const NotAuthorizedNotification = {
     title: intl.formatMessage(messages.notAuthorizedNotificationTitle)
 };
 
+export const exportNotifications = {
+    pending: {
+        title: `Preparing export. Once complete, your download will start automatically.`,
+        variant: 'info'
+    },
+    success: {
+        title: `Downloading export`,
+        variant: 'success'
+    },
+    error: {
+        title: 'Couldn’t download export',
+        variant: 'danger',
+        autoDismiss: false
+    }
+};
+
 export const ONLY_NON_VULNERABLE_SYSTEMS = 'affected_not_vulnerable';
 
 export const RULE_PRESENCE_OPTIONS = [


### PR DESCRIPTION
To test this, run the commands in the comments below. You'll visit the Vulnerability -> Reports page and select the "Report by operating system versions" report to open the modal.

This PR does a couple of basic things.

1. It sets some loading states for the modal so that when the fetch for data happens on modal open, and when the export happens, buttons are disabled.
2. It connects this modal to the pdf-generator service so that we can export an empty report. The component for the pdf template should be receiving the data.