### PR TITLE
chore(dsn): update sentry dsn

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -18,7 +18,7 @@ module.exports = {
             org: 'red-hat-it',
             project: 'vulnerability-rhel',
             moduleMetadata: ({ release }) => ({
-              dsn: `https://cb035c73625db2cf00141494a95bdedb@o490301.ingest.us.sentry.io/4508683271077888`,
+              dsn: `https://4b0cbf4c163d2eddc1fc0a72b23b4aee@o490301.ingest.us.sentry.io/4508683271077888`,
               org: 'red-hat-it',
               project: 'vulnerability-rhel',
               release,


### PR DESCRIPTION
Some folks would like to rotate the dsn for vulnerability, this PR implements that change.
There is no change to functionality at all. The DSN is just the sentry projects 'address', but is useless information unless you have the key for that door. We dont need to implement this change in other apps/ we dont need to worry about this

## Summary by Sourcery

Chores:
- Update the configured Sentry DSN value in fec.config.js for the vulnerability RHEL project.