### PR TITLE
feat(RHINENG:29298): add advisory column to cve table

### DIFF
--- a/src/Components/SmartComponents/IoP/CveDetailTable.js
+++ b/src/Components/SmartComponents/IoP/CveDetailTable.js
@@ -136,6 +136,7 @@ const CveDetailTable = ({ cveName, isCveDataLoading, cveData }) => {
                 /* TODO: Should also be true for Edge systems vvv */
                 linkToCustomerPortal={row.attributes.remediation === MANUAL_REMEDIATION}
             />,
+            row.attributes.advisory_available ? 'Available' : 'Not available',
             <StatusColumn
                 key="status"
                 cveStatusId={row.attributes.cve_status_id}

--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -794,6 +794,27 @@ export const CVE_SYSTEMS_HEADER = [
         isShownByDefault: true
     },
     {
+        key: 'advisory_available',
+        sortKey: 'advisory_available',
+        sortParam: 'advisory_available',
+        title: <span>
+            {intl.formatMessage(messages.advisory)}
+            <Tooltip content={intl.formatMessage(messages.advisoryColumnTooltip)}>
+                <Icon>
+                    <OutlinedQuestionCircleIcon
+                        className="pf-v5-u-ml-sm"
+                        color="var(--pf-v5-global--secondary-color--100)"
+                        style={{ verticalAlign: -2 }}
+                    />
+                </Icon>
+            </Tooltip>
+        </span>,
+        dataLabel: intl.formatMessage(messages.advisory),
+        transforms: [sortable],
+        isShown: true,
+        isShownByDefault: true
+    },
+    {
         key: 'status',
         sortKey: 'status',
         sortParam: 'status',
@@ -1150,7 +1171,7 @@ export const IOP_ENVIRONMENT_CONTEXT = {
     pages: {
         cveList: {
             title: 'Vulnerabilities',
-            columns: ['synopsis', 'public_date', 'impact', 'cvss_score', 'systems_affected', 'business_risk', 'status', 'rhel_versions'],
+            columns: ['synopsis', 'public_date', 'impact', 'cvss_score', 'systems_affected', 'business_risk', 'status', 'rhel_versions', 'advisory_available'],
             filters: [
                 'filter', 'impact', 'publish_date', 'cvss_score', 'rule_presence', 'known_exploit',
                 'affecting_host_type', 'rhel_version', 'advisory_available'


### PR DESCRIPTION
This PR adds the advisory column to the cve table. 

To test, run in IOP mod, via 
```
export IOP_URL=iopinstance(I can give you one if you need it)
  npm run start:proxy:iop
  
  Navigate to https://iop.foo.redhat.com:1337/
```

Navigate to vulnerability cve page and verify that the column exist, is sortable, and that you are able to paginate with the items still in accordance to the sort. Ensure the payload is correct in the network request as well.

## Summary by Sourcery

Add an advisory availability column to the CVE vulnerabilities table and ensure it is included in IoP CVE list configuration.

New Features:
- Display advisory availability status in the CVE details table, indicating whether an advisory is available for each CVE.

Enhancements:
- Include the advisory availability column in the IoP vulnerabilities page configuration so it can be shown and sorted alongside existing CVE columns.