### PR TITLE
fix(Reports): RHINENG-24661 - Fix service name used for PDF generator

### DIFF
--- a/src/Components/SmartComponents/Reports/CVEsReport/CVEsReportFetch.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/CVEsReportFetch.js
@@ -296,15 +296,18 @@ export const fetchData = async (createAsyncRequest, { params, reportData }) => {
     sort: params.sort || '-cvss_score',
     advanced_report: 'true',
   };
-  const { data: cves, meta } = await createAsyncRequest('vulnerability', {
-    method: 'GET',
-    url: `/api/vulnerability/v1/vulnerabilities/cves`,
-    params: {
-      ...allParams,
-      page: 1,
-      page_size: 10,
+  const { data: cves, meta } = await createAsyncRequest(
+    'vulnerability-engine',
+    {
+      method: 'GET',
+      url: `/api/vulnerability/v1/vulnerabilities/cves`,
+      params: {
+        ...allParams,
+        page: 1,
+        page_size: 10,
+      },
     },
-  });
+  );
 
   // console.log('c-cves', JSON.stringify(cves, null, 2));
   // console.log('c-meta', JSON.stringify(meta, null, 2));

--- a/src/Components/SmartComponents/Reports/CVEsReport/CVEsReportFetchTable.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/CVEsReportFetchTable.js
@@ -298,15 +298,18 @@ export const fetchData = async (createAsyncRequest, { params, reportData }) => {
   };
   console.log('param', JSON.stringify(allParams, null, 2));
 
-  const { data: cves, meta } = await createAsyncRequest('vulnerability', {
-    method: 'GET',
-    url: `/api/vulnerability/v1/vulnerabilities/cves`,
-    params: {
-      ...allParams,
-      report: 'true',
-      advanced_report: 'true',
+  const { data: cves, meta } = await createAsyncRequest(
+    'vulnerability-engine',
+    {
+      method: 'GET',
+      url: `/api/vulnerability/v1/vulnerabilities/cves`,
+      params: {
+        ...allParams,
+        report: 'true',
+        advanced_report: 'true',
+      },
     },
-  });
+  );
 
   // console.log('c-cves', JSON.stringify(cves, null, 2));
   // console.log('c-meta', JSON.stringify(meta, null, 2));

--- a/src/Components/SmartComponents/Reports/CVEsReport/helpers.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/helpers.js
@@ -173,7 +173,7 @@ const queryPageFn =
       page_size: batchSize,
     };
 
-    const res = await createAsyncRequest('vulnerability', {
+    const res = await createAsyncRequest('vulnerability-engine', {
       method: 'GET',
       url: `/api/vulnerability/v1/vulnerabilities/cves`,
       params: queryParams,


### PR DESCRIPTION
The PDF generator uses the name 'vulnerability-engine' not 'vulnerability', this PR fixes the issue.

## Summary by Sourcery

Bug Fixes:
- Fix CVE report and PDF generation requests to target the 'vulnerability-engine' service instead of the incorrect 'vulnerability' service.