### PR TITLE
fix(Reports): RHINENG-24661 - Fix colors in Executive Report

### DIFF
--- a/src/Components/SmartComponents/Reports/ExecutiveReport/ExecutiveReport.js
+++ b/src/Components/SmartComponents/Reports/ExecutiveReport/ExecutiveReport.js
@@ -13,7 +13,7 @@ import {
   t_color_orange_50,
   t_global_background_color_100,
   t_global_color_brand_200,
-  t_color_red_10,
+  t_color_red_50,
 } from '@patternfly/react-tokens';
 import truncate from 'lodash/truncate';
 import { InsightsLabel } from '@redhat-cloud-services/frontend-components';
@@ -48,7 +48,7 @@ const NumberDisplay = ({ label, number, variant = 'primary' }) => (
     <div
       style={{
         fontSize: 24,
-        color: variant === 'primary' ? t_color_red_10.value : 'black',
+        color: variant === 'primary' ? t_color_red_50.value : 'black',
       }}
     >
       {number}
@@ -104,7 +104,7 @@ const ExecutiveReport = ({ additionalData }) => {
           style={{
             fontSize: 32,
             marginBottom: 16,
-            color: t_color_red_10.value,
+            color: t_color_red_50.value,
           }}
         >
           Executive report: Vulnerability
@@ -147,8 +147,8 @@ const ExecutiveReport = ({ additionalData }) => {
       </div>
       <PageBreak />
       <div style={styles.document}>
-        <div style={{ fontSize: 24, color: t_color_red_10.value }}>CVEs</div>
-        <div style={{ fontSize: 16, color: t_color_red_10.value }}>
+        <div style={{ fontSize: 24, color: t_color_red_50.value }}>CVEs</div>
+        <div style={{ fontSize: 16, color: t_color_red_50.value }}>
           Identified CVEs by CVSS score
         </div>
         <Grid hasGutter style={{ marginBottom: 16 }}>
@@ -215,7 +215,7 @@ const ExecutiveReport = ({ additionalData }) => {
         <div
           style={{
             fontSize: 16,
-            color: t_color_red_10.value,
+            color: t_color_red_50.value,
             marginTop: 16,
             marginBottom: 8,
           }}
@@ -248,7 +248,7 @@ const ExecutiveReport = ({ additionalData }) => {
         <div
           style={{
             fontSize: 16,
-            color: t_color_red_10.value,
+            color: t_color_red_50.value,
             marginTop: 16,
             marginBottom: 8,
           }}
@@ -291,14 +291,14 @@ const ExecutiveReport = ({ additionalData }) => {
       </div>
       <PageBreak />
       <div style={styles.document}>
-        <div style={{ fontSize: 24, color: t_color_red_10.value }}>
+        <div style={{ fontSize: 24, color: t_color_red_50.value }}>
           {additionalData.isLightspeedEnabled ? 'Lightspeed' : 'Insights'}{' '}
           Security Rules
         </div>
         <div
           style={{
             fontSize: 16,
-            color: t_color_red_10.value,
+            color: t_color_red_50.value,
             marginTop: 16,
             marginBottom: 8,
           }}
@@ -363,7 +363,7 @@ const ExecutiveReport = ({ additionalData }) => {
         <div
           style={{
             fontSize: 16,
-            color: t_color_red_10.value,
+            color: t_color_red_50.value,
             marginTop: 16,
             marginBottom: 8,
           }}


### PR DESCRIPTION
Fixes the missing var error and correctly updates the colors.

**Before:**

<img width="600" height="321" alt="Screenshot 2026-05-12 at 15 58 09" src="https://github.com/user-attachments/assets/365072f8-df30-46ea-bc57-948f526df126" />

**After:**

<img width="599" height="369" alt="Screenshot 2026-05-12 at 15 58 18" src="https://github.com/user-attachments/assets/77554c2f-0b13-44fe-9487-40abc8f5c564" />

## Summary by Sourcery

Bug Fixes:
- Fix incorrect and missing color token usage in Executive Report labels, headings, and number displays.