### PR TITLE
feat(RHINENG-17936): update exposure selection

### DIFF
--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
@@ -10,8 +10,10 @@ import {
 const LifecycleSelect = ({
     exportLoading,
     fetchLoading,
+    fullVersionDetails,
     minorVersion,
-    minorVersionDetails
+    selectedOsVersions,
+    setSelectedOsVersions
 }) => {
     const [isSelectOpen, setIsSelectOpen] = useState(false);
     const [selectedValue, setValue] = useState('Minor release');
@@ -27,28 +29,44 @@ const LifecycleSelect = ({
                     onClick={() => setIsSelectOpen(!isSelectOpen)}
                     isExpanded={isSelectOpen}
                     style={{ width: '261px' }}
-                    isDisabled={
-                        (!minorVersionDetails[minorVersion].eus && !minorVersionDetails[minorVersion].aus)
-                        || fetchLoading || exportLoading
-                    }
+                    isDisabled={(!fullVersionDetails.eus && !fullVersionDetails.aus) || fetchLoading || exportLoading}
                 >
                     {`RHEL ${minorVersion}: ${selectedValue}`}
                 </MenuToggle>
             )}
             onOpenChange={(isOpen) => setIsSelectOpen(!isOpen)}
             onSelect={(_, value) => {
+                let indexOfOsVersion;
+                let selectedOsVersionsCopy = [...selectedOsVersions];
+                selectedOsVersions.forEach((osVersion, index) => {
+                    if (Object.keys(osVersion)[0] === minorVersion) {
+                        indexOfOsVersion = index;
+                        return;
+                    }
+                });
+
+                if (value === 'Minor release') {
+                    selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { minor: fullVersionDetails.minor } };
+                } else if (value === 'Extended update support') {
+                    selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { eus: fullVersionDetails.eus } };
+                } else if (value === 'Enhanced extended update support') {
+                    selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { aus: fullVersionDetails.aus } };
+                }
+
+                setSelectedOsVersions(selectedOsVersionsCopy);
+
                 setValue(value);
                 setIsSelectOpen(false);
             }}
         >
             <SelectList>
