### PR TITLE
fix(Reports): Use pdf-generator requests feature

### DIFF
--- a/src/Components/SmartComponents/Reports/CVEsReport/CVEsReport.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/CVEsReport.js
@@ -231,7 +231,7 @@ const buildData = (fetchData, reportData) => {
 
 const CVEsReport = ({
   additionalData,
-  fetchData: { vulnerability: fetchData },
+  fetchData: { vulnerability: fetchData } = {},
 }) => {
   const data = buildData(fetchData, additionalData.reportData);
 

--- a/src/Components/SmartComponents/Reports/DownloadCVEsReportButton.js
+++ b/src/Components/SmartComponents/Reports/DownloadCVEsReportButton.js
@@ -1,28 +1,56 @@
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 import { exportNotifications } from '../../../Helpers/constants';
 import { useNotifications } from '@redhat-cloud-services/frontend-components-notifications';
 
 import { EnvironmentContext } from '../../../App';
-import { preparePayloads } from './CVEsReport/helpers';
+import { preparePayloads, preparePDFRequests } from './CVEsReport/helpers';
 
 const DownloadCVEsReportButton = ({ params, filters, reportData }) => {
+  const enablePDFRequests = true; // TODO Replace with feature flag
   const { addNotification } = useNotifications();
   const [isGenerating, setGenerating] = useState(false);
 
   const envContext = useContext(EnvironmentContext);
 
-  const fetchPDF = async () => {
+  const fetchPDF = useCallback(async () => {
     addNotification(exportNotifications.pending);
 
     try {
       setGenerating(true);
 
-      await envContext.requestPdf({
-        filename: `vulnerability_cves-report--${new Date().toISOString().split('T')[0]}.pdf`,
-        payload: await preparePayloads(params, reportData, filters, envContext),
-      });
+      if (enablePDFRequests) {
+        await envContext.requestPdf({
+          filename: `vulnerability_cves-report--${new Date().toISOString().split('T')[0]}.pdf`,
+          payload: {
+            manifestLocation: '/apps/vulnerability/fed-mods.json',
+            scope: 'vulnerability',
+            module: './CVEsReport',
+            fetchDataParams: {
+              params,
+              reportData,
+            },
+            additionalData: {
+              reportData,
+              filters,
+              user: await envContext.getUser(),
+            },
+            requests: await preparePDFRequests(params),
+            landscape: true,
+          },
+        });
+      } else {
+        await envContext.requestPdf({
+          filename: `vulnerability_cves-report--${new Date().toISOString().split('T')[0]}.pdf`,
+          payload: await preparePayloads(
+            params,
+            reportData,
+            filters,
+            envContext,
+          ),
+        });
+      }
 
       addNotification(exportNotifications.success);
       setGenerating(false);
@@ -33,7 +61,14 @@ const DownloadCVEsReportButton = ({ params, filters, reportData }) => {
         description: error?.message || error?.detail,
       });
     }
-  };
+  }, [
+    addNotification,
+    params,
+    filters,
+    reportData,
+    enablePDFRequests,
+    envContext,
+  ]);
 
   return (
     <Button


### PR DESCRIPTION
## Summary by Sourcery

Switch CVEs report PDF generation to use the pdf-generator requests-based payload while retaining a fallback to the existing payload format.

New Features:
- Enable a requests-based PDF generation flow for CVEs reports using the pdf-generator manifest and module configuration.

Enhancements:
- Wrap the CVEs report download handler in useCallback with appropriate dependencies to avoid unnecessary re-creations.
- Make the CVEsReport component resilient to missing vulnerability fetchData by providing a default empty object.