### PR TITLE
fix(Reports): RHINENG-29225 - Show missing systems count and labels in PDF

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,13 @@ const flatPlugins = [
 ];
 
 export default defineConfig([
-  globalIgnores(['node_modules/*', 'static/*', 'dist/*']),
+  globalIgnores([
+    'node_modules/*',
+    'static/*',
+    'dist/*',
+    'build-tools/*',
+    '.venv/*',
+  ]),
   ...flatPlugins,
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/src/Components/SmartComponents/Reports/CVEsReport/components/CVElabels.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/components/CVElabels.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Label } from '@patternfly/react-core';
+
+const CVElabels = ({ cve }) => {
+  const hasRules = cve.rules && cve.rules?.length > 0;
+  const hasExploit = cve.known_exploit;
+
+  return (
+    <>
+      {hasExploit && (
+        <Label color="red" isCompact>
+          Known exploit
+        </Label>
+      )}
+      {hasRules && (
+        <Label color="blue" isCompact>
+          Security rule
+        </Label>
+      )}
+    </>
+  );
+};
+
+CVElabels.propTypes = {
+  cve: propTypes.object,
+};
+
+export default CVElabels;

--- a/src/Components/SmartComponents/Reports/CVEsReport/components/CVEsTable.js
+++ b/src/Components/SmartComponents/Reports/CVEsReport/components/CVEsTable.js
@@ -7,6 +7,8 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
+import CVElabels from './CVElabels';
+
 function parseRhelVersions(versions = []) {
   const result = [];
   let currentMajor = null;
@@ -28,9 +30,17 @@ export const columns = [
   {
     name: 'synopsis',
     header: 'CVE ID',
-    Component: ({ attributes: { synopsis } }) => {
-      return synopsis;
+    /* eslint-disable react/prop-types */
+    Component: ({ attributes }) => {
+      const { synopsis } = attributes;
+
+      return (
+        <>
+          {synopsis} <CVElabels cve={attributes} />
+        </>
+      );
     },
+    /* eslint-enable react/prop-types */
   },
   {
     name: 'publish_date',
@@ -56,8 +66,8 @@ export const columns = [
   {
     name: 'affecting',
     header: 'Systems',
-    Component: ({ attributes: { affecting } }) => {
-      return affecting;
+    Component: ({ attributes: { systems_affected } }) => {
+      return systems_affected;
     },
   },
   {


### PR DESCRIPTION
This PR fixes the PDF to show the affected systems and appropriate labels for CVEs listed. 


**How to test**

1) Follow the setup instructions on https://github.com/RedHatInsights/vulnerability-ui/pull/2494
2) Open the Vulnerability "Reports" page
3) Download/Export a "Report by CVEs"
4) Verify the PDF downloaded includes the number of systems and CVEs with known exploits or security rules have a label shown. 

## Summary by Sourcery

Augment CVE report table to display additional labels and correct systems affected data in the PDF export.

New Features:
- Add contextual labels to CVE IDs indicating known exploits and associated security rules in the CVE reports.

Bug Fixes:
- Show the correct systems_affected count instead of the previous affecting field in the CVE reports.