-                {minorVersionDetails[minorVersion].minor &&
+                {fullVersionDetails.minor &&
                     <SelectOption value="Minor release">Minor release</SelectOption>
                 }
-                {minorVersionDetails[minorVersion].eus &&
+                {fullVersionDetails.eus &&
                     <SelectOption value="Extended update support">Extended update support</SelectOption>
                 }
-                {minorVersionDetails[minorVersion].aus &&
+                {fullVersionDetails.aus &&
                     <SelectOption value="Enhanced extended update support">Enhanced extended update support</SelectOption>
                 }
             </SelectList>
@@ -57,10 +75,12 @@ const LifecycleSelect = ({
 };
 
 LifecycleSelect.propTypes = {
-    exportLoading: propTypes.bool,
-    fetchLoading: propTypes.bool,
-    minorVersion: propTypes.string,
-    minorVersionDetails: propTypes.object
+    exportLoading: propTypes.bool.isRequired,
+    fetchLoading: propTypes.bool.isRequired,
+    fullVersionDetails: propTypes.object.isRequired,
+    minorVersion: propTypes.string.isRequired,
+    selectedOsVersions: propTypes.array.isRequired,
+    setSelectedOsVersions: propTypes.func.isRequired
 };
 
 export default LifecycleSelect;

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.js
@@ -6,6 +6,7 @@ import {
     SelectList,
     SelectOption
 } from '@patternfly/react-core';
+import { LIFECYCLE_VALUE } from '../../../../Helpers/constants';
 
 const LifecycleSelect = ({
     exportLoading,
@@ -16,7 +17,7 @@ const LifecycleSelect = ({
     setSelectedOsVersions
 }) => {
     const [isSelectOpen, setIsSelectOpen] = useState(false);
-    const [selectedValue, setValue] = useState('Minor release');
+    const [selectedValue, setValue] = useState(LIFECYCLE_VALUE.minor);
 
     return (
         <Select
@@ -45,11 +46,11 @@ const LifecycleSelect = ({
                     }
                 });
 
-                if (value === 'Minor release') {
+                if (value === LIFECYCLE_VALUE.minor) {
                     selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { minor: fullVersionDetails.minor } };
-                } else if (value === 'Extended update support') {
+                } else if (value === LIFECYCLE_VALUE.eus) {
                     selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { eus: fullVersionDetails.eus } };
-                } else if (value === 'Enhanced extended update support') {
+                } else if (value === LIFECYCLE_VALUE.aus) {
                     selectedOsVersionsCopy[indexOfOsVersion] = { [minorVersion]: { aus: fullVersionDetails.aus } };
                 }
 
@@ -61,13 +62,13 @@ const LifecycleSelect = ({
         >
             <SelectList>
                 {fullVersionDetails.minor &&
-                    <SelectOption value="Minor release">Minor release</SelectOption>
+                    <SelectOption value={LIFECYCLE_VALUE.minor}>Minor release</SelectOption>
                 }
                 {fullVersionDetails.eus &&
-                    <SelectOption value="Extended update support">Extended update support</SelectOption>
+                    <SelectOption value={LIFECYCLE_VALUE.eus}>Extended update support</SelectOption>
                 }
                 {fullVersionDetails.aus &&
-                    <SelectOption value="Enhanced extended update support">Enhanced extended update support</SelectOption>
+                    <SelectOption value={LIFECYCLE_VALUE.aus}>Enhanced extended update support</SelectOption>
                 }
             </SelectList>
         </Select>

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.test.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/LifecycleSelect.test.js
@@ -2,18 +2,35 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import LifecycleSelect from './LifecycleSelect';
-import { rhel8Dot8MinorVersionDetails, rhel9Dot5MinorVersionDetails } from './osExposureReport.fixtures';
+import { rhel8Dot8MinorVersionDetails, rhel8Dot8MinorSelectedOs, rhel9Dot5MinorVersionDetails, rhel9Dot5MinorSelectedOs } from './osExposureReport.fixtures';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
 describe('LifecycleSelect Component', () => {
+  const setSelectedOsVersions = jest.fn();
+
   it('renders correctly with default props', () => {
-    render(<LifecycleSelect minorVersion="8.8" minorVersionDetails={rhel8Dot8MinorVersionDetails} />);
+    render(
+      <LifecycleSelect
+        minorVersion="8.8"
+        fullVersionDetails={rhel8Dot8MinorVersionDetails}
+        selectedOsVersions={rhel8Dot8MinorSelectedOs}
+        setSelectedOsVersions={setSelectedOsVersions}
+      />
+    );
+
     expect(screen.getByText('RHEL 8.8: Minor release')).toBeInTheDocument();
   });
 
   it('toggles the select menu on click and selects new option', async () => {
-    render(<LifecycleSelect minorVersion="8.8" minorVersionDetails={rhel8Dot8MinorVersionDetails} />);
+    render(
+      <LifecycleSelect
+        minorVersion="8.8"
+        fullVersionDetails={rhel8Dot8MinorVersionDetails}
+        selectedOsVersions={rhel8Dot8MinorSelectedOs}
+        setSelectedOsVersions={setSelectedOsVersions}
+      />
+    );
 
     const button = screen.getByRole('button', {
         name: /rhel 8\.8: minor release/i
@@ -34,10 +51,19 @@ describe('LifecycleSelect Component', () => {
             name: /rhel 8\.8: extended update support/i
         })
     ).toBeVisible());
+
+    expect(setSelectedOsVersions).toHaveBeenCalledWith([{ 8.8: { eus: rhel8Dot8MinorVersionDetails.eus }}])
   });
 
   it('does not open the menu if minorVersionDetails[minorVersion].eus is empty', async () => {
-    render(<LifecycleSelect minorVersion="9.5" minorVersionDetails={rhel9Dot5MinorVersionDetails} />);
+    render(
+      <LifecycleSelect
+        minorVersion="9.5"
+        fullVersionDetails={rhel9Dot5MinorVersionDetails}
+        selectedOsVersions={rhel9Dot5MinorSelectedOs}
+        setSelectedOsVersions={setSelectedOsVersions}
+      />
+    );
 
     const button = screen.getByRole('button', {
         name: /rhel 9\.5: minor release/i

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportModal.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/OsExposureReportModal.js
@@ -19,7 +19,6 @@ import {
     VULNERABILITY_EXPOSURE_BY_OS_REPORT_TITLE
 } from '../../../../Helpers/constants';
 import sortBy from 'lodash/sortBy';
-import xorWith from 'lodash/xorWith';
 import { getOSExposure } from '../../../../Helpers/APIHelper';
 import { useDispatch } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -108,11 +107,16 @@ const OsExposureReportModal = ({
     }, [osExposureData]);
 
     const isMinorOsVersionSelected = (targetOsVersion) =>
-        selectedOsVersions.some(osVersion => isEqual(osVersion, targetOsVersion));
+        selectedOsVersions.some(osVersion => isEqual(Object.keys(osVersion)[0], Object.keys(targetOsVersion)[0]));
 
     const toggleArrayItem = (item) => {
-        const unsorted = xorWith(selectedOsVersions, [item], isEqual);
+        let unsorted = selectedOsVersions.filter((os) => !isEqual(Object.keys(os)[0], Object.keys(item)[0]));
+        if (unsorted.length === selectedOsVersions.length) {
+            unsorted.push(item);
+        }
+
         const sorted = sortBy(unsorted, (obj) => Object.keys(obj)[0]).reverse();
+
         setSelectedOsVersions(sorted);
     };
 
@@ -186,7 +190,9 @@ const OsExposureReportModal = ({
                                                             && selectedOsVersions.length > 4)
                                                             || fetchLoading || exportLoading
                                                         }
-                                                        onChange={() => toggleArrayItem({ [osMinor]: minorValues })}
+                                                        onChange={
+                                                            () => toggleArrayItem({ [osMinor]: { minor: minorValues.minor } })
+                                                        }
                                                     />
                                                 </FlexItem>
                                             );
@@ -204,13 +210,16 @@ const OsExposureReportModal = ({
                             </Text>
                             : selectedOsVersions.map((selectedVersion) => {
                                 const minorVersion = Object.keys(selectedVersion)[0];
+                                const majorVersion = `RHEL ${minorVersion[0]}`;
                                 return (
                                     <FlexItem key={`lifecycle-select-${minorVersion}`}>
                                         <LifecycleSelect
-                                            minorVersionDetails={selectedVersion}
+                                            fullVersionDetails={exposureMap[majorVersion][minorVersion]}
                                             minorVersion={minorVersion}
                                             fetchLoading={fetchLoading}
                                             exportLoading={exportLoading}
+                                            selectedOsVersions={selectedOsVersions}
+                                            setSelectedOsVersions={setSelectedOsVersions}
                                         />
                                     </FlexItem>
                                 );
@@ -255,8 +264,8 @@ const OsExposureReportModal = ({
 };
 
 OsExposureReportModal.propTypes = {
-    isOsExposureModalOpen: propTypes.bool,
-    setOsExposureModalOpen: propTypes.func
+    isOsExposureModalOpen: propTypes.bool.isRequired,
+    setOsExposureModalOpen: propTypes.func.isRequired
 };
 
 export default OsExposureReportModal;

--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/osExposureReport.fixtures.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/osExposureReport.fixtures.js
@@ -1022,67 +1022,105 @@ export const osExposureData = [
 ];
 
 export const rhel8Dot8MinorVersionDetails = {
-    8.8: {
-        aus: {
-            cves_critical: 0,
-            cves_important: 0,
-            cves_low: 0,
-            cves_moderate: 0,
-            cves_unpatched_critical: 0,
-            cves_unpatched_important: 0,
-            cves_unpatched_low: 0,
-            cves_unpatched_moderate: 0,
-            lifecycle_phase: 'aus',
-            major: 8,
-            minor: 8,
-            name: 'RHEL'
-        },
-        eus: {
-            cves_critical: 0,
-            cves_important: 61,
-            cves_low: 40,
-            cves_moderate: 263,
-            cves_unpatched_critical: 0,
-            cves_unpatched_important: 0,
-            cves_unpatched_low: 0,
-            cves_unpatched_moderate: 0,
-            lifecycle_phase: 'eus',
-            major: 8,
-            minor: 8,
-            name: 'RHEL'
-        },
-        minor: {
-            cves_critical: 0,
-            cves_important: 62,
-            cves_low: 234,
-            cves_moderate: 526,
-            cves_unpatched_critical: 0,
-            cves_unpatched_important: 14,
-            cves_unpatched_low: 878,
-            cves_unpatched_moderate: 1217,
-            lifecycle_phase: 'minor',
-            major: 8,
-            minor: 8,
-            name: 'RHEL'
-        }
+    aus: {
+        cves_critical: 0,
+        cves_important: 0,
+        cves_low: 0,
+        cves_moderate: 0,
+        cves_unpatched_critical: 0,
+        cves_unpatched_important: 0,
+        cves_unpatched_low: 0,
+        cves_unpatched_moderate: 0,
+        lifecycle_phase: 'aus',
+        major: 8,
+        minor: 8,
+        name: 'RHEL'
+    },
+    eus: {
+        cves_critical: 0,
+        cves_important: 61,
+        cves_low: 40,
+        cves_moderate: 263,
+        cves_unpatched_critical: 0,
+        cves_unpatched_important: 0,
+        cves_unpatched_low: 0,
+        cves_unpatched_moderate: 0,
+        lifecycle_phase: 'eus',
+        major: 8,
+        minor: 8,
+        name: 'RHEL'
+    },
+    minor: {
+        cves_critical: 0,
+        cves_important: 62,
+        cves_low: 234,
+        cves_moderate: 526,
+        cves_unpatched_critical: 0,
+        cves_unpatched_important: 14,
+        cves_unpatched_low: 878,
+        cves_unpatched_moderate: 1217,
+        lifecycle_phase: 'minor',
+        major: 8,
+        minor: 8,
+        name: 'RHEL'
     }
 };
 
-export const rhel9Dot5MinorVersionDetails = {
-    9.5: {
-        minor: {
-            cves_critical: 0,
-            cves_important: 0,
-            cves_low: 0,
-            cves_moderate: 0,
-            cves_unpatched_critical: 0,
-            cves_unpatched_important: 17,
-            cves_unpatched_low: 850,
-            cves_unpatched_moderate: 1385,
-            lifecycle_phase: 'minor',
-            major: 9,
-            minor: 5,
-            name: 'RHEL'
+export const rhel8Dot8MinorSelectedOs = [
+    {
+        8.8: {
+            minor: {
+                cves_critical: 0,
+                cves_important: 62,
+                cves_low: 234,
+                cves_moderate: 526,
+                cves_unpatched_critical: 0,
+                cves_unpatched_important: 14,
+                cves_unpatched_low: 878,
+                cves_unpatched_moderate: 1217,
+                lifecycle_phase: 'minor',
+                major: 8,
+                minor: 8,
+                name: 'RHEL'
+            }
         }
     }
+];
+
+export const rhel9Dot5MinorVersionDetails = {
+    minor: {
+        cves_critical: 0,
+        cves_important: 0,
+        cves_low: 0,
+        cves_moderate: 0,
+        cves_unpatched_critical: 0,
+        cves_unpatched_important: 17,
+        cves_unpatched_low: 850,
+        cves_unpatched_moderate: 1385,
+        lifecycle_phase: 'minor',
+        major: 9,
+        minor: 5,
+        name: 'RHEL'
+    }
 };
+
+export const rhel9Dot5MinorSelectedOs = [
+    {
+        9.5: {
+            minor: {
+                cves_critical: 0,
+                cves_important: 0,
+                cves_low: 0,
+                cves_moderate: 0,
+                cves_unpatched_critical: 0,
+                cves_unpatched_important: 17,
+                cves_unpatched_low: 850,
+                cves_unpatched_moderate: 1385,
+                lifecycle_phase: 'minor',
+                major: 9,
+                minor: 5,
+                name: 'RHEL'
+            }
+        }
+    }
+];

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -1082,6 +1082,12 @@ export const PERMISSIONS = {
     readHosts: 'inventory:hosts:read'
 };
 
+export const LIFECYCLE_VALUE = {
+    minor: 'Minor release',
+    eus: 'Extended update support',
+    aus: 'Enhanced extended update support'
+};
+
 /*eslint-disable max-len*/
 export const CUSTOM_REPORT_CARD_TITLE = 'Report by CVEs';
 export const CUSTOM_REPORT_CARD_DESCRIPTION = 'A customizable PDF report of vulnerabilities identified by Red Hat across workloads that may impact your RHEL servers.';


### PR DESCRIPTION
This PR updates the way we make OS version and lifecycle selections for the PDF. We want to use the `selectedOsVersions` array as a reference for the pdf to get only the data it needs. So if a user select RHEL 8.8, it will default to only the `minor` lifecycle data.
```
[

    {

        8.8: {

           minor:  { ...data }

        }

    }

]
```

And, if a user changes the lifecycle selection to Extended Support:
```
[

    {

        8.8: {

           eus: { ...data }

        }

    }

]
```