### PR TITLE
feat(RHINENG-25676): add advisory filters

### DIFF
--- a/src/Components/PresentationalComponents/Kebab/KebabItems.js
+++ b/src/Components/PresentationalComponents/Kebab/KebabItems.js
@@ -1,4 +1,4 @@
-import { DropdownItem } from '@patternfly/react-core';
+import { DropdownItem, Switch } from '@patternfly/react-core';
 import React from 'react';
 import messages from '../../../Messages';
 import { FormattedMessage } from 'react-intl';
@@ -48,5 +48,32 @@ export const kebabItemEditStatus = (
     {...props}
   >
     <FormattedMessage {...messages.kebabEditStatus} />
+  </DropdownItem>
+);
+
+export const kebabItemToggleCvesWithoutAdvisories = (
+  isEnabled,
+  onToggle,
+  props = {},
+) => (
+  <DropdownItem
+    key="toggleCvesWithoutAdvisories"
+    ouiaId="toggle-cves-without-advisories"
+    onClick={(e) => {
+      e.preventDefault();
+      onToggle(!isEnabled);
+    }}
+    {...props}
+  >
+    <Switch
+      id="cves-without-advisories-toggle"
+      label={<FormattedMessage {...messages.kebabShowCvesWithoutAdvisories} />}
+      isChecked={isEnabled}
+      onChange={(event, checked) => {
+        event.stopPropagation();
+        onToggle(checked);
+      }}
+      ouiaId="cves-without-advisories-switch"
+    />
   </DropdownItem>
 );

--- a/src/Components/PresentationalComponents/Kebab/KebabItems.test.js
+++ b/src/Components/PresentationalComponents/Kebab/KebabItems.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { kebabItemEditBusinessRisk, kebabItemEditStatus } from './KebabItems';
+import {
+  kebabItemEditBusinessRisk,
+  kebabItemEditStatus,
+  kebabItemToggleCvesWithoutAdvisories,
+} from './KebabItems';
 import { Dropdown, DropdownList, MenuToggle } from '@patternfly/react-core';
 import configureStore from 'redux-mock-store';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import TestWrapper from '../../../Utilities/TestWrapper';
 
 const mockStore = configureStore([(store) => (next) => (action) => {}]);
@@ -25,5 +29,30 @@ describe('KebabItems component', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  describe('kebabItemToggleCvesWithoutAdvisories', () => {
+    it('should render toggle kebab item', () => {
+      const mockOnToggle = jest.fn();
+      const item = kebabItemToggleCvesWithoutAdvisories(true, mockOnToggle);
+
+      const { asFragment } = render(
+        <TestWrapper store={store}>
+          <Dropdown
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => {}}
+                isExpanded={true}
+              />
+            )}
+          >
+            <DropdownList>{[item]}</DropdownList>
+          </Dropdown>
+        </TestWrapper>,
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
   });
 });

--- a/src/Components/PresentationalComponents/Kebab/__snapshots__/KebabItems.test.js.snap
+++ b/src/Components/PresentationalComponents/Kebab/__snapshots__/KebabItems.test.js.snap
@@ -34,3 +34,38 @@ exports[`KebabItems component Should render without default params 1`] = `
   </button>
 </DocumentFragment>
 `;
