### PR TITLE
fix(RHINENG-30039): allow default filter to default to true

### DIFF
--- a/src/Components/SmartComponents/IoP/Common.js
+++ b/src/Components/SmartComponents/IoP/Common.js
@@ -394,5 +394,6 @@ export const cveListHeader = (envContext) => [
 /* MISCELLANEOUS */
 
 export const CVE_LIST_DEFAULT_FILTERS = {
-    affecting_host_type: 'rpmdnf'
+    affecting_host_type: 'rpmdnf',
+    advisory_available: 'true'
 };

--- a/src/Components/SmartComponents/IoP/CveListTable.js
+++ b/src/Components/SmartComponents/IoP/CveListTable.js
@@ -92,7 +92,7 @@ const CveListTable = () => {
     });
 
     const cvesWithoutErrataMeta = data?.data?.meta?.cves_without_errata;
-    const showCvesWithoutAdvisories = cvesWithoutErrataMeta ?? false;
+    const showCvesWithoutAdvisories = cvesWithoutErrataMeta !== false;
 
     const osVersionFilterItems =
         convertOperatingSystemsToFilterGroupItems(osVersionData.data.results.map(version => version.value));


### PR DESCRIPTION
We just need the filter to be true on page load.
The default filters should match whats shown when you select the 'Reset Filter' button
Before:
<img width="1044" height="399" alt="Screenshot 2026-08-27 at 12 26 55 PM" src="https://github.com/user-attachments/assets/0fee9843-7192-4c8d-b24a-64e7567f4373" />
After:
<img width="1059" height="218" alt="Screenshot 2026-08-27 at 12 27 11 PM" src="https://github.com/user-attachments/assets/6eeee32e-18be-4534-aab5-9c9b287cb675" />

## Summary by Sourcery

Bug Fixes:
- Default the CVE advisory availability filter to true on page load when CVEs without advisories are enabled, aligning initial results with the Reset Filter state.