### PR TITLE
feat(RHINENG-30183): add advisory column to details page

### DIFF
--- a/src/Helpers/constants.js
+++ b/src/Helpers/constants.js
@@ -800,13 +800,11 @@ export const CVE_SYSTEMS_HEADER = [
         title: <span>
             {intl.formatMessage(messages.advisory)}
             <Tooltip content={intl.formatMessage(messages.advisoryColumnTooltip)}>
-                <Icon>
-                    <OutlinedQuestionCircleIcon
-                        className="pf-v5-u-ml-sm"
-                        color="var(--pf-v5-global--secondary-color--100)"
-                        style={{ verticalAlign: -2 }}
-                    />
-                </Icon>
+                <OutlinedQuestionCircleIcon
+                    className="pf-v5-u-ml-sm"
+                    color="var(--pf-v5-global--secondary-color--100)"
+                    style={{ verticalAlign: -2 }}
+                />
             </Tooltip>
         </span>,
         dataLabel: intl.formatMessage(messages.advisory),
@@ -1180,8 +1178,8 @@ export const IOP_ENVIRONMENT_CONTEXT = {
             areParamsUrlBound: true
         },
         cveDetail: {
-            columns: ['display_name', 'os', 'last_upload'],
-            filters: ['filter', 'rhel_version'],
+            columns: ['display_name', 'os', 'advisory_available', 'last_upload'],
+            filters: ['filter', 'rhel_version', 'advisory_available'],
             areColumnsManageable: false,
             areParamsUrlBound: true
         },


### PR DESCRIPTION
This PR implements: https://redhat.atlassian.net/browse/RHINENG-30183 

Simply adding the advisory column, as well as filter to the details page

## Summary by Sourcery

Expose advisory availability in the CVE details table and allow users to filter by it.

New Features:
- Add an advisory availability column and corresponding filter to the CVE details page.

Chores:
- Simplify the advisory column tooltip icon markup.