### PR TITLE
fix(setUp): circular dependency and runtime res

### DIFF
--- a/config/patchFederationForIop.js
+++ b/config/patchFederationForIop.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-undef */
+/**
+ * Foreman/IOP hosts provide react in the module federation shared scope but not
+ * react/jsx-runtime. FEC defaults mark jsx-runtime as chromeProvided with
+ * import: false, so the remote fails with:
+ *   Shared module react/jsx-runtime doesn't exist in shared scope default
+ *
+ * Remove jsx-runtime from chromeProvided so webpack bundles it in the remote.
+ */
+const federatedModulesPath = require.resolve(
+    '@redhat-cloud-services/frontend-components-config-utilities/federated-modules'
+);
+const federatedModulesUtil = require(federatedModulesPath);
+const originalCreateIncludes = federatedModulesUtil.createIncludes;
+
+federatedModulesUtil.createIncludes = () => {
+    const includes = originalCreateIncludes();
+    delete includes.chromeProvided['react/jsx-runtime'];
+    return includes;
+};

--- a/fec.config.js
+++ b/fec.config.js
@@ -2,6 +2,8 @@
 const { resolve } = require('path');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
+require('./config/patchFederationForIop');
+
 module.exports = {
     appUrl: '/insights/vulnerability',
     debug: true,

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React, {
     useEffect,
     useState,
     Fragment,
-    createContext,
     useContext
 } from 'react';
 import { useDispatch } from 'react-redux';
@@ -19,11 +18,11 @@ import { useHccEnvironmentContext } from './Helpers/Hooks';
 import { SERVICE_NAME } from './Helpers/constants';
 import { NotAuthorized } from '@patternfly/react-component-groups';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EnvironmentContext, PersistenceContext } from './Utilities/AppContexts';
+
+export { EnvironmentContext, PersistenceContext };
 
 ReducerRegistry.register({ notifications });
