### PR TITLE
feat(RHINENG-18786): Add system count to pdf

### DIFF
--- a/src/Components/SmartComponents/Modals/OsExposureReportModal/PdfExportButton.js
+++ b/src/Components/SmartComponents/Modals/OsExposureReportModal/PdfExportButton.js
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
-import { exportNotifications } from '../../../../Helpers/constants';
+import { exportNotifications, NotAuthorizedNotification } from '../../../../Helpers/constants';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useDispatch } from 'react-redux';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
+import {
+    addNotification,
+    clearNotifications
+} from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
+import messages from '../../../../Messages';
+import { getSystems } from '../../../../Helpers/APIHelper';
+import { intl } from '../../../../Utilities/IntlProvider';
 
 const PdfExportButton = ({
     filterData,
@@ -17,10 +23,7 @@ const PdfExportButton = ({
     const dispatch = useDispatch();
     const { requestPdf } = useChrome();
 
-    const dataFetch = async () => {
-        dispatch(addNotification(exportNotifications.pending));
-        setOsExposureModalOpen(false);
-
+    const fetchPDF = async (currentRhelVersions, currentSystemCounts) => {
         try {
             await requestPdf({
                 filename: `${reportTitle}.pdf`,
@@ -30,7 +33,9 @@ const PdfExportButton = ({
                     module: './OsExposureReport',
                     additionalData: {
                         filterData,
+                        rhelVersions: currentRhelVersions,
                         selectedOsData,
+                        systemCounts: currentSystemCounts,
                         userNote
                     }
                 }
@@ -42,12 +47,52 @@ const PdfExportButton = ({
         }
     };
 
+    const fetchSystemCounts = async () => {
+        dispatch(addNotification(exportNotifications.pending));
+        setOsExposureModalOpen(false);
+
+        const rhelVersionsCopy = [];
+        const systemCountsCopy = {};
+
+        for (const selectedMajorVersion of selectedOsData) {
+            const rhelVersion = Object.keys(selectedMajorVersion)[0].slice(-1);
+
+            try {
+                const { meta } = await getSystems({
+                    rhel_version: rhelVersion
+                });
+
+                systemCountsCopy[Object.keys(selectedMajorVersion)[0]] = meta.total_items;
+            } catch (error) {
+                clearNotifications();
+                dispatch(
+                    addNotification(Number(error.status) === 403 ? NotAuthorizedNotification : {
+                        variant: 'danger',
+                        autoDismiss: false,
+                        msg: intl.formatMessage(messages.notificationReportDownloadFailureTitle),
+                        description: intl.formatMessage(messages.notificationReportDownloadFailureBody)
+                    })
+                );
+
+                return;
+            }
+
+            selectedMajorVersion[Object.keys(selectedMajorVersion)[0]].forEach((rhelMinor) => {
+                rhelVersionsCopy.push(rhelMinor.os);
+            });
+        }
+
+        if (rhelVersionsCopy.length > 0) {
+            fetchPDF(rhelVersionsCopy, systemCountsCopy);
+        }
+    };
+
     return (
         <Button
             key="export-pdf"
             variant="primary"
             aria-label="Export to PDF"
-            onClick={dataFetch}
+            onClick={fetchSystemCounts}
             isDisabled={isDisabled}
         >
             Export PDF

--- a/src/Components/SmartComponents/Reports/OsExposureReport/ExposureReportChart.js
+++ b/src/Components/SmartComponents/Reports/OsExposureReport/ExposureReportChart.js
@@ -10,7 +10,7 @@ import {
     chart_color_red_100
 } from '@patternfly/react-tokens';
 
-const ExposureReportChart = ({ filterData, impactMap, selectedOsData }) => {
+const ExposureReportChart = ({ filterData, impactMap, rhelVersions, selectedOsData }) => {
     const chartData = transformFilteredCvesToChartData(selectedOsData);
     const fillMap = {
         critical: chart_color_red_100.value,
@@ -33,6 +33,11 @@ const ExposureReportChart = ({ filterData, impactMap, selectedOsData }) => {
         <span style={{ fontSize: '32px', color: chart_color_red_100.value }}>
             Severity breakdown of selected RHEL OS versions
         </span>
+        <div style={{ fontSize: '12px' }}>
+            {rhelVersions.map((rhelVersion) =>
+                <span key={rhelVersion} style={{ paddingRight: 16 }}>{rhelVersion}</span>
+            )}
+        </div>
         <Chart
             ariaDesc="OS versions and the number of CVEs per severity"
             ariaTitle="Vulnerability OS exposure chart"
@@ -125,6 +130,7 @@ const ExposureReportChart = ({ filterData, impactMap, selectedOsData }) => {
 ExposureReportChart.propTypes = {
     filterData: PropTypes.object.isRequired,
     impactMap: PropTypes.object.isRequired,
+    rhelVersions: PropTypes.array.isRequired,
     selectedOsData: PropTypes.array.isRequired
 };
 

--- a/src/Components/SmartComponents/Reports/OsExposureReport/ExposureReportTable.js
+++ b/src/Components/SmartComponents/Reports/OsExposureReport/ExposureReportTable.js
@@ -6,10 +6,11 @@ import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
 import ExposureReportTableRow from './ExposureReportTableRow';
 
-const ExposureReportTable = ({ filterData, impactMap, os, selectedMinorVersions }) => {
+const ExposureReportTable = ({ filterData, impactMap, os, selectedMinorVersions, systemCounts }) => {
     return (
         <React.Fragment>
             <Text style={{ color: chart_color_red_100.value, fontSize: '32px' }}>{os}</Text>
+            <div style={{ fontSize: 12 }}>{`There are ${systemCounts[os]} systems using a ${os} OS version.`}</div>
             <Table variant="compact">
                 <Thead>
                     <Tr>
@@ -51,7 +52,8 @@ ExposureReportTable.propTypes = {
     filterData: PropTypes.object.isRequired,
     impactMap: PropTypes.object.isRequired,
     os: PropTypes.string.isRequired,
-    selectedMinorVersions: PropTypes.array.isRequired
+    selectedMinorVersions: PropTypes.array.isRequired,
+    systemCounts: PropTypes.object.isRequired
 };
 
 export default ExposureReportTable;

--- a/src/Components/SmartComponents/Reports/OsExposureReport/OsExposureReport.js
+++ b/src/Components/SmartComponents/Reports/OsExposureReport/OsExposureReport.js
@@ -28,7 +28,7 @@ const OsExposureReport = ({ additionalData }) => {
         2: 'Low'
     };
 
-    const { filterData, selectedOsData, userNote } = additionalData;
+    const { filterData, rhelVersions, selectedOsData, systemCounts, userNote } = additionalData;
 
     return (
         <div>
@@ -61,6 +61,7 @@ const OsExposureReport = ({ additionalData }) => {
                                 <ExposureReportTable
                                     impactMap={impactMap}
                                     os={Object.keys(selectedMajorVersion)[0]}
+                                    systemCounts={systemCounts}
                                     selectedMinorVersions={selectedMajorVersion[Object.keys(selectedMajorVersion)[0]]}
                                     filterData={filterData}
                                 />
@@ -71,7 +72,12 @@ const OsExposureReport = ({ additionalData }) => {
             </div>
             <div style={{ ...styles.document, pageBreakBefore: 'always' }}>
                 <div>
-                    <ExposureReportChart filterData={filterData} impactMap={impactMap} selectedOsData={selectedOsData} />
+                    <ExposureReportChart
+                        filterData={filterData}
+                        impactMap={impactMap}
+                        rhelVersions={rhelVersions}
+                        selectedOsData={selectedOsData}
+                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR adds a system count to the RHEL major version tables in the "Report by operating system versions" report on the Reports page.

To see, go to Vulnerability -> Reports and click the "Report by operating system versions" card link. Select up to 5 os versions and Export PDF. The rendered PDF should show the total number of systems for your selected RHEL major versions.

So, if you selected RHEL 9.3 and 9.4, it will provide you with a count of ALL systems using RHEL 9.

In addition, the bar chart on the last page of the PDF includes a list of all of the RHEL minor versions underneath the title.