### PR TITLE
feat(IOP): add IOP mode support with custom routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,44 @@ In a separate terminal, run Vulnerability with proxy enabled and list Inventory:
 LOCAL_APPS=inventory:8003~http npm run start:proxy
 ```
 
+## Running in IOP (Insights on Premises) mode
+
+IOP mode enables local development against a Satellite/Foreman instance.
+
+### Running with IOP
+
+```bash
+IOP_URL="https://your-iop-instance.example.com" npm run start:proxy:iop
+```
+
+This uses the published proxy image from the remote registry.
+
+### Testing with Local Proxy Changes
+
+To test local modifications to the proxy before they're published:
+
+```bash
+# Build proxy locally
+cd frontend-development-proxy
+podman build -t ghcr.io/redhatinsights/frontend-development-proxy:latest .
+
+# Run vulnerability with local proxy
+cd vulnerability-ui
+IOP_URL="https://your-iop-instance.example.com" npm run start:proxy:iop:local
+```
+
+The `:local` script prevents pulling the remote image and uses your local build instead.
+
+Access at: `https://iop.foo.redhat.com:1337`
+
+### How it works
+
+- `IOP=true` enables IOP-specific webpack configuration
+- `custom_routes.json` routes vulnerability assets to your local dev server (port 8003)
+- All other requests (Chrome, APIs, other apps) proxy to the IOP instance
+- Location header rewriting keeps you on the local proxy URL during redirects
+- `tls_insecure_skip_verify` allows self-signed IOP certificates
+
 ## Testing
 [Jest](https://jestjs.io/) and [Cypress](https://www.cypress.io/) are used as the testing frameworks
 - ```npm run test``` - run all tests

--- a/custom_routes.json
+++ b/custom_routes.json
@@ -1,0 +1,9 @@
+{
+  "/assets/apps/vulnerability/*": {
+    "url": "http://host.docker.internal:8003",
+    "strip_prefix": "/assets"
+  },
+  "/apps/vulnerability/*": {
+    "url": "http://host.docker.internal:8003"
+  }
+}

--- a/fec.config.js
+++ b/fec.config.js
@@ -9,6 +9,7 @@ module.exports = {
     debug: true,
     useProxy: true,
     proxyVerbose: true,
+    SPAFallback: process.env.IOP !== 'true',
     interceptChromeConfig: false,
     devtool: 'hidden-source-map',
     plugins: [

--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "server:ctr": "node src/server/generateServerKey.js",
     "start": "fec dev",
     "start:proxy": "PROXY=true fec dev",
+    "start:proxy:iop": "PROXY=true IOP=true HCC_ENV=iop HCC_ENV_URL=${IOP_URL} FEC_IOP_CUSTOM_ROUTES_PATH=custom_routes.json fec dev-proxy --iop",
+    "start:proxy:iop:local": "FEC_DEV_PROXY_IMAGE=ghcr.io/redhatinsights/frontend-development-proxy:latest PROXY=true IOP=true HCC_ENV=iop HCC_ENV_URL=${IOP_URL} FEC_IOP_CUSTOM_ROUTES_PATH=custom_routes.json fec dev-proxy --iop",
     "static": "fec static",
     "ci:verify": "npm run test:coverage",
     "verify": "npm-run-all build lint test",


### PR DESCRIPTION
This is a long summary but I wanted to catch all pain points. Essentially the goal is for iop branches to just be able to run npm run start:proxy:iop on appropriate branches and thats it.



  Adds IOP (Insights on Premises) mode support for local development against Satellite/Foreman instances.

  Changes

  - package.json: Added start:proxy:iop and start:proxy:iop:local scripts with dynamic IOP_URL
  - fec.config.js: Disabled Chrome SPA fallback in IOP mode (SPAFallback: process.env.IOP !== 'true')
  - custom_routes.json: Routes vulnerability assets/APIs to local dev server with strip_prefix support

  Testing (Before Dependencies Merge)

  1. Build local frontend-components package:
  cd frontend-components
  git checkout IOP
  npm install && npm run build
  cd packages/config 
  npm pack  # Creates .tgz file

  2. Build local proxy image:
  cd frontend-development-proxy
  git checkout config
  # Comment out test lines 23-28 in Dockerfile (local Docker build issue)
  podman build -t ghcr.io/redhatinsights/frontend-development-proxy:latest .

  3. Install and run:
  cd vulnerability-ui
  npm install /path/to/redhat-cloud-services-frontend-components-config-*.tgz
  IOP_URL="https://your-iop-instance.example.com" npm run start:proxy:iop:local
  
  Access at: https://iop.foo.redhat.com:1337/insights/vulnerability

  After Dependencies Merge

  Just run:
  IOP_URL="https://your-iop-instance.example.com" npm run start:proxy:iop


  - https://github.com/RedHatInsights/frontend-components/pull/2308
  - vulnerability-ui: foreman-3.16 branch IOP setup:  https://github.com/RedHatInsights/vulnerability-ui/pull/2695
  - insights-advisor-frontend: foreman-3.16 branch IOP setup: https://github.com/RedHatInsights/insights-advisor-frontend/pull/2036
  -proxy: https://github.com/RedHatInsights/frontend-development-proxy/pull/131