-
-export const EnvironmentContext = createContext({});
-export const PersistenceContext = createContext({});
 
 const App = () => {
     const { pathname } = useLocation();

--- a/src/Components/SmartComponents/IoP/Announcement.js
+++ b/src/Components/SmartComponents/IoP/Announcement.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import sanitizeHtml from 'sanitize-html';

--- a/src/Components/SmartComponents/IoP/Common.js
+++ b/src/Components/SmartComponents/IoP/Common.js
@@ -12,7 +12,7 @@ import {
 } from '../../../Helpers/constants';
 import { formatDate } from '../../../Helpers/MiscHelper';
 import { useQueryParamsCustom } from '../../../Helpers/Hooks';
-import { PersistenceContext } from '../../../App';
+import { PersistenceContext } from '../../../Utilities/AppContexts';
 import { checkboxFilter, textFilter, radioFilter, rangeFilter } from 'declarative-table';
 import { capitalize, Tooltip } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';

--- a/src/Components/SmartComponents/IoP/CveDetailHeader.js
+++ b/src/Components/SmartComponents/IoP/CveDetailHeader.js
@@ -9,7 +9,7 @@ import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-com
 import GroupedCVELabels from '../../PresentationalComponents/Snippets/GroupedCVELabels';
 import BaseDropdown from '../../PresentationalComponents/BaseDropdown/BaseDropdown';
 import EditCveStatusModal from './EditCveStatusModal';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import EditCveBusinessRiskModal from './EditCveBusinessRiskModal';
 
 const CveDetailHeader = ({ cveName, data, error, isLoading, onEdit }) => {

--- a/src/Components/SmartComponents/IoP/CveDetailPage.js
+++ b/src/Components/SmartComponents/IoP/CveDetailPage.js
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import CveDetailTable from './CveDetailTable';
 import CveDetailHeader from './CveDetailHeader';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import './iop.scss';

--- a/src/Components/SmartComponents/IoP/CveDetailTable.js
+++ b/src/Components/SmartComponents/IoP/CveDetailTable.js
@@ -6,7 +6,7 @@ import {
     hierarchyFilter
 }  from '../../../Frameworks/DeclarativeTable';
 import { CVE_SYSTEMS_HEADER, DEFAULT_PAGE_SIZE, GENERIC_ERROR_STATUS, MANUAL_REMEDIATION } from '../../../Helpers/constants';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import {
     advisoryAvailableFilter,
     advisoryNameFilter,

--- a/src/Components/SmartComponents/IoP/CveListPage.js
+++ b/src/Components/SmartComponents/IoP/CveListPage.js
@@ -2,7 +2,7 @@ import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-com
 import React, { Fragment, useContext } from 'react';
 import CveListTable from './CveListTable';
 import Dashbar from './Dashbar';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { Stack, StackItem } from '@patternfly/react-core';
 import Announcement from './Announcement';
 import './iop.scss';

--- a/src/Components/SmartComponents/IoP/CveListTable.js
+++ b/src/Components/SmartComponents/IoP/CveListTable.js
@@ -12,7 +12,7 @@ import {
     STATUS_OPTIONS
 } from '../../../Helpers/constants';
 import { useContext } from 'react';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { useQuery } from '@tanstack/react-query';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { Shield } from '@redhat-cloud-services/frontend-components';

--- a/src/Components/SmartComponents/IoP/Dashbar.js
+++ b/src/Components/SmartComponents/IoP/Dashbar.js
@@ -16,7 +16,7 @@ import { GENERIC_ERROR_STATUS, impactList } from '../../../Helpers/constants';
 import propTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import ErrorHandler from '../../PresentationalComponents/ErrorHandler/ErrorHandler';
 import { CVE_LIST_DEFAULT_FILTERS, usePersistentParams } from './Common';
 

--- a/src/Components/SmartComponents/IoP/EditCveBusinessRiskModal.js
+++ b/src/Components/SmartComponents/IoP/EditCveBusinessRiskModal.js
@@ -11,7 +11,7 @@ import {
     TextArea
 } from '@patternfly/react-core';
 import { BUSINESS_RISK_OPTIONS, NotAuthorizedNotification, ReadOnlyNotification } from '../../../Helpers/constants';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { axiosInstance } from './Common';
 
 const EditCveBusinessRiskModal = ({ targetItems, clearTargetItems, refreshData }) => {

--- a/src/Components/SmartComponents/IoP/EditCveStatusModal.js
+++ b/src/Components/SmartComponents/IoP/EditCveStatusModal.js
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { NotAuthorizedNotification, ReadOnlyNotification, STATUS_OPTIONS } from '../../../Helpers/constants';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { axiosInstance } from './Common';
 
 const EditCveStatusModal = ({ targetItems, clearTargetItems, refreshData }) => {

--- a/src/Components/SmartComponents/IoP/EditPairStatusModal.js
+++ b/src/Components/SmartComponents/IoP/EditPairStatusModal.js
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { NotAuthorizedNotification, ReadOnlyNotification, STATUS_OPTIONS } from '../../../Helpers/constants';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import { axiosInstance } from './Common';
 
 export const EditPairStatusModalType = {

--- a/src/Components/SmartComponents/IoP/Hooks.js
+++ b/src/Components/SmartComponents/IoP/Hooks.js
@@ -7,7 +7,7 @@ import { axiosInstance,
     transformPublishDateParam,
     transformAffectingParam
 } from './Common';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 
 export const useSystemsOptOut = () => {
     const envContext = useContext(EnvironmentContext);

--- a/src/Components/SmartComponents/IoP/IopBridge.js
+++ b/src/Components/SmartComponents/IoP/IopBridge.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { NotAuthorized } from '@patternfly/react-component-groups';
 import { IntlProvider } from 'react-intl';
-import { EnvironmentContext, PersistenceContext } from '../../../App';
+import { EnvironmentContext, PersistenceContext } from '../../../Utilities/AppContexts';
 import { useIoPEnvironmentContext } from '../../../Helpers/Hooks';
 import '../../../App.scss';
 

--- a/src/Components/SmartComponents/IoP/SystemDetailTable.js
+++ b/src/Components/SmartComponents/IoP/SystemDetailTable.js
@@ -11,7 +11,7 @@ import {
     GENERIC_ERROR_STATUS,
     SYSTEM_DETAILS_HEADER
 } from '../../../Helpers/constants';
-import { EnvironmentContext } from '../../../App';
+import { EnvironmentContext } from '../../../Utilities/AppContexts';
 import {
     cvssScoreFilter,
     knownExploitFilter,

--- a/src/Utilities/AppContexts.js
+++ b/src/Utilities/AppContexts.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+export const EnvironmentContext = createContext({});
+export const PersistenceContext = createContext({});

--- a/src/Utilities/VulnerabilityRoutes.js
+++ b/src/Utilities/VulnerabilityRoutes.js
@@ -9,7 +9,7 @@ import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { useAccountStats, useNotification } from '../Helpers/Hooks';
 import PageLoading from '../Components/PresentationalComponents/Snippets/PageLoading';
 import { Unavailable } from '@redhat-cloud-services/frontend-components';
-import { EnvironmentContext } from '../App';
+import { EnvironmentContext } from './AppContexts';
 import { NotAuthorized } from '@patternfly/react-component-groups';
 
 const SystemsPage = lazy(() =>


### PR DESCRIPTION
Enables local federated development of vulnerability IoP exposes (./CveListPage, etc.) against the Foreman/IOP shell via frontend-development-proxy.

Two runtime issues were blocking module load (unrelated to the minimatch CVE fix in https://github.com/RedHatInsights/vulnerability-ui/pull/2680):

Circular import / TDZ: Loading ./CveListPage pulled in App.js → VulnerabilityRoutes → back to App.js before exports finished initializing, causing Cannot access 'WEBPACK_DEFAULT_EXPORT' before initialization.
Module federation shared deps: FEC assumes an Insights Chrome host that provides react/jsx-runtime in the shared scope. Foreman/IOP provides react but not react/jsx-runtime, causing Shared module react/jsx-runtime doesn't exist in shared scope default.
Changes:

Extract EnvironmentContext and PersistenceContext into src/Utilities/AppContexts.js so IoP components and VulnerabilityRoutes no longer import from App.js. App.js re-exports the contexts for backward compatibility.
Add config/patchFederationForIop.js to remove react/jsx-runtime from FEC’s chromeProvided list so the remote bundles it locally when loaded by Foreman.