+
+exports[`KebabItems component kebabItemToggleCvesWithoutAdvisories should render toggle kebab item 1`] = `
+<DocumentFragment>
+  <button
+    aria-expanded="true"
+    class="pf-v6-c-menu-toggle pf-m-expanded"
+    data-ouia-component-id="OUIA-Generated-MenuToggle-:rd:"
+    data-ouia-component-type="PF6/MenuToggle"
+    data-ouia-safe="true"
+    type="button"
+  >
+    <span
+      class="pf-v6-c-menu-toggle__controls"
+    >
+      <span
+        class="pf-v6-c-menu-toggle__toggle-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="pf-v6-svg"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          viewBox="0 0 20 20"
+          width="1em"
+        >
+          <path
+            d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+          />
+        </svg>
+      </span>
+    </span>
+  </button>
+</DocumentFragment>
+`;

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.advisoryFilter.test.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.advisoryFilter.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import configureStore from 'redux-mock-store';
+import TestWrapper from '../../../Utilities/TestWrapper';
+import { CVETableContext } from './CVEs';
+import { AccountStatsContext } from '../../../Utilities/VulnerabilityRoutes';
+import CVEsTableToolbar from './CVEsTableToolbar';
+import { setCvesWithoutErrata } from '../../../Helpers/APIHelper';
+
+jest.mock('../../../Helpers/APIHelper', () => ({
+  setCvesWithoutErrata: jest.fn(() => Promise.resolve()),
+}));
+
+const mockStore = configureStore([]);
+const store = mockStore({});
+
+const buildContext = (cvesWithoutErrata) => ({
+  cves: { meta: { total_items: 0, cves_without_errata: cvesWithoutErrata } },
+  params: {},
+  methods: {
+    apply: jest.fn(),
+    selectCves: jest.fn(),
+  },
+  selectedCves: [],
+});
+
+const renderToolbar = (context) =>
+  render(
+    <TestWrapper store={store}>
+      <AccountStatsContext.Provider
+        value={{ hasEdgeDevices: false, includesCvesWithoutErrata: false }}
+      >
+        <CVETableContext.Provider value={context}>
+          <CVEsTableToolbar operatingSystems={[]} />
+        </CVETableContext.Provider>
+      </AccountStatsContext.Provider>
+    </TestWrapper>,
+  );
+
+const openFilterCategoryDropdown = () => {
+  const categoryToggle = screen.getByText('CVE');
+  fireEvent.click(categoryToggle);
+};
+
+test('Advisory filter option visibility follows showCvesWithoutAdvisories preference', () => {
+  localStorage.clear();
+  const { unmount } = renderToolbar(buildContext(null));
+
+  openFilterCategoryDropdown();
+  expect(screen.queryByText('Advisory')).toBeInTheDocument();
+  unmount();
+
+  localStorage.setItem('vulnerability:showCvesWithoutAdvisories', 'false');
+  renderToolbar(buildContext(null));
+
+  openFilterCategoryDropdown();
+  expect(screen.queryByText('Advisory')).not.toBeInTheDocument();
+});
+
+test('clicking "Hide CVEs without Advisories" in the actions menu also hides the Advisory filter', () => {
+  localStorage.clear();
+  localStorage.setItem('vulnerability:showCvesWithoutAdvisories', 'true');
+  renderToolbar(buildContext(true));
+
+  // Advisory filter starts out visible, since the preference defaults to true.
+  openFilterCategoryDropdown();
+  expect(screen.queryByText('Advisory')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Advisory')); // close the category dropdown
+
+  fireEvent.click(screen.getByLabelText('kebab dropdown toggle'));
+  fireEvent.click(screen.getByText('Hide CVEs without Advisories'));
+
+  expect(setCvesWithoutErrata).toHaveBeenCalledWith(false);
+  expect(localStorage.getItem('vulnerability:showCvesWithoutAdvisories')).toBe(
+    'false',
+  );
+
+  openFilterCategoryDropdown();
+  expect(screen.queryByText('Advisory')).not.toBeInTheDocument();
+});

--- a/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
+++ b/src/Components/SmartComponents/CVEs/CVEsTableToolbar.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import messages from '../../../Messages';
@@ -16,7 +16,10 @@ import knownExploitFilter from '../../PresentationalComponents/Filters/PrimaryTo
 import appliesToOSFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/AppliesToOSFilter';
 import statusFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/StatusFilter';
 import advisoryAvailabilityFilter from '../../PresentationalComponents/Filters/PrimaryToolbarFilters/AdvisoryAvailabilityFilter';
-import { kebabItemDownloadPDF } from '../../PresentationalComponents/Kebab/KebabItems';
+import {
+  kebabItemDownloadPDF,
+  kebabItemToggleCvesWithoutAdvisories,
+} from '../../PresentationalComponents/Kebab/KebabItems';
 import {
   handleChangePage,
   handleSetPageSize,
@@ -37,11 +40,14 @@ import { getCveDefaultFilters } from './CVEsAssets';
 import { AccountStatsContext } from '../../../Utilities/VulnerabilityRoutes';
 import useFeatureFlag from '../../../Utilities/useFeatureFlag';
 import { EnvironmentContext } from '../../../App';
+import useShowCvesWithoutAdvisories from '../../../Utilities/useShowCvesWithoutAdvisories';
 
 // TODO add back CVE PDF export
 const CVEsTableToolbarWithContext = ({ context, intl, operatingSystems }) => {
   const envContext = useContext(EnvironmentContext);
   const [exportPDF, setExportPDF] = useState(false);
+  const [showCvesWithoutAdvisoriesPref, setShowCvesWithoutAdvisoriesPref] =
+    useShowCvesWithoutAdvisories();
 
   const { cves, params, methods, selectedCves } = context;
 
@@ -54,10 +60,44 @@ const CVEsTableToolbarWithContext = ({ context, intl, operatingSystems }) => {
   const showCvesWithoutErrata = cves?.meta?.cves_without_errata;
   const isAppliesToOSEnabled = useFeatureFlag('vulnerability.applies_to_os');
 
-  const defaultFilters = getCveDefaultFilters(
-    shouldUseHybridSystemFilter,
-    includesCvesWithoutErrata || showCvesWithoutErrata,
-  );
+  useEffect(() => {
+    if (
+      envContext.areCvesWithoutErrataTogglable &&
+      showCvesWithoutErrata !== null &&
+      showCvesWithoutErrata !== undefined &&
+      showCvesWithoutErrata !== showCvesWithoutAdvisoriesPref
+    ) {
+      setShowCvesWithoutAdvisoriesPref(showCvesWithoutErrata);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [envContext.areCvesWithoutErrataTogglable, showCvesWithoutErrata]);
+
+  const defaultFilters = {
+    ...getCveDefaultFilters(
+      shouldUseHybridSystemFilter,
+      includesCvesWithoutErrata || showCvesWithoutErrata,
+    ),
+    ...(!showCvesWithoutAdvisoriesPref ? { advisory_available: 'true' } : {}),
+  };
+
+  // Used by the Export dropdown's "Show CVEs without advisories" switch.
+  // Keeps the account-level backend setting (when available) in sync with the
+  // local preference, so both controls agree with each other.
+  const handleShowCvesWithoutAdvisoriesToggle = (newValue) => {
+    setShowCvesWithoutAdvisoriesPref(newValue);
+
+    if (
+      envContext.areCvesWithoutErrataTogglable &&
+      showCvesWithoutErrata !== null
+    ) {
+      setCvesWithoutErrata(newValue).then(() =>
+        methods.apply({
+          page: 1,
+          advisory_available: newValue ? undefined : 'true',
+        }),
+      );
+    }
+  };
 
   const selectOptions = selectAllCheckbox({
     selectedItems: selectedCves,
@@ -142,17 +182,11 @@ const CVEsTableToolbarWithContext = ({ context, intl, operatingSystems }) => {
           showCvesWithoutErrata
             ? {
                 label: intl.formatMessage(messages.hideCvesWithoutAdvisories),
-                onClick: () =>
-                  setCvesWithoutErrata(false).then(() =>
-                    methods.apply({ page: 1, advisory_available: undefined }),
-                  ),
+                onClick: () => handleShowCvesWithoutAdvisoriesToggle(false),
               }
             : {
                 label: intl.formatMessage(messages.showCvesWithoutAdvisories),
-                onClick: () =>
-                  setCvesWithoutErrata(true).then(() =>
-                    methods.apply({ page: 1, advisory_available: 'true' }),
-                  ),
+                onClick: () => handleShowCvesWithoutAdvisoriesToggle(true),
               },
         ]
       : []),
@@ -219,7 +253,7 @@ const CVEsTableToolbarWithContext = ({ context, intl, operatingSystems }) => {
           affectingFilter(methods.apply, params),
           publishDateFilter(methods.apply, params),
           statusFilter(methods.apply, params),
-          ...(showCvesWithoutErrata
+          ...(showCvesWithoutAdvisoriesPref
             ? [advisoryAvailabilityFilter(methods.apply, params)]
             : []),
         ],
@@ -238,7 +272,13 @@ const CVEsTableToolbarWithContext = ({ context, intl, operatingSystems }) => {
       exportConfig={
         envContext.isExportEnabled && {
           isDisabled: cves.meta.total_items === 0,
-          extraItems: [kebabItemDownloadPDF(exportPDF, setExportPDF)],
+          extraItems: [
+            kebabItemDownloadPDF(exportPDF, setExportPDF),
+            kebabItemToggleCvesWithoutAdvisories(
+              showCvesWithoutAdvisoriesPref,
+              handleShowCvesWithoutAdvisoriesToggle,
+            ),
+          ],
           ouiaId: 'export',
           ...exportConfig(methods),
         }

--- a/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
+++ b/src/Components/SmartComponents/SystemsExposedTable/SystemsExposedTable.js
@@ -65,6 +65,7 @@ import advisoryAvailabilityFilter from '../../PresentationalComponents/Filters/P
 import PageLoading from '../../PresentationalComponents/Snippets/PageLoading';
 import { CVE_SYSTEMS_HEADER } from '../../../Helpers/constants';
 import { EnvironmentContext } from '../../../App';
+import useShowCvesWithoutAdvisories from '../../../Utilities/useShowCvesWithoutAdvisories';
 
 function exposedSystemsParamsWithoutPagination(parameters) {
   const { page: _p, page_size: _ps, ...rest } = parameters;
@@ -93,6 +94,7 @@ const SystemsExposedTable = ({
 }) => {
   const envContext = useContext(EnvironmentContext);
   const { addNotification, clearNotifications } = useNotifications();
+  const [showCvesWithoutAdvisoriesPref] = useShowCvesWithoutAdvisories();
 
   const dispatch = useDispatch();
   const [isAllExpanded, setIsAllExpanded] = useState(false);
@@ -312,6 +314,7 @@ const SystemsExposedTable = ({
 
   const defaultFilters = {
     ...(meta?.cves_without_errata ? { advisory_available: 'true' } : {}),
+    ...(!showCvesWithoutAdvisoriesPref ? { advisory_available: 'true' } : {}),
   };
 
   return (
@@ -406,7 +409,7 @@ const SystemsExposedTable = ({
                 ),
               }),
               statusFilter(apply, parameters),
-              ...(meta?.cves_without_errata
+              ...(showCvesWithoutAdvisoriesPref
                 ? [advisoryAvailabilityFilter(apply, parameters)]
                 : []),
               advisoryNameFilter,

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1218,6 +1218,11 @@ export default defineMessages({
     description: 'Kebab item',
     defaultMessage: 'Edit status',
   },
+  kebabShowCvesWithoutAdvisories: {
+    id: 'kebab.showCvesWithoutAdvisories',
+    description: 'Kebab item to toggle showing CVEs without advisories',
+    defaultMessage: 'Show CVEs without advisories',
+  },
 
   systemKebabEnableAnalysis: {
     id: 'systemKebab.enableAnalysis',

--- a/src/Utilities/useShowCvesWithoutAdvisories.js
+++ b/src/Utilities/useShowCvesWithoutAdvisories.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'vulnerability:showCvesWithoutAdvisories';
+
+/**
+ * Hook to manage the user preference for showing CVEs without advisories
+ * @returns {[boolean, Function]} - [isEnabled, setIsEnabled]
+ */
+const useShowCvesWithoutAdvisories = () => {
+  const [isEnabled, setIsEnabled] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    // Default to true (show CVEs without advisories) if not set
+    return stored === null ? true : stored === 'true';
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, isEnabled.toString());
+  }, [isEnabled]);
+
+  return [isEnabled, setIsEnabled];
+};
+
+export default useShowCvesWithoutAdvisories;

--- a/src/Utilities/useShowCvesWithoutAdvisories.test.js
+++ b/src/Utilities/useShowCvesWithoutAdvisories.test.js
@@ -1,0 +1,91 @@
+import { renderHook, act } from '@testing-library/react';
+import useShowCvesWithoutAdvisories from './useShowCvesWithoutAdvisories';
+
+const STORAGE_KEY = 'vulnerability:showCvesWithoutAdvisories';
+
+describe('useShowCvesWithoutAdvisories', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should default to true when localStorage is empty', () => {
+    const { result } = renderHook(() => useShowCvesWithoutAdvisories());
+    const [isEnabled] = result.current;
+
+    expect(isEnabled).toBe(true);
+  });
+
+  it('should read initial value from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'false');
+
+    const { result } = renderHook(() => useShowCvesWithoutAdvisories());
+    const [isEnabled] = result.current;
+
+    expect(isEnabled).toBe(false);
+  });
+
+  it('should update localStorage when value changes', () => {
+    const { result } = renderHook(() => useShowCvesWithoutAdvisories());
+
+    act(() => {
+      const [, setIsEnabled] = result.current;
+      setIsEnabled(false);
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+
+    const [isEnabled] = result.current;
+    expect(isEnabled).toBe(false);
+  });
+
+  it('should toggle value correctly', () => {
+    const { result } = renderHook(() => useShowCvesWithoutAdvisories());
+
+    // Initial value should be true
+    expect(result.current[0]).toBe(true);
+
+    // Toggle to false
+    act(() => {
+      result.current[1](false);
+    });
+    expect(result.current[0]).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+
+    // Toggle back to true
+    act(() => {
+      result.current[1](true);
+    });
+    expect(result.current[0]).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('should handle string "true" from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+
+    const { result } = renderHook(() => useShowCvesWithoutAdvisories());
+    const [isEnabled] = result.current;
+
+    expect(isEnabled).toBe(true);
+  });
+
+  it('should persist across multiple hook instances', () => {
+    const { result: result1 } = renderHook(() =>
+      useShowCvesWithoutAdvisories(),
+    );
+
+    act(() => {
+      result1.current[1](false);
+    });
+
+    // Create a new instance of the hook
+    const { result: result2 } = renderHook(() =>
+      useShowCvesWithoutAdvisories(),
+    );
+
+    expect(result2.current[0]).toBe(false);
+  });
+});


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-25676 
https://redhat.atlassian.net/browse/RHINENG-25677

This implements an advisory filter on cve tables.

   1 # Add Advisory Filter Toggle to CVEs Page
   2
   3 ## Changes
   4 - Added kebab menu toggle "Show CVEs without advisories" to the export dropdown on CVEs page
   5 - Added Advisory filter to CVEs page and CVE detail pages (always visible when toggle is ON)
   6 - Toggle state persists in localStorage across sessions
   7 - When toggle is OFF: Advisory filter UI is hidden AND CVEs without advisories are automatically filtered out
   8 - Syncs with backend `cves_without_errata` setting when available
   9
  10 ## Testing Instructions
  11
  12 ### Test 1: Basic Toggle Functionality
  13 1. Navigate to `/insights/vulnerability/cves`
  14 2. Click the export kebab menu (3 dots)
  15 3. Verify you see "Show CVEs without advisories" toggle (should be ON by default)
  16 4. Verify "Advisory" filter appears in the filters dropdown
  17 5. Click the toggle to turn it OFF
  18 6. Verify "Advisory" filter disappears from filters dropdown
  19 7. Verify CVEs without advisories are filtered out (advisory_available=true applied)
  20 8. Click toggle to turn it back ON
  21 9. Verify "Advisory" filter reappears and CVEs without advisories show again
  22
  23 ### Test 2: localStorage Persistence
  24 1. Turn the toggle OFF
  25 2. Refresh the page
  26 3. Verify toggle remains OFF
  27 4. Verify Advisory filter is hidden
  28 5. Turn toggle ON
  29 6. Refresh the page
  30 7. Verify toggle remains ON
  31 8. Verify Advisory filter is visible
  32
  33 ### Test 3: Advisory Filter Functionality (when toggle is ON)
  34 1. Ensure toggle is ON
  35 2. Click the "Advisory" filter
  36 3. Select "Available"
  37 4. Verify only CVEs with advisories are shown
  38 5. Select "Not available"
  39 6. Verify only CVEs without advisories are shown
  40 7. Clear the filter
  41 8. Verify all CVEs are shown
  42
  43 ### Test 4: CVE Detail Page
  44 1. Navigate to a specific CVE detail page
  45 2. Verify the toggle exists in the export kebab menu
  46 3. Test that toggle ON shows Advisory filter in Systems Exposed table
  47 4. Test that toggle OFF hides Advisory filter and filters out systems without advisories
  48
  49 ### Test 5: Backend Sync (if areCvesWithoutErrataTogglable is enabled)
  50 1. If environment has the legacy "Hide/Show CVEs without advisories" action in the kebab
  51 2. Verify toggling the switch also updates the legacy action
  52 3. Verify toggling the legacy action also updates the switch state